### PR TITLE
Add Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,9 @@ To set a short jwt session, log out of your account and then do the following in
 `window.localStorage.setItem('chrome:jwt:shortSession', true);`
 
 Note: You must log out of your short session and set `window.localStorage.setItem('chrome:jwt:shortSession', false);` to return to the regular realm.
+
+## Sentry
+
+This project captures events with [Sentry.io](https://sentry.io/welcome/).
+
+Out of the box, we capture all fatal errors. We also provide Sentry to developers so they can [throw their own errors](https://docs.sentry.io/error-reporting/capturing/?platform=javascript).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4062,6 +4062,63 @@
         "axios": "^0.18.0"
       }
     },
+    "@sentry/browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.3.0.tgz",
+      "integrity": "sha512-MV02kS3Q5hv8/CW0nsjD/bOwWAq75aSFzebidwLfl6fvRSmuDsy5bjufr7a3ZK4SyYEe8GakqfQqqr81Y0vlVw==",
+      "requires": {
+        "@sentry/core": "5.3.0",
+        "@sentry/types": "5.2.0",
+        "@sentry/utils": "5.3.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.3.0.tgz",
+      "integrity": "sha512-m4kB1RB5Ilx7/QTvhfRblyEfyGdV8dDLqE6CS3ftqjbFG0lhkqHjhj3Zai7wphfRnnZsfLGpYT8VJOgS9jUQuQ==",
+      "requires": {
+        "@sentry/hub": "5.3.0",
+        "@sentry/minimal": "5.3.0",
+        "@sentry/types": "5.2.0",
+        "@sentry/utils": "5.3.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.3.0.tgz",
+      "integrity": "sha512-FT+V5bScUoKbiMVZGOYcj81A7F7kQGbMXG+/94yO5s/6s/XJw4AbX5asR/N3Y57QNeeUYWQ2O4eDCjMeRdwXLw==",
+      "requires": {
+        "@sentry/types": "5.2.0",
+        "@sentry/utils": "5.3.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.3.0.tgz",
+      "integrity": "sha512-s1ok1AI7FQZx+zvgFVjcj1on090VSHo6Bf3f8idGRI2EvAB868q8DJoEcMXJGdJE59zZQ6YCEF5PXAmBm/h9Uw==",
+      "requires": {
+        "@sentry/hub": "5.3.0",
+        "@sentry/types": "5.2.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.2.0.tgz",
+      "integrity": "sha512-QzMVYgONsScAiEGY5XRtSeMwH8464oRdaxCMTtXBuYfF9muvxHqQyF094GVRiconpgKelok5ke9HwrbNUEiE7w=="
+    },
+    "@sentry/utils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.3.0.tgz",
+      "integrity": "sha512-4nfv6p2/PPWt7jk/AE73K7YydFHiBs3GvJLpO+PHgNyU3GBtQGST5HggdkGy+mCbtoBdkCIf1CRNeabCxTZ92g==",
+      "requires": {
+        "@sentry/types": "5.2.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@tippy.js/react": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@tippy.js/react/-/react-1.1.1.tgz",
@@ -21605,6 +21662,11 @@
       "requires": {
         "glob": "^7.1.2"
       }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@redhat-cloud-services/frontend-components-inventory": "0.0.11",
     "@redhat-cloud-services/frontend-components-remediations": "0.0.3",
     "@redhat-cloud-services/frontend-components-utilities": "0.0.5",
+    "@sentry/browser": "^5.3.0",
     "axios": "^0.18.0",
     "axios-cache-adapter": "^2.3.0",
     "babel-plugin-rewire": "^1.2.0",

--- a/src/js/chrome.js
+++ b/src/js/chrome.js
@@ -1,5 +1,6 @@
 import auth from './auth';
 import analytics from './analytics';
+import sentry from './sentry';
 import { bootstrap, chromeInit }   from './entry';
 
 // start auth asap
@@ -8,7 +9,7 @@ const libjwt = auth();
 function noop () {}
 
 libjwt.initPromise.then(() => {
-    libjwt.jwt.getUserInfo().then(analytics).catch(noop);
+    libjwt.jwt.getUserInfo().then(analytics && sentry).catch(noop);
 });
 
 window.insights = window.insights || {};

--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -114,6 +114,7 @@ export function bootstrap(libjwt, initFunc) {
 }
 
 function loadChrome(user) {
+
     import('./App/index').then(
         ({ UnauthedHeader, Header, Sidenav }) => {
             const store = insights.chrome.$internal.store;

--- a/src/js/sentry.js
+++ b/src/js/sentry.js
@@ -1,0 +1,42 @@
+const API_KEY = 'https://80e5a70255df4bd3ba6eb3b4bfebc58c@sentry.io/1466891'
+
+// - Sentry Options
+// dsn: key
+// environment: logs PROD or PROD Beta for filtering
+// maxBreadcrumbs, if there is an error, trace back up to (x) lines if needed
+// attachStacktrace: attach the actual console logs
+// debug: will attempt to print out useful debugging information if something goes wrong with sending the event
+// sampleRate: 0.0 to 1.0 - percentage of events to send (1.0 by default)
+
+function initSentry() {
+    let betaCheck = (window.location.pathname.split('/')[1] === 'beta' ? ' Beta' : '');
+
+    Sentry.init({
+        dsn: API_KEY,
+        environment: `PROD${betaCheck}`,
+        maxBreadcrumbs: 50,
+        attachStacktrace: true,
+        debug: true
+    });
+}
+
+function sentryUser(user) {
+    // TODO: Add request_id to this
+    Sentry.configureScope((scope) => {
+        scope.setUser({
+            "id": user.identity.account_number,
+            "account_id": user.identity.internal.account_id
+        });
+    });
+}
+
+export default (user) => {
+    let environment = window.location.host.split('.')[0];
+
+    if (environment === 'cloud') {
+        initSentry();
+        sentryUser(user);
+    } else {
+        console.log('[sentry.js] Sentry not initialized for pre-prod');
+    }
+}

--- a/src/js/sentry.js
+++ b/src/js/sentry.js
@@ -1,4 +1,6 @@
-const API_KEY = 'https://80e5a70255df4bd3ba6eb3b4bfebc58c@sentry.io/1466891'
+import * as Sentry from '@sentry/browser';
+
+const API_KEY = 'https://80e5a70255df4bd3ba6eb3b4bfebc58c@sentry.io/1466891';
 
 // - Sentry Options
 // dsn: key
@@ -20,15 +22,17 @@ function initSentry() {
     });
 }
 
+/* eslint-disable camelcase */
 function sentryUser(user) {
     // TODO: Add request_id to this
     Sentry.configureScope((scope) => {
         scope.setUser({
-            "id": user.identity.account_number,
-            "account_id": user.identity.internal.account_id
+            id: user.identity.account_number,
+            account_id: user.identity.internal.account_id
         });
     });
 }
+/* eslint-enable camelcase */
 
 export default (user) => {
     let environment = window.location.host.split('.')[0];
@@ -36,7 +40,5 @@ export default (user) => {
     if (environment === 'cloud') {
         initSentry();
         sentryUser(user);
-    } else {
-        console.log('[sentry.js] Sentry not initialized for pre-prod');
     }
-}
+};

--- a/src/pug/templates/head-block.pug
+++ b/src/pug/templates/head-block.pug
@@ -3,4 +3,6 @@ meta(name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit
 base(href=`${ release === 'insights' ? '/' : '/beta/'}`)
 link(rel="icon"  type="image/png" href="https://access.redhat.com/webassets/avalon/g/favicon.ico")
 link(rel='stylesheet', href='https://use.fontawesome.com/releases/v5.0.10/css/all.css', integrity='sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg', crossorigin='anonymous')
-link(rel='stylesheet', href='./apps/chrome/chrome.css')
+link(rel='stylesheet', href='./apps/chrome/chrome.css')\
+//- Add sentry here so other apps can use it
+script(src="https://browser.sentry-cdn.com/5.3.0/bundle.min.js", crossorigin="anonymous")

--- a/src/pug/templates/head-block.pug
+++ b/src/pug/templates/head-block.pug
@@ -3,6 +3,6 @@ meta(name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit
 base(href=`${ release === 'insights' ? '/' : '/beta/'}`)
 link(rel="icon"  type="image/png" href="https://access.redhat.com/webassets/avalon/g/favicon.ico")
 link(rel='stylesheet', href='https://use.fontawesome.com/releases/v5.0.10/css/all.css', integrity='sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg', crossorigin='anonymous')
-link(rel='stylesheet', href='./apps/chrome/chrome.css')\
+link(rel='stylesheet', href='./apps/chrome/chrome.css')
 //- Add sentry here so other apps can use it
 script(src="https://browser.sentry-cdn.com/5.3.0/bundle.min.js", crossorigin="anonymous")


### PR DESCRIPTION
Default configuration should capture all fatal events in all apps using chrome

If other apps want to roll their own errors, they have the ability to do so.