### PR TITLE
adding padding to top of nav

### DIFF
--- a/src/sass/partials/_sidebar.scss
+++ b/src/sass/partials/_sidebar.scss
@@ -33,4 +33,6 @@ aside.pf-c-page__sidebar {
     .pf-c-nav__list > .pf-c-nav__item > .pf-c-nav__link::after {
         bottom: var(--pf-c-nav__list-link--after--Bottom);
     }
+
+    nav.pf-c-nav { padding-top: var(--pf-global--spacer--sm); }
 }


### PR DESCRIPTION
I'd use a PF nav variable, but there's a discrepancy from their docs to what they actually show. This global space is the one that should be used. Yes, that little space between the border and the highlight should be there according to PF.

![Screen Shot 2019-09-30 at 11 59 31 AM](https://user-images.githubusercontent.com/12520842/65895646-c6f4f100-e379-11e9-967d-fca36fb8e2e7.png)
