### PR TITLE
Load chrome and user after successfull login

### DIFF
--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -23,11 +23,15 @@ const PUBLIC_EVENTS = {
 
 export function chromeInit(libjwt) {
     const { store, middlewareListener, actions } = spinUpStore();
-    libjwt.jwt.getUserInfo().then(actions.userLogIn);
 
     // public API actions
     const { identifyApp, appNav, appNavClick } = actions;
-    libjwt.jwt.getUserInfo().then(loadChrome);
+    libjwt.initPromise.then(() => {
+        libjwt.jwt.getUserInfo().then((user) => {
+            actions.userLogIn(user);
+            loadChrome();
+        });
+    });
 
     return {
         identifyApp: (data) => identifyApp(data, store.getState().chrome.globalNav),
@@ -120,5 +124,3 @@ function loadChrome() {
         }
     );
 }
-
-;


### PR DESCRIPTION
Whn user logs in it looks kinda strange that we have those loading sripes in navigation and they are never replaced by correct navigation and user has to refresh. This PR updates this by waiting on correct response and shows navigation and user after initPromise is resolved and user info returns correct user.