### PR TITLE
Track which app is selected after refresh

### DIFF
--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -138,11 +138,14 @@ function loadNav(yamlConfig) {
     const groupedNav = getNavFromConfig(safeLoad(yamlConfig));
 
     const splitted = location.pathname.split('/') ;
-    const active = splitted[1] === 'beta' ? splitted[2] : splitted[1];
+    const [active, section] = splitted[1] === 'beta' ? [splitted[2], splitted[3]] : [splitted[1], splitted[2]];
+    const globalNav = groupedNav[active].routes;
+    let activeSection = globalNav.find(({ id }) => id === section);
     return groupedNav[active] ? {
-        globalNav: groupedNav[active].routes,
+        globalNav,
         activeTechnology: groupedNav[active].title,
-        activeLocation: active
+        activeLocation: active,
+        activeSection
     } : {
         globalNav: groupedNav.insights.routes,
         activeTechnology: 'Applications'

--- a/src/js/redux/actions.js
+++ b/src/js/redux/actions.js
@@ -16,7 +16,7 @@ function isCurrApp(item, app) {
         return true;
     } else if (item.subItems && item.subItems.some(sub => sub.id === app)) {
         return true;
-    } else if (item.group === app) {
+    } else if (item.group === app && item.active) {
         return true;
     }
 

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -8,7 +8,7 @@ export function clickReducer(state, action) {
 }
 
 export function globalNavReducer(state, { data: { id, activeApp } }) {
-    const activeGroup = state.globalNav.filter(item => item.group === id);
+    const activeGroup = state.globalNav ? state.globalNav.filter(item => item.group === id) : [];
     let active;
     if (activeGroup.length > 0) {
         active = activeGroup.find(item => window.location.href.indexOf(item.id) !== -1);
@@ -28,10 +28,14 @@ export function globalNavReducer(state, { data: { id, activeApp } }) {
     };
 }
 
-export function navUpdateReducer(state, { payload }) {
+export function navUpdateReducer(state, { payload: { activeSection, globalNav, ...payload } }) {
     return {
         ...state,
-        ...payload
+        ...payload,
+        globalNav: globalNav.map(app => ({
+            ...app,
+            active: activeSection && (app.title === activeSection.title || app.id === activeSection.id)
+        }))
     };
 }
 


### PR DESCRIPTION
### Fixes - page reload missing active app
When on insights and user refreshes page active app is forgotten and only overview is shown. This can be fixed on app level by calling `appNavClick` but that is not pleasent and not nice. So this PR calculates active app from URL.