### PR TITLE
Do not log null if user is null

### DIFF
--- a/src/js/jwt/insights/user.js
+++ b/src/js/jwt/insights/user.js
@@ -23,7 +23,12 @@ module.exports = (token) => {
         }
     } : null;
 
-    log(`User ID: ${user.identity.account_number}`);
+    if (user) {
+        log(`User ID: ${user.identity.account_number}`);
+    } else {
+        log('User not ready');
+    }
+
     return user;
 };
 /* eslint-enable camelcase */


### PR DESCRIPTION
When the auth is first called, the first thing that happens is an attempt to get the user even though the user hasn't been authenticated, returning a null value. Before, the logger would pick this up and log a null value which would throw an error in the console.