### PR TITLE
Fix shifting masthead

### DIFF
--- a/src/pug/header.pug
+++ b/src/pug/header.pug
@@ -9,7 +9,7 @@ header.pf-c-page__header.pf-l-page__header(role="banner")
         .pf-l-toolbar.ins-c-header-toolbar__loading
             .pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
                 .pf-l-toolbar__item(data-key='0')
-                    button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
+                    button.pf-c-button.pf-m-plain.pf-c-dropdown__toggle(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
                         img(src="apps/chrome/assets/images/faq-button.svg")
             .pf-l-toolbar__group
                 .pf-l-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
@@ -20,5 +20,5 @@ header.pf-c-page__header.pf-l-page__header(role="banner")
                     .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                         button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-1(type='button' aria-expanded='false' aria-haspopup='true')
                             span.pf-c-dropdown__toggle-text Logging in...
-                            img(src="apps/chrome/assets/images/overflow-actions-lg.svg")
+                            img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
         img.pf-c-avatar(src="apps/chrome/assets/images/img_avatar.svg" alt="Avatar Image")

--- a/src/pug/header.pug
+++ b/src/pug/header.pug
@@ -6,17 +6,17 @@ header.pf-c-page__header.pf-l-page__header(role="banner")
         a.pf-c-page__header-brand-link.pf-l-page__header-brand-link(href='#')
             img(src="apps/chrome/assets/images/logo.svg")
     .pf-c-page__header-tools.pf-l-page__header-tools(widget-type='InsightsToolbar')
-        .pf-c-toolbar.ins-c-header-toolbar__loading
-            .pf-c-toolbar__group.pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
-                .pf-c-toolbar__item.pf-l-toolbar__item(data-key='0')
+        .pf-l-toolbar.ins-c-header-toolbar__loading
+            .pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
+                .pf-l-toolbar__item(data-key='0')
                     button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
                         img(src="apps/chrome/assets/images/faq-button.svg")
-            dif.pf-c-toolbar__group.pf-l-toolbar__group
-                .pf-c-toolbar__item.pf-l-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
+            .pf-l-toolbar__group
+                .pf-l-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
                     .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                         button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-1(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
                             img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
-                .pf-c-toolbar__item.pf-l-toolbar__item.pf-u-screen-reader.pf-u-visible-on-lg
+                .pf-l-toolbar__item.pf-u-screen-reader.pf-u-visible-on-lg
                     .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                         button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-1(type='button' aria-expanded='false' aria-haspopup='true')
                             span.pf-c-dropdown__toggle-text Logging in...

--- a/src/pug/landing-header.pug
+++ b/src/pug/landing-header.pug
@@ -6,17 +6,17 @@ header.pf-c-page__header.pf-l-page__header(role="banner")
         a.pf-c-page__header-brand-link.pf-l-page__header-brand-link(href='#')
             img(src="apps/chrome/assets/images/logo.svg")
     .pf-c-page__header-tools.pf-l-page__header-tools(widget-type='InsightsToolbar')
-        .pf-c-toolbar
-            .pf-c-toolbar__group.pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
-                .pf-c-toolbar__item.pf-l-toolbar__item(data-key='0')
+        .pf-l-toolbar
+            .pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
+                .pf-l-toolbar__item(data-key='0')
                     button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
                         img(src="apps/chrome/assets/images/faq-button.svg")
-            .pf-l-toolbar__group.pf-c-toolbar__group
-                .pf-l-toolbar__item.pf-c-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
+            .pf-l-toolbar__group
+                .pf-l-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
                     .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                         button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-1(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
                             img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
-                .pf-c-toolbar__item.pf-l-toolbar__item.pf-u-screen-reader.pf-u-visible-on-lg
+                .pf-l-toolbar__item.pf-u-screen-reader.pf-u-visible-on-lg
                     .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                         button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-2(type='button' aria-expanded='false' aria-haspopup='true')
                             span.pf-c-dropdown__toggle-text Logging in...

--- a/src/pug/landing-header.pug
+++ b/src/pug/landing-header.pug
@@ -9,7 +9,7 @@ header.pf-c-page__header.pf-l-page__header(role="banner")
         .pf-l-toolbar
             .pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
                 .pf-l-toolbar__item(data-key='0')
-                    button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
+                    button.pf-c-button.pf-m-plain.pf-c-dropdown__toggle(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
                         img(src="apps/chrome/assets/images/faq-button.svg")
             .pf-l-toolbar__group
                 .pf-l-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
@@ -20,5 +20,5 @@ header.pf-c-page__header.pf-l-page__header(role="banner")
                     .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                         button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-2(type='button' aria-expanded='false' aria-haspopup='true')
                             span.pf-c-dropdown__toggle-text Logging in...
-                            img(src="apps/chrome/assets/images/overflow-actions-lg.svg")
+                            img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
         img.pf-c-avatar(src="apps/chrome/assets/images/img_avatar.svg" alt="Avatar Image")


### PR DESCRIPTION
`.pf-c-toolbar` & suffixes are deprecated at this point.

Turns out, when we added `.pf-l-toolbar`, we missed one spot - this caused the shifting of the masthead.

I'm just removing all instances of `pf-c-toolbar` since it's no longer used.