### PR TITLE
move user management spot up one

### DIFF
--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -29,13 +29,6 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
             }
         </React.Fragment>,
         <DropdownSeparator key="separator" />,
-        <DropdownItem
-            key="My Profile"
-            href="https://access.redhat.com/user"
-            target="_blank"
-            rel='noopener noreferrer'>
-                My profile
-        </DropdownItem>,
         <React.Fragment key="user management wrapper">
             { isOrgAdmin &&
                 <DropdownItem
@@ -46,6 +39,13 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
                 </DropdownItem>
             }
         </React.Fragment>,
+        <DropdownItem
+            key="My Profile"
+            href="https://access.redhat.com/user"
+            target="_blank"
+            rel='noopener noreferrer'>
+                My profile
+        </DropdownItem>,
         <DropdownItem
             key="logout"
             component="button"


### PR DESCRIPTION
In some browsers, using the arrow keys to navigate through the menu options don't work because of (what I think is) the fragment wrapping user management. Moving it up one solves this issue temporarily. I'll take a further look into this, but it may be a PF problem.