### PR TITLE
Support for disabled_on_prod flag

### DIFF
--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -33,7 +33,8 @@ function getRoutesForApp(app, masterConfig) {
 // Gets the app's data from the master config, if it exists
 function getAppData(appId, propName, masterConfig) {
     const app = masterConfig[appId];
-    if (app && app.hasOwnProperty('frontend')) {
+    if (app && app.hasOwnProperty('frontend') &&
+        !(app.disabled_on_prod && window.location.hostname === 'cloud.redhat.com')) {
         const routes = getRoutesForApp(app, masterConfig);
         let appData = {
             title: app.frontend.title || app.title

--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -24,7 +24,9 @@ function getRoutesForApp(app, masterConfig) {
 
             if (subItem.group) {subAppData.group = subItem.group;}
 
-            routes.push(subAppData);
+            if (!(subAppData.disabled_on_prod && window.location.hostname === 'cloud.redhat.com')) {
+                routes.push(subAppData);
+            }
         }));
         return routes;
     }
@@ -33,8 +35,7 @@ function getRoutesForApp(app, masterConfig) {
 // Gets the app's data from the master config, if it exists
 function getAppData(appId, propName, masterConfig) {
     const app = masterConfig[appId];
-    if (app && app.hasOwnProperty('frontend') &&
-        !(app.disabled_on_prod && window.location.hostname === 'cloud.redhat.com')) {
+    if (app && app.hasOwnProperty('frontend')) {
         const routes = getRoutesForApp(app, masterConfig);
         let appData = {
             title: app.frontend.title || app.title
@@ -42,6 +43,10 @@ function getAppData(appId, propName, masterConfig) {
         if (!app.frontend.suppress_id) {appData.id = appId;}
 
         if (app.frontend.reload) {appData.reload = app.frontend.reload;}
+
+        if (app.disabled_on_prod) {
+            appData.disabled_on_prod = app.disabled_on_prod; // eslint-disable-line camelcase
+        }
 
         if (routes) {appData[propName] = routes;}
 

--- a/src/js/nav/sourceOfTruth.js
+++ b/src/js/nav/sourceOfTruth.js
@@ -19,7 +19,7 @@ module.exports = (cachePrefix) => {
 
     instance.interceptors.response.use((response) => response.data || response);
 
-    // TODO: Add prefix (/beta) depending on environment
+    // Add prefix (/beta) depending on environment
     let prefix = '';
     if (window.location.pathname.indexOf('/beta') !== -1) {
         prefix = '/beta';


### PR DESCRIPTION
Add support for the disabled_on_prod flag. Makes it so the nav doesn't add an entry for an app if the app is supposed to be disabled on prod, and the hostname indicates that we're on prod.

The logic feels a little clunkier than I'd like, but I'm not immediately seeing a way to clean this up and achieve the same result. Let me know if you see a way to simplify this!