### PR TITLE
Update FEC-inventory to 0.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4377,9 +4377,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-inventory": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory/-/frontend-components-inventory-0.0.23.tgz",
-      "integrity": "sha512-djK17udQJuVOSLJxG2FqspeAzCVkmzZtic+dfE7QH6DfoKb6wrF/baf//aDuW5VqafdjRO+tvmgNPVAJUKBvDw==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory/-/frontend-components-inventory-0.0.25.tgz",
+      "integrity": "sha512-YHYK46pEHnpPQmsz9xWisc6h5UjKWs6Pxx/Gxc8neSTGgP2ggJjgyXnXsKe1+G+xOpfOpbhaQArVkHX57iAGUg==",
       "requires": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@patternfly/react-icons": "^3.14.9",
     "@redhat-cloud-services/entitlements-client": "^1.0.18",
     "@redhat-cloud-services/frontend-components": "0.0.24",
-    "@redhat-cloud-services/frontend-components-inventory": "0.0.23",
+    "@redhat-cloud-services/frontend-components-inventory": "0.0.25",
     "@redhat-cloud-services/frontend-components-remediations": "0.0.3",
     "@redhat-cloud-services/frontend-components-utilities": "0.0.9",
     "@redhat-cloud-services/keycloak-js": "0.0.2",


### PR DESCRIPTION
We would need the latest version in insights-chrome to make sure the inventory skeleton looks properly as per UXD (see RHICOMPL-167 for more info, https://github.com/RedHatInsights/frontend-components/pull/206). 