### PR TITLE
Fixing error for alt tag in avatar

### DIFF
--- a/src/js/App/Header/UserIcon.js
+++ b/src/js/App/Header/UserIcon.js
@@ -29,7 +29,7 @@ class UserIcon extends Component {
         const { avatar } = this.state;
 
         return (
-            <Avatar src={ avatar }/>
+            <Avatar src={ avatar } alt='User Avatar'/>
         );
     }
 }


### PR DESCRIPTION
`alt` is needed as a prop. This adds it.