### PR TITLE
Use babel preset env instead of 2015 to have smaller build files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015"],
+  "presets": ["env"],
   "plugins": [
     "transform-inline-environment-variables",
     "transform-object-rest-spread",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.7.0",
     "babel-runtime": "^6.26.0",
     "concurrently": "^3.5.1",
     "cpx": "^1.5.0",


### PR DESCRIPTION
With this babel preset the final files will be smaller. It's also recommended way how to set up babel https://babeljs.io/docs/en/env