### PR TITLE
Add a copy button to the about modal

### DIFF
--- a/src/js/App/Header/InsightsAbout.js
+++ b/src/js/App/Header/InsightsAbout.js
@@ -2,8 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
     AboutModal,
+    Alert, AlertActionCloseButton,
     Button,
-    Tooltip, TooltipPosition,
+    Tooltip,
     TextContent, TextList, TextListItem,
     Stack, StackItem
 } from '@patternfly/react-core';
@@ -74,8 +75,12 @@ class InsightsAbout extends Component {
                 { name: 'Cost Management', path: 'apps/cost-management/app.info.json', version: 'N/A' },
                 { name: 'Insights', path: 'apps/insights/app.info.json', version: 'N/A' }
             ] },
+            showCopyAlert: false,
+            showCopyAlertError: false,
             currentApp: app && app.title
         };
+        this.hideCopyAlert = () => this.setState({ showCopyAlert: false });
+        this.hideCopyAlertError = () => this.setState({ showCopyAlertError: false });
         this.updateAppVersion = this.updateAppVersion.bind(this);
     }
 
@@ -116,9 +121,11 @@ class InsightsAbout extends Component {
         }
 
         navigator.clipboard.writeText(JSON.stringify(debugDetails, null, 2))
-            .then(function() {
+            .then(() => {
+                this.setState({ showCopyAlert: true });
                 console.info('Copy to clipboard successful');
-            }, function(err) {
+            }, (err) => {
+                this.setState({ showCopyAlertError: true });
                 console.error('Could not copy text: ', err);
                 Sentry.captureException(err);
             });
@@ -135,6 +142,7 @@ class InsightsAbout extends Component {
 
     render() {
         const { isModalOpen, onClose, user } = this.props;
+        const { showCopyAlert, showCopyAlertError } = this.state;
 
         return (
             <AboutModal
@@ -143,6 +151,7 @@ class InsightsAbout extends Component {
                 brandImageSrc={logo}
                 brandImageAlt="Red Hat Logo"
                 trademark={<Copyright />}
+                className='ins-c-about-modal'
             >
                 <Stack gutter='sm'>
                     <StackItem>
@@ -154,6 +163,26 @@ class InsightsAbout extends Component {
                                 <CopyIcon/>
                             </Button>
                         </Tooltip>
+                    {showCopyAlert && (
+                        <StackItem>
+                            <Alert
+                                className='ins-c-alert__copied'
+                                variant="success"
+                                title="Successfully copied details"
+                                action={<AlertActionCloseButton onClose={this.hideCopyAlert} />}
+                            />
+                        </StackItem>
+                    )}
+                    {showCopyAlertError && (
+                        <StackItem>
+                            <Alert
+                                className='ins-c-alert__copied'
+                                variant="danger"
+                                title="Error copying details"
+                                action={<AlertActionCloseButton onClose={this.hideCopyAlertError} />}
+                            />
+                        </StackItem>
+                    )}
                     </StackItem>
                     <StackItem>
                         <TextContent className="ins-c-page__about--modal">

--- a/src/js/App/Header/InsightsAbout.js
+++ b/src/js/App/Header/InsightsAbout.js
@@ -2,12 +2,18 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
     AboutModal,
+    Button,
+    Tooltip, TooltipPosition,
     TextContent, TextList, TextListItem,
     Stack, StackItem
 } from '@patternfly/react-core';
+
+import { CopyIcon } from '@patternfly/react-icons';
+
 import logo from '../../../../static/images/logo.svg';
 import { connect } from 'react-redux';
 import './InsightsAbout.scss';
+import * as Sentry from '@sentry/browser';
 
 const Copyright = () => (
     <div className='ins-c-footer__traditional-nav pf-l-flex pf-m-column
@@ -99,6 +105,25 @@ class InsightsAbout extends Component {
         this.setState(appDetails);
     }
 
+
+    copyDetails(username) {
+
+        const debugDetails = {
+            Username: username, 
+            Current_App: this.state.currentApp || 'Landing',
+            Application_Path: window.location.pathname,
+            ...this.state.appDetails
+        }
+
+        navigator.clipboard.writeText(JSON.stringify(debugDetails, null, 2))
+            .then(function() {
+                console.info('Copy to clipboard successful');
+            }, function(err) {
+                console.error('Could not copy text: ', err);
+                Sentry.captureException(err);
+            });
+    }
+
     componentDidMount() {
         this.state.appDetails.apps.forEach((app) => {
             fetch(app.path)
@@ -122,7 +147,13 @@ class InsightsAbout extends Component {
                 <Stack gutter='sm'>
                     <StackItem>
                         Please include these details when opening a support case.
-
+                        <Tooltip
+                            position='top'
+                            content={<span> Copy to clipboard </span>}>
+                            <Button variant='plain' onClick={() => this.copyDetails(user.username)} aria-label='Copy details'>
+                                <CopyIcon/>
+                            </Button>
+                        </Tooltip>
                     </StackItem>
                     <StackItem>
                         <TextContent className="ins-c-page__about--modal">

--- a/src/js/App/Header/InsightsAbout.js
+++ b/src/js/App/Header/InsightsAbout.js
@@ -110,25 +110,22 @@ class InsightsAbout extends Component {
         this.setState(appDetails);
     }
 
-
     copyDetails(username) {
 
         const debugDetails = {
-            Username: username, 
-            Current_App: this.state.currentApp || 'Landing',
-            Application_Path: window.location.pathname,
+            Username: username,
+            CurrentApp: this.state.currentApp || 'Landing',
+            ApplicationPath: window.location.pathname,
             ...this.state.appDetails
-        }
+        };
 
         navigator.clipboard.writeText(JSON.stringify(debugDetails, null, 2))
-            .then(() => {
-                this.setState({ showCopyAlert: true });
-                console.info('Copy to clipboard successful');
-            }, (err) => {
-                this.setState({ showCopyAlertError: true });
-                console.error('Could not copy text: ', err);
-                Sentry.captureException(err);
-            });
+        .then(() => {
+            this.setState({ showCopyAlert: true });
+        }, (err) => {
+            this.setState({ showCopyAlertError: true });
+            Sentry.captureException(err);
+        });
     }
 
     componentDidMount() {
@@ -163,6 +160,7 @@ class InsightsAbout extends Component {
                                 <CopyIcon/>
                             </Button>
                         </Tooltip>
+                    </StackItem>
                     {showCopyAlert && (
                         <StackItem>
                             <Alert
@@ -183,7 +181,6 @@ class InsightsAbout extends Component {
                             />
                         </StackItem>
                     )}
-                    </StackItem>
                     <StackItem>
                         <TextContent className="ins-c-page__about--modal">
                             <TextList component="dl" className='ins-debug-info'>

--- a/src/js/App/Header/InsightsAbout.scss
+++ b/src/js/App/Header/InsightsAbout.scss
@@ -34,3 +34,5 @@
         }
     }
 }
+
+.ins-c-about-modal .pf-c-alert.ins-c-alert__copied .pf-c-alert__title { margin: 0; }


### PR DESCRIPTION
~Patternfly alerts don't render on top of modals, so i'm going to inline them 😄~

This is actually the PF spec for alerts in modals

On Load:
<img width="1246" alt="Screen Shot 2019-06-11 at 2 55 17 PM" src="https://user-images.githubusercontent.com/12520842/59299064-d11fa200-8c59-11e9-89c0-56bfdb6a7d7c.png">

On hover:
<img width="1254" alt="Screen Shot 2019-06-11 at 2 55 23 PM" src="https://user-images.githubusercontent.com/12520842/59299080-daa90a00-8c59-11e9-8eaa-9825b0051ccd.png">

On successful copy:
![Screen Shot 2019-06-12 at 11 11 18 AM](https://user-images.githubusercontent.com/12520842/59363224-d38a0680-8d02-11e9-96d0-141a8732bbf2.png)


Will output:
```
{
  "Username": "rhn-insights-rlong",
  "CurrentApp": "Landing",
  "ApplicationPath": "/",
  "apps": [
    {
      "name": "Chrome",
      "path": "apps/chrome/app.info.json"
    },
    {
      "name": "Dashboard",
      "path": "apps/dashboard/app.info.json",
      "version": "be8c41a4f1a812e064897dfbf34ef94ab1b02f42"
    },
    {
      "name": "Inventory",
      "path": "apps/inventory/app.info.json",
      "version": "8c6757740cb36a26da6e36820cc8936dbb633b33"
    },
    {
      "name": "Remediations",
      "path": "apps/remediations/app.info.json",
      "version": "84681c6bec6d888ba2dbca74871be340e06ac285"
    },
    {
      "name": "Vulnerability",
      "path": "apps/vulnerability/app.info.json",
      "version": "587b8d07c01a20a75af2dfd4146c438dd8a39207"
    },
    {
      "name": "Compliance",
      "path": "apps/compliance/app.info.json",
      "version": "d6aa513798317cfa699ed40d78f15789ca4a0ec7"
    },
    {
      "name": "Cost Management",
      "path": "apps/cost-management/app.info.json",
      "version": "579d2fd614b11a8a2bc1d6b848ce98661504b46b"
    },
    {
      "name": "Insights",
      "path": "apps/insights/app.info.json",
      "version": "31041e1173fae843836750099436fc26a52e0535"
    }
  ]
}
```
