### PR TITLE
removing dashboard styles

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -52,23 +52,6 @@ body {
   }
 }
 
-// Page main
-.page__dashboard.pf-l-page__main {
-    // background: var(--pf-global--BackgroundColor--dark-transparent-100);
-
-    .pf-l-page__main-section:not(:first-child) {
-        background: var(--pf-global--BackgroundColor--dark-transparent-100);
-    }
-}
-
-// Page header title
-.page__dashboard .pf-c-title {
-    @extend %pf-t-dark;
-    margin-top: 0;
-    margin-bottom: 0;
-    color: #fff;
-}
-
 // Page sidebar
 .pf-l-page__sidebar {
     grid-row-end: 4;


### PR DESCRIPTION
Dashboard styles are present in this repo. If styles are platform specific, they should be here. Otherwise, they should be in the app itself. Many styles get overwritten by [the Dark component](https://github.com/RedHatInsights/insights-frontend-components/pull/102)

On hold until https://github.com/RedHatInsights/insights-dashboard/pull/14