### PR TITLE
Complete rename of service-portal to catalog

### DIFF
--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -4,7 +4,7 @@ export default Object.freeze([
         title: 'Dashboard'
     },
     {
-        id: 'service-portal',
+        id: 'catalog',
         title: 'Catalog',
         // nav is built before window.insights.chrome
         // detect isProd manually here


### PR DESCRIPTION
Change top-level nav id from `service-portal` to `catalog`.