### PR TITLE
Make the cookie to expire at the same time as the JWT

### DIFF
--- a/src/js/jwt/jwt.js
+++ b/src/js/jwt/jwt.js
@@ -238,11 +238,27 @@ function updateToken() {
     });
 }
 
-// Set the cookie fo 3scale
+function getCookieExpires(exp) {
+    // we want the cookie to expire at the same time as the JWT session
+    // so we take the exp and get a new GTMString from that
+    const date = new Date(0);
+    date.setUTCSeconds(exp);
+    return date.toGMTString();
+}
+
+// Set the cookie for 3scale
 function setCookie(token) {
     if (token && token.length > 10) {
-        document.cookie = `${priv.cookie.cookieName}=${token};path=/;secure=true;`;
+        setCookieWrapper(`${priv.cookie.cookieName}=${token};` +
+                         `path=/;` +
+                         `secure=true;` +
+                         `expires=${getCookieExpires(decodeToken(token).exp)}`);
     }
+}
+
+// do this so we can mock out for test
+function setCookieWrapper(str) {
+    document.cookie = str;
 }
 
 // Encoded WIP

--- a/src/js/jwt/jwt.unit.test.js
+++ b/src/js/jwt/jwt.unit.test.js
@@ -21,6 +21,19 @@ describe('JWT', () => {
         __rewire_reset_all__();
     });
 
+    describe('setCookie', () => {
+        const setCookie = jwt.__get__('setCookie');
+        const setCookieWrapper = jest.fn();
+        jwt.__set__('setCookieWrapper', setCookieWrapper);
+        test('sets a cookie that expires on the same second the JWT expires', () => {
+            setCookie(encodedToken);
+            expect(setCookieWrapper).toBeCalledWith(`cs_jwt=${encodedToken};` +
+                                `path=/;` +
+                                `secure=true;` +
+                                `expires=Wed, 24 Apr 2019 17:13:47 GMT`);
+        });
+    });
+
     describe('decodeToken', () => {
         const decodeToken = jwt.__get__('decodeToken');
 

--- a/src/js/jwt/jwt.unit.test.js
+++ b/src/js/jwt/jwt.unit.test.js
@@ -21,11 +21,25 @@ describe('JWT', () => {
         __rewire_reset_all__();
     });
 
+    describe('getCookieExpires', () => {
+        const getCookieExpires = jwt.__get__('getCookieExpires');
+        test('should expire at epoch if 0 is given', () => {
+            expect(getCookieExpires(0)).toBe('Thu, 01 Jan 1970 00:00:00 GMT');
+        });
+
+        test('should expire at now if now is given', () => {
+            const now = new Date();
+            const nowString = now.toGMTString();
+            const nowUnix   = Math.floor(now.getTime() / 1000);
+            expect(getCookieExpires(nowUnix)).toBe(nowString);
+        });
+    });
+
     describe('setCookie', () => {
-        const setCookie = jwt.__get__('setCookie');
-        const setCookieWrapper = jest.fn();
-        jwt.__set__('setCookieWrapper', setCookieWrapper);
         test('sets a cookie that expires on the same second the JWT expires', () => {
+            const setCookie = jwt.__get__('setCookie');
+            const setCookieWrapper = jest.fn();
+            jwt.__set__('setCookieWrapper', setCookieWrapper);
             setCookie(encodedToken);
             expect(setCookieWrapper).toBeCalledWith(`cs_jwt=${encodedToken};` +
                                 `path=/;` +


### PR DESCRIPTION
So that we can never have any stale cookie laying around.
Its a security thing and a sanity thing.