### PR TITLE
Convert settings icon to a drop-down; add sources link to settings.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6236,7 +6236,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         }

--- a/src/js/App/Header/ToolbarToggle.js
+++ b/src/js/App/Header/ToolbarToggle.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import {
+    Dropdown,
+    DropdownToggle,
+    DropdownItem,
+    DropdownPosition
+} from '@patternfly/react-core/dist/esm/components/Dropdown';
+import PropTypes from 'prop-types';
+
+class ToolbarToggle extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isOpen: false
+        };
+        this.onSelect = this.onSelect.bind(this);
+        this.onToggle = this.onToggle.bind(this);
+    }
+
+    onSelect() {
+        this.setState({ isOpen: !this.state.isOpen });
+    }
+
+    onToggle(isOpen) {
+        this.setState({ isOpen });
+    }
+
+    onClick(_ev, url) {
+        window.location = document.baseURI + url;
+    }
+
+    render() {
+        const dropdownItems = this.props.dropdownItems.map(({ url, title }) =>
+            <DropdownItem component='button' onClick={ev => this.onClick(ev, url)}>{ title }</DropdownItem>
+        );
+
+        const toggle = <DropdownToggle iconComponent={null} onToggle={this.onToggle}>
+            <this.props.icon />
+        </DropdownToggle>;
+
+        return (
+            <Dropdown
+                aria-label='Settings'
+                position={DropdownPosition.right}
+                toggle={toggle}
+                isOpen={this.state.isOpen}
+                dropdownItems={dropdownItems}
+                onSelect={this.onSelect}
+            />
+        );
+    }
+}
+
+ToolbarToggle.propTypes = {
+    icon: PropTypes.node,
+    dropdownItems: PropTypes.arrayOf(PropTypes.node)
+};
+
+export default ToolbarToggle;

--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -7,6 +7,7 @@ import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import UserToggle from './UserToggle';
+import ToolbarToggle from './ToolbarToggle';
 
 const actions = [
     {
@@ -22,7 +23,13 @@ const actions = [
     {
         title: 'Settings',
         icon: CogIcon,
-        widget: 'InsightsSettings'
+        widget: 'InsightsSettings',
+        items: [
+            {
+                title: 'Sources',
+                url: 'sources'
+            }
+        ]
     },
     {
         title: 'FAQ',
@@ -36,15 +43,17 @@ export default () => (
         <Toolbar>
             <ToolbarGroup className="pf-u-sr-only pf-u-visible-on-lg">
                 {actions.map((oneItem, key) => (
-                    <ToolbarItem key={key} data-key={key}>
-                        <Button
-                            variant="plain"
-                            aria-label={`Overflow ${oneItem.title}`}
-                            widget-type={oneItem.widget}
-                        >
-                            <oneItem.icon />
-                        </Button>
-                    </ToolbarItem>
+                    oneItem.items ?
+                        <ToolbarToggle icon={oneItem.icon} dropdownItems={oneItem.items} /> :
+                        <ToolbarItem key={key} data-key={key}>
+                            <Button
+                                variant="plain"
+                                aria-label={`Overflow ${oneItem.title}`}
+                                widget-type={oneItem.widget}
+                            >
+                                <oneItem.icon />
+                            </Button>
+                        </ToolbarItem>
                 ))}
             </ToolbarGroup>
             <ToolbarGroup>


### PR DESCRIPTION
Sources is supposed to be accessible from the menu. So according to discussion with @karelhala, I am adding `items` to the `actions` with a list of URL fragments to navigate to that render a drop down list below the icon.

The navigation is done using setting of the `window.location` not using the router.

Replacement for https://github.com/RedHatInsights/insights-chrome/pull/90