### PR TITLE
Remove canceled requests as well

### DIFF
--- a/src/js/iqeEnablement.js
+++ b/src/js/iqeEnablement.js
@@ -10,7 +10,7 @@ function init () {
     const oldFetch = window.fetch;
 
     // must use function here because arrows dont "this" like functions
-    window.XMLHttpRequest.prototype.open = function openReplacement(method, url) { // eslint-disable-line func-names
+    window.XMLHttpRequest.prototype.open = function openReplacement(_method, url) { // eslint-disable-line func-names
         this._url = url;
         return open.apply(this, arguments);
     };
@@ -46,8 +46,8 @@ export default {
         }
     },
     hasPendingAjax: () => {
-        const xhrRemoved = xhrResults.filter(result => result.readyState === 4);
-        xhrResults = xhrResults.filter(result => result.readyState !== 4);
+        const xhrRemoved = xhrResults.filter(result => result.readyState === 4 || result.readyState === 0);
+        xhrResults = xhrResults.filter(result => result.readyState !== 4 && result.readyState !== 0);
         for (const e of xhrRemoved) {
             console.log(`[iqe] xhr complete:   ${e._url}`);// eslint-disable-line no-console
         }


### PR DESCRIPTION
We have to remove requests with readyState 0 as well. These requests are not actually sent so we don't have to wait for them. Plus if axios cancels request it sets readyState to 0 as well.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState