### PR TITLE
Fix cost-management left hand navigation links.

### DIFF
--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -49,11 +49,11 @@ export const options = Object.freeze([{
             title: 'Overview'
         },
         {
-            id: 'cost',
+            id: 'aws',
             title: 'Cloud Cost'
         },
         {
-            id: 'openshift-charge',
+            id: 'ocp',
             title: 'OpenShift Charge'
         }
     ]


### PR DESCRIPTION
Links were broken when dynamic left hand navigation was altered to static left hand navigation.

Chrome and underlying app were not in sync as left hand navigation changes were not understood.