### PR TITLE
Show reload instead of ID in href

### DIFF
--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -63,10 +63,10 @@ class Navigation extends Component {
                                         {
                                             item.subItems.map((subItem, subKey) => (
                                                 <NavigationItem
-                                                    itemId={subItem.id}
+                                                    itemId={subItem.reload || subItem.id}
                                                     key={subKey}
                                                     title={subItem.title}
-                                                    parent={`${activeLocation}/${item.id}`}
+                                                    parent={`${activeLocation}${item.id ? `/${item.id}` : ''}`}
                                                     isActive={item.active && subItem.id === activeApp}
                                                     onClick={event => this.onClick(event, subItem, item)}
                                                 />


### PR DESCRIPTION
Currently if item has subitems, but has no id it will be shown as for instance `rhcs/undefined/webhooks` but we want to show `rhcs/webhooks` so if ID is no defined (for parent) do not show it in href and if reload is defined show this instead of ID (subitem).