### PR TITLE
Remove Overview from Vulnerability secondary nav

### DIFF
--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -22,10 +22,6 @@ export const options = Object.freeze([{
     title: 'Vulnerability',
     subItems: [
         {
-            id: '',
-            title: 'Overview'
-        },
-        {
             id: 'cves',
             title: 'CVEs'
         },


### PR DESCRIPTION
According to current mock-ups, Overview page will not be in the secondary nav.