### PR TITLE
Stretch drawer content and main page to entire height

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -48,6 +48,11 @@ aside {
   --pf-m-emphasis--FontSize:                        var(--pf-global--FontSize--xl);
 }
 
+// Page layout styles
+.pf-c-drawer__content, #root.pf-c-page__main {
+    height: 100%;
+}
+
 // Page root background color
 .pf-c-page__main#root {
     background: var(--pf-c-page__main-section--BackgroundColor);


### PR DESCRIPTION
If the content is not tall enough black background will be shown because drawer content and main root does not fill the entire content.

### Before
![Screenshot from 2019-09-23 16-12-43](https://user-images.githubusercontent.com/3439771/65433289-0624be80-de1d-11e9-8c6f-ba24f87aed3d.png)

### After
![Screenshot from 2019-09-23 16-12-00](https://user-images.githubusercontent.com/3439771/65433233-eb524a00-de1c-11e9-9e2e-e94b855ace0d.png)
