### PR TITLE
updating lint to use react rules, fixing errors

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,10 +4,14 @@ env:
   jest: true
   es6: true
   node: true
+settings:
+  react:
+    version: '16.0'
 plugins:
   - react
 extends:
   - 'eslint:recommended'
+  - 'plugin:react/recommended'
   - 'prettier'
 parserOptions:
   ecmaVersion: 7

--- a/src/js/App/Footer.js
+++ b/src/js/App/Footer.js
@@ -1,3 +1,5 @@
 import React from 'react';
 
-export default () => <div>I am Footer</div>;
+const Footer = () => <div>I am Footer</div>;
+
+export default Footer;

--- a/src/js/App/Header/Brand.js
+++ b/src/js/App/Header/Brand.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { onToggle } from '../../redux/actions';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
@@ -22,6 +23,11 @@ const Brand = ({ toggleNav, navHidden }) => (
         </a>
     </div>
 );
+
+Brand.propTypes = {
+    navHidden: PropTypes.bool,
+    toggleNav: PropTypes.func
+};
 
 function mapDispatchToProps(dispatch) {
     return {

--- a/src/js/App/Header/InsightsAbout.js
+++ b/src/js/App/Header/InsightsAbout.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
     AboutModal,
     TextContent, TextList, TextListItem,
@@ -14,25 +15,28 @@ const Copyright = () => (
         <div>Copyright © 2019 Red Hat, Inc.</div>
         <Level>
             <LevelItem>
-                <a class="nav-link"
+                <a className="nav-link"
                     href="https://www.redhat.com/en/about/privacy-policy"
                     target="_blank"
+                    rel='noopener noreferrer'
                 >
                     Privacy Policy
                 </a>
             </LevelItem>
             <LevelItem>
-                <a class="nav-link"
+                <a className="nav-link"
                     href="https://access.redhat.com/help/terms"
                     target="_blank"
+                    rel='noopener noreferrer'
                 >
                     Customer Portal Terms of Use
                 </a>
             </LevelItem>
             <LevelItem>
-                <a class="nav-link"
+                <a className="nav-link"
                     href="https://www.redhat.com/en/about/all-policies-guidelines"
                     target="_blank"
+                    rel='noopener noreferrer'
                 >
                     All Policies and Guidelines
                 </a>
@@ -138,6 +142,14 @@ class InsightsAbout extends Component {
         );
     }
 }
+
+InsightsAbout.propTypes = {
+    globalNav: PropTypes.any,
+    activeApp: PropTypes.string,
+    isModalOpen: PropTypes.bool,
+    onClose: PropTypes.func,
+    user: PropTypes.object
+};
 
 function mapStateToProps({ chrome: { user: { identity: { user } }, appId, globalNav, activeApp } }) {
     return { appId, globalNav, user, activeApp };

--- a/src/js/App/Header/Login.js
+++ b/src/js/App/Header/Login.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { login } from '../../jwt/jwt';
 
-export default () => (
+const Login = () => (
     <div className="pf-c-page__header-tools">
         <Button
             variant="tertiary"
@@ -14,3 +14,4 @@ export default () => (
     </div>
 );
 
+export default Login;

--- a/src/js/App/Header/Logo.js
+++ b/src/js/App/Header/Logo.js
@@ -1,4 +1,6 @@
 import React from 'react';
 import logo from '../../../../static/images/logo.svg';
 
-export default () => <img src={logo} alt="Red Hat Logo" />;
+const Logo = () => <img src={logo} alt="Red Hat Logo" />;
+
+export default Logo;

--- a/src/js/App/Header/ToolbarToggle.js
+++ b/src/js/App/Header/ToolbarToggle.js
@@ -39,6 +39,7 @@ class ToolbarToggle extends Component {
     render() {
         const dropdownItems = this.props.dropdownItems.map(({ url, title, onClick }) =>
             <DropdownItem
+                key={title}
                 component={ url ? 'a' : 'button' }
                 {
                 ...url ? { href: url } : {}
@@ -68,8 +69,8 @@ class ToolbarToggle extends Component {
 }
 
 ToolbarToggle.propTypes = {
-    icon: PropTypes.node,
-    dropdownItems: PropTypes.arrayOf(PropTypes.node)
+    icon: PropTypes.func,
+    dropdownItems: PropTypes.array
 };
 
 export default ToolbarToggle;

--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -79,9 +79,10 @@ class Tools extends Component {
                     <ToolbarGroup className='pf-u-mr-0 pf-u-mr-lg-on-lg'>
                         {actions.map((oneItem, key) => (
                             oneItem.items ?
-                                <ToolbarToggle icon={oneItem.icon} dropdownItems={oneItem.items} /> :
+                                <ToolbarToggle key={key} icon={oneItem.icon} dropdownItems={oneItem.items} /> :
                                 <ToolbarItem key={key} data-key={key}>
                                     <Button
+                                        key={key}
                                         variant="plain"
                                         aria-label={`Overflow ${oneItem.title}`}
                                         widget-type={oneItem.widget}

--- a/src/js/App/Header/index.js
+++ b/src/js/App/Header/index.js
@@ -11,7 +11,7 @@ export function unauthed() {
 }
 
 ;
-
+// eslint-disable-next-line
 export default () => (
     <Fragment>
         <Brand />

--- a/src/js/App/Header/index.js
+++ b/src/js/App/Header/index.js
@@ -11,10 +11,12 @@ export function unauthed() {
 }
 
 ;
-// eslint-disable-next-line
-export default () => (
+
+const Header = () => (
     <Fragment>
         <Brand />
         <Tools />
     </Fragment>
 );
+
+export default Header;

--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Nav, NavItem, NavExpandable, NavList } from '@patternfly/react-core/dist/esm/components/Nav';
+import { Nav, NavItem, NavExpandable, NavList, NavItemSeparator } from '@patternfly/react-core/dist/esm/components/Nav';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { appNavClick, clearActive } from '../../redux/actions';
@@ -111,11 +111,16 @@ class Navigation extends Component {
                             }
                         })
                     }
-                    { documentation && <NavItem
-                        className="ins-c-page__documentation"
-                        to={documentation}
-                        rel='noopener'
-                        target='_blank'>Documentation</NavItem>
+                    { documentation &&
+                        <React.Fragment>
+                            <NavItemSeparator/>
+                            <NavItem
+                                className="ins-c-page__documentation"
+                                to={documentation}
+                                rel='noopener noreferrer'
+                                target='_blank'>Documentation
+                            </NavItem>
+                        </React.Fragment>
                     }
                     { activeLocation === 'openshift' &&
                         Object.entries(openshiftLinks).map(
@@ -123,7 +128,8 @@ class Navigation extends Component {
                                 return <NavItem
                                     key={key}
                                     to={value.link}
-                                    target='_blank'>
+                                    target='_blank'
+                                    rel='noopener noreferrer'>
                                     {value.title}
                                 </NavItem>;
                             }
@@ -147,7 +153,10 @@ Navigation.propTypes = {
     activeApp: PropTypes.string,
     navHidden: PropTypes.bool,
     activeLocation: PropTypes.string,
-    documentation: PropTypes.string
+    documentation: PropTypes.string,
+    onNavigate: PropTypes.func,
+    onClearActive: PropTypes.func,
+    activeGroup: PropTypes.string
 };
 
 function stateToProps({ chrome: { globalNav, activeApp, navHidden, activeLocation, activeGroup, appId } }) {

--- a/src/js/App/Sidenav/NavigationItem.js
+++ b/src/js/App/Sidenav/NavigationItem.js
@@ -3,7 +3,7 @@ import { NavItem } from '@patternfly/react-core/dist/esm/components/Nav';
 
 const basepath = document.baseURI;
 
-export default ({ itemID, title, parent = '', navigate, ...props }) => (
+const NavigationItem = ({ itemID, title, parent = '', navigate, ...props }) => (
     <NavItem
         {...props}
         itemId={itemID}
@@ -13,3 +13,5 @@ export default ({ itemID, title, parent = '', navigate, ...props }) => (
         {title}
     </NavItem>
 );
+
+export default NavigationItem;

--- a/src/js/App/Sidenav/index.js
+++ b/src/js/App/Sidenav/index.js
@@ -21,7 +21,7 @@ class SideNav extends Component {
                         <HomeIcon size="md" />
                     </a>
                 </SplitItem>
-                <SplitItem isMain className="pf-u-display-flex pf-u-align-items-center">
+                <SplitItem isFilled className="pf-u-display-flex pf-u-align-items-center">
                     <div className="ins-c-navigation__header-title">
                         {activeTechnology}
                     </div>

--- a/src/sass/partials/_sidebar.scss
+++ b/src/sass/partials/_sidebar.scss
@@ -24,13 +24,4 @@ aside.pf-c-page__sidebar {
         .ins-c-page__home-icon { @include rem('padding-left', 30px); }
 
     }
-
-    .ins-c-page__documentation a:before {
-        position: absolute;
-        @include rem('top', 5px);
-        width: 75%;
-        @include rem('height', 1px);
-        content: "";
-        background-color: var(--pf-global--disabled-color--200);
-    }
 }


### PR DESCRIPTION
Fixes some tech debt.

Linter wasn't using react recommended rules. Updated so that it does and fixed all associated errors.

Killed the separator above the "documentation" link in favor of the Patternfly supplied one.