### PR TITLE
Use correct scope for offline access token

### DIFF
--- a/src/js/jwt/jwt.js
+++ b/src/js/jwt/jwt.js
@@ -78,7 +78,7 @@ exports.doOffline = (key, val) => {
     const kc = Keycloak(options);
     kc.init(options).then(() => {
         kc.login({
-            scope: 'offline'
+            scope: 'offline_access'
         });
     });
 };


### PR DESCRIPTION
The Keycloak documentation says the correct scope for offline access
tokens is offline_access
https://www.keycloak.org/docs/2.5/server_admin/topics/sessions/offline.html

When the scope is incorrect, we still get a token, but it's not the
offline token we need, and it expires after a while.

Changing the scope to offline_access should fix this problem.

cc: @iphands @karelhala