### PR TITLE
Reuse cache from localStorage

### DIFF
--- a/src/js/jwt/insights/entitlements.js
+++ b/src/js/jwt/insights/entitlements.js
@@ -1,31 +1,12 @@
 const axios = require('axios');
 const { ServicesApi } = require('@redhat-cloud-services/entitlements-client');
-const { setupCache } = require('axios-cache-adapter');
-const localforage = require('localforage');
-const { deleteLocalStorageItems } = require('../../utils');
+const { bootstrapCache } = require('../../utils');
 const BASE_PATH = '/api/entitlements/v1';
 
 module.exports = (cachePrefix) => {
-    const store = localforage.createInstance({
-        driver: [
-            localforage.LOCALSTORAGE
-        ],
-        name: `${cachePrefix}-entitlements`
-    });
-    const cache = setupCache({
-        store,
-        maxAge: 10 * 60 * 1000 // 10 minutes
-    });
+    const cache = bootstrapCache(BASE_PATH, `${cachePrefix}-entitlements`);
 
     const instance = axios.create({ adapter: cache.adapter });
-    instance.interceptors.response.use((response) => {
-        if (response && response.request && response.request.fromCache !== true) {
-            const keys = Object.keys(localStorage).filter(key => key.endsWith('/api/entitlements/v1/services')).slice(0, -1);
-            deleteLocalStorageItems(keys);
-        }
-
-        return response;
-    });
     instance.interceptors.response.use((response) => response.data || response);
 
     return new ServicesApi(undefined, BASE_PATH, instance);

--- a/src/js/nav/sourceOfTruth.js
+++ b/src/js/nav/sourceOfTruth.js
@@ -1,31 +1,11 @@
 const axios = require('axios');
-const { setupCache } = require('axios-cache-adapter');
-const localforage = require('localforage');
-const { deleteLocalStorageItems } = require('../utils');
+const { bootstrapCache } = require('../utils');
 
 // Gets the source of truth from the CS Config repository, and caches it for 10 minutes.
 module.exports = (cachePrefix) => {
-    const store = localforage.createInstance({
-        driver: [
-            localforage.LOCALSTORAGE
-        ],
-        name: `${cachePrefix}-nav`
-    });
-    const cache = setupCache({
-        store,
-        maxAge: 10 * 60 * 1000 // 10 minutes
-    });
+    const cache = bootstrapCache('/config/main.yml', `${cachePrefix}-nav`);
 
     const instance = axios.create({ adapter: cache.adapter });
-
-    instance.interceptors.response.use((response) => {
-        if (response && response.request && response.request.fromCache !== true) {
-            const keys = Object.keys(localStorage).filter(key => key.endsWith('/config/main.yml')).slice(0, -1);
-            deleteLocalStorageItems(keys);
-        }
-
-        return response;
-    });
 
     instance.interceptors.response.use((response) => response.data || response);
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -73,10 +73,9 @@ export function deleteLocalStorageItems(keys) {
     keys.map(key => localStorage.removeItem(key));
 }
 
-export function lastActive(searhString, fallback) {
+export function lastActive(searchString, fallback) {
     return Object.keys(localStorage).reduce((acc, curr) => {
-        console.log(curr, searhString);
-        if (curr.includes(searhString)) {
+        if (curr.includes(searchString)) {
             try {
                 let accDate;
                 try {
@@ -85,7 +84,6 @@ export function lastActive(searhString, fallback) {
                     accDate = new Date();
                 }
 
-                console.log(accDate);
                 const currObj = JSON.parse(localStorage.getItem(curr));
                 return (accDate >= new Date(currObj.expires)) ? acc : curr;
             } catch (e) {
@@ -99,7 +97,6 @@ export function lastActive(searhString, fallback) {
 
 export function bootstrapCache(endpoint, cacheKey) {
     const name = lastActive(endpoint, cacheKey);
-    console.log(name, 'fff');
     const store = localforage.createInstance({
         driver: [
             localforage.LOCALSTORAGE

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,4 +1,6 @@
 import get from 'lodash/get';
+import { setupCache } from 'axios-cache-adapter';
+import localforage from 'localforage';
 
 function getWindow() {
     return window;
@@ -69,4 +71,43 @@ export function createReduxListener(store, path, fn) {
 
 export function deleteLocalStorageItems(keys) {
     keys.map(key => localStorage.removeItem(key));
+}
+
+export function lastActive(searhString, fallback) {
+    return Object.keys(localStorage).reduce((acc, curr) => {
+        console.log(curr, searhString);
+        if (curr.includes(searhString)) {
+            try {
+                let accDate;
+                try {
+                    accDate = new Date(JSON.parse(localStorage.getItem(acc).expires));
+                } catch {
+                    accDate = new Date();
+                }
+
+                console.log(accDate);
+                const currObj = JSON.parse(localStorage.getItem(curr));
+                return (accDate >= new Date(currObj.expires)) ? acc : curr;
+            } catch (e) {
+                return acc;
+            }
+        }
+
+        return acc;
+    }, fallback);
+}
+
+export function bootstrapCache(endpoint, cacheKey) {
+    const name = lastActive(endpoint, cacheKey);
+    console.log(name, 'fff');
+    const store = localforage.createInstance({
+        driver: [
+            localforage.LOCALSTORAGE
+        ],
+        name: name.split('/')[0]
+    });
+    return setupCache({
+        store,
+        maxAge: 10 * 60 * 1000 // 10 minutes
+    });
 }


### PR DESCRIPTION
Looks like our cache busting was too good and removed all items every time. This reuses active cache so when changing between tabs it will use the same data. I had to remove cache invalidation, because it was removing all things instead of active one @PanSpagetka can you look at how to enable it back? We can merge this one and reintroduce the cache invalidation after it.