### PR TITLE
Force a kc.login() whenever getUser is called with no cookie

### DIFF
--- a/src/js/jwt/jwt.js
+++ b/src/js/jwt/jwt.js
@@ -203,8 +203,9 @@ function loginAllTabs() {
 exports.getUserInfo = () => {
     log('Getting User Information');
 
-    if (pageRequiresAuthentication()) {
+    if (!cookie.get(DEFAULT_COOKIE_NAME) && pageRequiresAuthentication()) {
         exports.login();
+        return false;
     }
 
     if (isExistingValid(priv.keycloak.token)) {

--- a/src/js/jwt/jwt.js
+++ b/src/js/jwt/jwt.js
@@ -2,6 +2,7 @@
 import Keycloak from 'keycloak-js';
 import BroadcastChannel from 'broadcast-channel';
 import cookie from 'js-cookie';
+import { pageRequiresAuthentication } from '../utils';
 
 // Utils
 const log = require('./logger')('jwt.js');
@@ -201,6 +202,10 @@ function loginAllTabs() {
 // Get user information
 exports.getUserInfo = () => {
     log('Getting User Information');
+
+    if (pageRequiresAuthentication()) {
+        exports.login();
+    }
 
     if (isExistingValid(priv.keycloak.token)) {
         return insightsUser(priv.keycloak.tokenParsed);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -7,6 +7,7 @@ function getWindow() {
 function getSection() {
     const sections = getWindow().location.pathname.split('/');
     if (sections[1] === 'beta') { return sections[2] || ''; }
+
     return sections[1];
 }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,12 +1,34 @@
 import get from 'lodash/get';
 
+function getWindow() {
+    return window;
+}
+
+function getSection() {
+    const sections = getWindow().location.pathname.split('/');
+    if (sections[1] === 'beta') { return sections[2] || ''; }
+    return sections[1];
+}
+
+export function pageRequiresAuthentication() {
+    const section = getSection();
+    if (section === 'insights' ||
+        section === 'rhel'     ||
+        section === 'hybrid'   ||
+        section === 'apps') {
+        return true;
+    }
+
+    return false;
+}
+
 /**
  * Creates a redux listener that watches the state on given path (e.g. chrome.appNav) and calls
  * the given function when the state on the given path changes.
  *
  * The function is called with two parameters: current state value on the path, store reference
  */
-export function createReduxListener (store, path, fn) {
+export function createReduxListener(store, path, fn) {
     let previous = undefined;
 
     return () => {

--- a/src/js/utils.test.js
+++ b/src/js/utils.test.js
@@ -1,0 +1,47 @@
+/*global describe, test, require, expect*/
+const utils = require('./utils');
+
+const testData = [
+    { auth: true,  path: '/insights', sec: 'insights' },
+    { auth: true,  path: '/insights/', sec: 'insights' },
+    { auth: true,  path: '/insights/foo', sec: 'insights' },
+    { auth: true,  path: '/insights/beta', sec: 'insights' },
+    { auth: true,  path: '/insights/beta/', sec: 'insights' },
+    { auth: true,  path: '/insights/beta/foo', sec: 'insights' },
+    { auth: true,  path: '/insights/foo/bar/', sec: 'insights' },
+    { auth: true,  path: '/hybrid', sec: 'hybrid' },
+    { auth: true,  path: '/hybrid/', sec: 'hybrid' },
+    { auth: true,  path: '/hybrid/foo', sec: 'hybrid' },
+    { auth: true,  path: '/hybrid/foo/bar/', sec: 'hybrid' },
+    { auth: true,  path: '/apps/foo/bar/', sec: 'apps' },
+    { auth: true,  path: '/apps/insights/bar/', sec: 'apps' },
+    { auth: false, path: '/', sec: '' },
+    { auth: false, path: '/beta', sec: '' },
+    { auth: false, path: '/404', sec: '404' }
+];
+
+function doMockWindow(path) {
+    utils.__set__('getWindow', () => {
+        return { location: { pathname: path } };
+    });
+}
+
+describe('utils', () => {
+    describe('pageRequiresAuthentication', () => {
+        for (const item of testData) {
+            test(`should return ${item.auth} for ${item.path}`, () => {
+                doMockWindow(item.path);
+                expect(utils.pageRequiresAuthentication()).toBe(item.auth);
+            });
+        }
+    });
+    describe('getSections', () => {
+        const getSection = utils.__get__('getSection');
+        for (const item of testData) {
+            test(`should extract give you ${item.sec} from ${item.path}`, () => {
+                doMockWindow(item.path);
+                expect(getSection()).toBe(item.sec);
+            });
+        }
+    });
+});


### PR DESCRIPTION
The cs_jwt cookie is now timebombed. It expires the same second as the JWT.

Any time someone calls getUser() on one of the authenticated pages we should
call kc.login() for them.