### PR TITLE
fix details so appName is landing only if appGroup is landing

### DIFF
--- a/src/js/sentry.js
+++ b/src/js/sentry.js
@@ -10,18 +10,18 @@ function getAppDetails() {
     if (pathName[1] === 'beta') {
         betaCheck = ' Beta';
         appGroup = pathName[2];
-        appName = pathName[3];
+        appName = (appGroup === 'landing' ? 'landing' : pathName[3]);
     } else {
         betaCheck = '';
         appGroup = pathName[1];
-        appName = pathName[2];
+        appName = (appGroup === 'landing' ? 'landing' : pathName[2]);
     }
 
     const appDetails = {
         beta: betaCheck,
         app: {
-            group: appGroup || 'landing',
-            name: appName || 'landing'
+            group: appGroup,
+            name: appName
         }
     };
 


### PR DESCRIPTION
Problem: Sometimes a page like /openshift/ doesn't have an `appName` and then it sends `landing`. We only want `appName` if `appGroup` is also `landing`.