### PR TITLE
Add second level navigation if reload enabled

### DIFF
--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -22,8 +22,16 @@ class Navigation extends Component {
     };
 
     onClick(_event, item, parent) {
-        const { onNavigate, onClearActive, activeGroup, activeLocation } = this.props;
+        const { onNavigate, onClearActive, activeGroup, activeLocation, settings, appId } = this.props;
         if (parent && parent.active) {
+            const activeLevel = settings.find(navItem => navItem.id === appId);
+            if (activeLevel) {
+                const activeItem = activeLevel.subItems.find(navItem => navItem.id === activeGroup);
+                if (activeItem && activeItem.reload && !item.reload) {
+                    window.location.href = `${basepath}${activeLocation}/${appId}/${item.id}`;
+                }
+            }
+
             if (!item.reload) {
                 onNavigate && onNavigate(item);
             } else {
@@ -93,6 +101,7 @@ class Navigation extends Component {
 }
 
 Navigation.propTypes = {
+    appId: PropTypes.string,
     settings: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,
@@ -105,8 +114,8 @@ Navigation.propTypes = {
     activeLocation: PropTypes.string
 };
 
-function stateToProps({ chrome: { globalNav, activeApp, navHidden, activeLocation, activeGroup } }) {
-    return ({ settings: globalNav, activeApp, navHidden, activeLocation, activeGroup });
+function stateToProps({ chrome: { globalNav, activeApp, navHidden, activeLocation, activeGroup, appId } }) {
+    return ({ settings: globalNav, activeApp, navHidden, activeLocation, activeGroup, appId });
 }
 
 function dispatchToProps(dispatch) {

--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -135,7 +135,7 @@ export const grouppedNav = {
                 subItems: [
                     {
                         id: 'sources',
-                        title: 'Catalog',
+                        title: 'Sources',
                         reload: 'sources'
                     },
                     {

--- a/src/js/redux/actions.js
+++ b/src/js/redux/actions.js
@@ -34,7 +34,7 @@ export function identifyApp (data, options) {
 
     const firstLevel = options.find((item) => isCurrApp(item, data));
 
-    return { type: actionTypes.GLOBAL_NAV_IDENT, data: { id: firstLevel.id, activeApp: data } };
+    return { type: actionTypes.GLOBAL_NAV_IDENT, data: { id: firstLevel.id || firstLevel.title, activeApp: data } };
 }
 
 export function appNav (data) {

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -23,7 +23,7 @@ export function globalNavReducer(state, { data: { id, activeApp } }) {
         navHidden: id === 'landing',
         globalNav: state.globalNav && state.globalNav.map(item => ({
             ...item,
-            active: active && item.id === active.id
+            active: active && (item.id === active.id || item.title === active.id)
         }))
     };
 }


### PR DESCRIPTION
* When in secondary nav that has no id (navigation with reload applications) pass title as identifier
* When in secondary nav and current item is seperate application and user wants to redirect to new application but this app has no reload use redirect (applicable to navigation from approval to catalog items)