### PR TITLE
fix the landing page loader to just be a spinner

### DIFF
--- a/src/pug/landing.pug
+++ b/src/pug/landing.pug
@@ -1,8 +1,6 @@
 .pf-c-page#page
     include landing-header.pug
     main.pf-c-page__main.pf-l-page__main#root(role='main', data-ouia-safe='false')
-        section.pf-l-page-header.pf-c-page-header.pf-l-page__main-section.pf-c-page__main-section.pf-m-light(widget-type="InsightsPageHeader")
-                h1.pf-c-title.pf-m-2xl(widget-type='InsightsPageHeaderTitle') Manage, automate, and optimize your IT
         section.pf-c-page__main-section.pf-l-page__main-section
             .ins-c-spinner.ins-m-center(role='status')
                 span(class="pf-u-screen-reader") Loading...


### PR DESCRIPTION
Let's just show a spinner instead of the header. No reason to show that text when the marketing page may show.

Related: https://github.com/RedHatInsights/landing-page-frontend/pull/88