### PR TITLE
fixes stable release

### DIFF
--- a/.travis/release_stable.sh
+++ b/.travis/release_stable.sh
@@ -2,7 +2,9 @@
 
 MESSAGE=$(git log --format=%B -n 1 $TRAVIS_COMMIT)
 git clone ${REPO}.git
-cd build
+cd ${REPO_DIR}
+git checkout stable
+cd ../build
 cp ../${REPO_DIR}/Jenkinsfile ./Jenkinsfile
 git init
 git config --global user.name $COMMIT_AUTHOR_USERNAME


### PR DESCRIPTION
Previously on stable release, we were checking out the beta Jenkinsfiles and overwriting the stable Jenkinsfile. This change makes it so that we checkout the stable Jenkinsfile.