### PR TITLE
Enable redux logging by changing localStorage value

### DIFF
--- a/src/js/debugFunctions.js
+++ b/src/js/debugFunctions.js
@@ -8,5 +8,6 @@ export default ({
     remediationsDebug: () => functionBuilder('remediations:debug', true),
     invTags: () => functionBuilder('rhcs-tags', true),
     shortSession: () => functionBuilder('chrome:jwt:shortSession', true),
-    jwtDebug: () => functionBuilder('chrome:jwt:debug', true)
+    jwtDebug: () => functionBuilder('chrome:jwt:debug', true),
+    reduxDebug: () => functionBuilder('chrome:redux:debug', true)
 });

--- a/src/js/redux-config.js
+++ b/src/js/redux-config.js
@@ -4,10 +4,11 @@ import ReducerRegistry, {
     dispatchActionsToStore
 } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
 import MiddlewareListener from '@redhat-cloud-services/frontend-components-utilities/files/MiddlewareListener';
+import logger from 'redux-logger';
 
 const basicMiddlewares = [];
-if (process.env.NODE_ENV === 'development') {
-    import('redux-logger').then(logger => basicMiddlewares.push(logger.default));
+if (window && window.localStorage.getItem('chrome:redux:debug') === 'true') {
+    basicMiddlewares.push(logger);
 }
 
 const middlewareListener = new MiddlewareListener();

--- a/src/js/redux-config.js
+++ b/src/js/redux-config.js
@@ -7,7 +7,10 @@ import MiddlewareListener from '@redhat-cloud-services/frontend-components-utili
 import logger from 'redux-logger';
 
 const basicMiddlewares = [];
-if (window && window.localStorage.getItem('chrome:redux:debug') === 'true') {
+if (
+    process.env.NODE_ENV === 'development' ||
+    (window && window.localStorage.getItem('chrome:redux:debug') === 'true')
+) {
     basicMiddlewares.push(logger);
 }
 


### PR DESCRIPTION
This will load redux logger in all envs and allow turning it on/off trough localStorage. The only downside to this is that it's always part of bundle, I made it working with async loading, but that requires changes in apps and that's not really a good thing.