### PR TITLE
externalDependencies - only override with actual value

### DIFF
--- a/src/js/externalDependencies.js
+++ b/src/js/externalDependencies.js
@@ -4,8 +4,8 @@ export let PFReactIcons;
 export let ReactRouterDOM;
 
 export default function setDependencies ({ react, reactRouterDom, reactCore, reactIcons }) {
-    PFReactCore = reactCore;
-    React = react;
-    PFReactIcons = reactIcons;
-    ReactRouterDOM = reactRouterDom;
+    PFReactCore = reactCore || PFReactCore;
+    React = react || React;
+    PFReactIcons = reactIcons || PFReactIcons;
+    ReactRouterDOM = reactRouterDom || ReactRouterDOM;
 }


### PR DESCRIPTION
This fixes a race-condition bug that occurs when both inventory and remediation hot-loaded components are used in the same view. If setDependencies() is called by inventory first and then by remediation then some of the values (icons) would be reset to undefined