### PR TITLE
Fix capitalization for Advisor navigation

### DIFF
--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -10,11 +10,11 @@ export const options = Object.freeze([{
     subItems: [
         {
             id: 'actions',
-            title: 'actions'
+            title: 'Actions'
         },
         {
             id: 'rules',
-            title: 'rules'
+            title: 'Rules'
         }
     ]
 }, {


### PR DESCRIPTION
Making the Advisor sub-navigation items consistent with the rest of the apps.
