### PR TITLE
Support unauthed views in Chrome

### DIFF
--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -128,7 +128,6 @@ function loadChrome(user) {
 
             store.dispatch(appNavClick(defaultActive));
 
-
             render(
                 <Provider store={store}>
                     { user ? <Header /> : <UnauthedHeader /> }

--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -128,21 +128,13 @@ function loadChrome(user) {
 
             store.dispatch(appNavClick(defaultActive));
 
-            if (user) {
-                render(
-                    <Provider store={store}>
-                        <Header />
-                    </Provider>,
-                    document.querySelector('header')
-                );
-            } else {
-                render(
-                    <Provider store={store}>
-                        <UnauthedHeader />
-                    </Provider>,
-                    document.querySelector('header')
-                );
-            }
+
+            render(
+                <Provider store={store}>
+                    { user ? <Header /> : <UnauthedHeader /> }
+                </Provider>,
+                document.querySelector('header')
+            );
 
             if (document.querySelector('aside')) {
                 render(


### PR DESCRIPTION
Paths equaling consts.allowedUnauthedPaths (+/) are not bounced.

chrome.loadChrome accepts a parameter, if false an UnauthedHeader is rendered
if the user is passed in the regular header is rendered