### PR TITLE
allow focus to the user management link

### DIFF
--- a/src/js/App/Header/HeaderTests/UserToggle.test.js
+++ b/src/js/App/Header/HeaderTests/UserToggle.test.js
@@ -42,7 +42,7 @@ describe('UserToggle', ()=>{
     });
 });
 
-describe('ConnectedUserToggle', () => {
+describe('ConnectedUserToggle -- not org admin', () => {
     let initialState;
     let mockStore;
 
@@ -58,6 +58,41 @@ describe('ConnectedUserToggle', () => {
                             first_name: 'someFirstName',
                             last_name: 'someLastName',
                             is_org_admin: false
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    it('should render correctly', () =>{
+        const store = mockStore(initialState);
+        const wrapper = mount(
+            <Provider store={store}>
+                <ConnectedUserToggle/>
+            </Provider>
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+});
+
+describe('ConnectedUserToggle -- org admin', () => {
+    let initialState;
+    let mockStore;
+
+    beforeEach(() =>{
+        mockStore = configureStore();
+        initialState = ({
+            chrome: {
+                user: {
+                    identity: {
+                        account_number: 'some accountNumber',
+                        user: {
+                            username: 'someUsername',
+                            first_name: 'someFirstName',
+                            last_name: 'someLastName',
+                            is_org_admin: true
                         }
                     }
                 }

--- a/src/js/App/Header/HeaderTests/__snapshots__/UserToggle.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/UserToggle.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConnectedUserToggle should render correctly 1`] = `
+exports[`ConnectedUserToggle -- not org admin should render correctly 1`] = `
 <Provider
   store={
     Object {
@@ -51,7 +51,6 @@ exports[`ConnectedUserToggle should render correctly 1`] = `
             </DropdownItem>,
             <React.Fragment />,
             <DropdownSeparator />,
-            <React.Fragment />,
             <DropdownItem
               href="https://access.qa.redhat.com/user"
               rel="noopener noreferrer"
@@ -105,7 +104,6 @@ exports[`ConnectedUserToggle should render correctly 1`] = `
               </DropdownItem>,
               <React.Fragment />,
               <DropdownSeparator />,
-              <React.Fragment />,
               <DropdownItem
                 href="https://access.qa.redhat.com/user"
                 rel="noopener noreferrer"
@@ -160,7 +158,6 @@ exports[`ConnectedUserToggle should render correctly 1`] = `
                   </DropdownItem>,
                   <React.Fragment />,
                   <DropdownSeparator />,
-                  <React.Fragment />,
                   <DropdownItem
                     href="https://access.qa.redhat.com/user"
                     rel="noopener noreferrer"
@@ -216,7 +213,6 @@ exports[`ConnectedUserToggle should render correctly 1`] = `
                   </DropdownItem>,
                   <React.Fragment />,
                   <DropdownSeparator />,
-                  <React.Fragment />,
                   <DropdownItem
                     href="https://access.qa.redhat.com/user"
                     rel="noopener noreferrer"
@@ -415,6 +411,445 @@ exports[`ConnectedUserToggle should render correctly 1`] = `
 </Provider>
 `;
 
+exports[`ConnectedUserToggle -- org admin should render correctly 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(UserToggle)>
+    <UserToggle
+      account={
+        Object {
+          "isOrgAdmin": true,
+          "name": "someFirstName someLastName",
+          "number": "some accountNumber",
+          "username": "someUsername",
+        }
+      }
+      dispatch={[Function]}
+      extraItems={Array []}
+      isSmall={false}
+    >
+      <Dropdown
+        aria-label="Overflow actions"
+        dropdownItems={
+          Array [
+            <DropdownItem
+              isDisabled={true}
+            >
+              <dl
+                className="ins-c-dropdown-item__stack"
+              >
+                <dt
+                  className="ins-c-dropdown-item__stack--header"
+                >
+                  Username:
+                </dt>
+                <dd
+                  className="ins-c-dropdown-item__stack--value"
+                >
+                  someUsername
+                </dd>
+              </dl>
+            </DropdownItem>,
+            <React.Fragment />,
+            <DropdownSeparator />,
+            <DropdownItem
+              href="https://www.qa.redhat.com/wapps/ugc/protected/usermgt/userList.html"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              User management
+            </DropdownItem>,
+            <DropdownItem
+              href="https://access.qa.redhat.com/user"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              My profile
+            </DropdownItem>,
+            <DropdownItem
+              component="button"
+              onClick={[Function]}
+            >
+              Logout
+            </DropdownItem>,
+            Array [],
+          ]
+        }
+        isOpen={false}
+        isPlain={true}
+        onSelect={[Function]}
+        position="right"
+        toggle={
+          <DropdownToggle
+            onToggle={[Function]}
+          >
+            someFirstName someLastName
+          </DropdownToggle>
+        }
+        widget-type="InsightsOverflowActions"
+      >
+        <Component
+          aria-label="Overflow actions"
+          dropdownItems={
+            Array [
+              <DropdownItem
+                isDisabled={true}
+              >
+                <dl
+                  className="ins-c-dropdown-item__stack"
+                >
+                  <dt
+                    className="ins-c-dropdown-item__stack--header"
+                  >
+                    Username:
+                  </dt>
+                  <dd
+                    className="ins-c-dropdown-item__stack--value"
+                  >
+                    someUsername
+                  </dd>
+                </dl>
+              </DropdownItem>,
+              <React.Fragment />,
+              <DropdownSeparator />,
+              <DropdownItem
+                href="https://www.qa.redhat.com/wapps/ugc/protected/usermgt/userList.html"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                User management
+              </DropdownItem>,
+              <DropdownItem
+                href="https://access.qa.redhat.com/user"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                My profile
+              </DropdownItem>,
+              <DropdownItem
+                component="button"
+                onClick={[Function]}
+              >
+                Logout
+              </DropdownItem>,
+              Array [],
+            ]
+          }
+          isOpen={false}
+          isPlain={true}
+          position="right"
+          toggle={
+            <DropdownToggle
+              onToggle={[Function]}
+            >
+              someFirstName someLastName
+            </DropdownToggle>
+          }
+          widget-type="InsightsOverflowActions"
+        >
+          <ComponentWithOuia
+            component={[Function]}
+            componentProps={
+              Object {
+                "aria-label": "Overflow actions",
+                "dropdownItems": Array [
+                  <DropdownItem
+                    isDisabled={true}
+                  >
+                    <dl
+                      className="ins-c-dropdown-item__stack"
+                    >
+                      <dt
+                        className="ins-c-dropdown-item__stack--header"
+                      >
+                        Username:
+                      </dt>
+                      <dd
+                        className="ins-c-dropdown-item__stack--value"
+                      >
+                        someUsername
+                      </dd>
+                    </dl>
+                  </DropdownItem>,
+                  <React.Fragment />,
+                  <DropdownSeparator />,
+                  <DropdownItem
+                    href="https://www.qa.redhat.com/wapps/ugc/protected/usermgt/userList.html"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    User management
+                  </DropdownItem>,
+                  <DropdownItem
+                    href="https://access.qa.redhat.com/user"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    My profile
+                  </DropdownItem>,
+                  <DropdownItem
+                    component="button"
+                    onClick={[Function]}
+                  >
+                    Logout
+                  </DropdownItem>,
+                  Array [],
+                ],
+                "isOpen": false,
+                "isPlain": true,
+                "position": "right",
+                "toggle": <DropdownToggle
+                  onToggle={[Function]}
+                >
+                  someFirstName someLastName
+                </DropdownToggle>,
+                "widget-type": "InsightsOverflowActions",
+              }
+            }
+            consumerContext={null}
+          >
+            <DropdownWithContext
+              aria-label="Overflow actions"
+              autoFocus={true}
+              className=""
+              direction="down"
+              dropdownItems={
+                Array [
+                  <DropdownItem
+                    isDisabled={true}
+                  >
+                    <dl
+                      className="ins-c-dropdown-item__stack"
+                    >
+                      <dt
+                        className="ins-c-dropdown-item__stack--header"
+                      >
+                        Username:
+                      </dt>
+                      <dd
+                        className="ins-c-dropdown-item__stack--value"
+                      >
+                        someUsername
+                      </dd>
+                    </dl>
+                  </DropdownItem>,
+                  <React.Fragment />,
+                  <DropdownSeparator />,
+                  <DropdownItem
+                    href="https://www.qa.redhat.com/wapps/ugc/protected/usermgt/userList.html"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    User management
+                  </DropdownItem>,
+                  <DropdownItem
+                    href="https://access.qa.redhat.com/user"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    My profile
+                  </DropdownItem>,
+                  <DropdownItem
+                    component="button"
+                    onClick={[Function]}
+                  >
+                    Logout
+                  </DropdownItem>,
+                  Array [],
+                ]
+              }
+              isGrouped={false}
+              isOpen={false}
+              isPlain={true}
+              onSelect={[Function]}
+              ouiaComponentType="Dropdown"
+              ouiaContext={
+                Object {
+                  "isOuia": false,
+                  "ouiaId": null,
+                }
+              }
+              position="right"
+              toggle={
+                <DropdownToggle
+                  onToggle={[Function]}
+                >
+                  someFirstName someLastName
+                </DropdownToggle>
+              }
+              widget-type="InsightsOverflowActions"
+            >
+              <div
+                aria-label="Overflow actions"
+                className="pf-c-dropdown"
+                widget-type="InsightsOverflowActions"
+              >
+                <DropdownToggle
+                  ariaHasPopup={true}
+                  id="pf-toggle-id-1"
+                  isOpen={false}
+                  isPlain={true}
+                  key=".0"
+                  onEnter={[Function]}
+                  onToggle={[Function]}
+                  parentRef={
+                    Object {
+                      "current": <div
+                        aria-label="Overflow actions"
+                        class="pf-c-dropdown"
+                        widget-type="InsightsOverflowActions"
+                      >
+                        <button
+                          aria-expanded="false"
+                          aria-haspopup="true"
+                          class="pf-c-dropdown__toggle pf-m-plain"
+                          id="pf-toggle-id-1"
+                          type="button"
+                        >
+                          <span
+                            class="pf-c-dropdown__toggle-text"
+                          >
+                            someFirstName someLastName
+                          </span>
+                          <svg
+                            aria-hidden="true"
+                            class="pf-c-dropdown__toggle-icon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                      </div>,
+                    }
+                  }
+                >
+                  <Toggle
+                    ariaHasPopup={true}
+                    className=""
+                    id="pf-toggle-id-1"
+                    isActive={false}
+                    isDisabled={false}
+                    isFocused={false}
+                    isHovered={false}
+                    isOpen={false}
+                    isPlain={true}
+                    isPrimary={false}
+                    isSplitButton={false}
+                    onEnter={[Function]}
+                    onToggle={[Function]}
+                    parentRef={
+                      Object {
+                        "current": <div
+                          aria-label="Overflow actions"
+                          class="pf-c-dropdown"
+                          widget-type="InsightsOverflowActions"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            class="pf-c-dropdown__toggle pf-m-plain"
+                            id="pf-toggle-id-1"
+                            type="button"
+                          >
+                            <span
+                              class="pf-c-dropdown__toggle-text"
+                            >
+                              someFirstName someLastName
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              class="pf-c-dropdown__toggle-icon"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </button>
+                        </div>,
+                      }
+                    }
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      className="pf-c-dropdown__toggle pf-m-plain"
+                      disabled={false}
+                      id="pf-toggle-id-1"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="pf-c-dropdown__toggle-text"
+                      >
+                        someFirstName someLastName
+                      </span>
+                      <CaretDownIcon
+                        className="pf-c-dropdown__toggle-icon"
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                        title={null}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          className="pf-c-dropdown__toggle-icon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </button>
+                  </Toggle>
+                </DropdownToggle>
+              </div>
+            </DropdownWithContext>
+          </ComponentWithOuia>
+        </Component>
+      </Dropdown>
+    </UserToggle>
+  </Connect(UserToggle)>
+</Provider>
+`;
+
 exports[`UserToggle should render correctly with isSmall false 1`] = `
 <Dropdown
   aria-label="Overflow actions"
@@ -438,7 +873,6 @@ exports[`UserToggle should render correctly with isSmall false 1`] = `
       </DropdownItem>,
       <React.Fragment />,
       <DropdownSeparator />,
-      <React.Fragment />,
       <DropdownItem
         href="https://access.qa.redhat.com/user"
         rel="noopener noreferrer"
@@ -493,7 +927,6 @@ exports[`UserToggle should render correctly with isSmall true 1`] = `
       </DropdownItem>,
       <React.Fragment />,
       <DropdownSeparator />,
-      <React.Fragment />,
       <DropdownItem
         href="https://access.qa.redhat.com/user"
         rel="noopener noreferrer"

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
-    const dropdownItems = [
+    return [
         <DropdownItem key="Username" isDisabled>
             <dl className='ins-c-dropdown-item__stack'>
                 <dt className="ins-c-dropdown-item__stack--header">Username:</dt>
@@ -29,6 +29,14 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
             }
         </React.Fragment>,
         <DropdownSeparator key="separator" />,
+        ...isOrgAdmin ? [
+            <DropdownItem
+                key="User management"
+                href={`https://www.${window.insights.chrome.isProd ? '' : 'qa.' }redhat.com/wapps/ugc/protected/usermgt/userList.html`}
+                target="_blank" rel='noopener noreferrer'>
+                    User management
+            </DropdownItem>
+        ] : [],
         <DropdownItem
             key="My Profile"
             href={`https://access.${window.insights.chrome.isProd ? '' : 'qa.'}redhat.com/user`}
@@ -55,7 +63,6 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
         </DropdownItem>);
     }
 
-    return dropdownItems;
 }
 
 export class UserToggle extends Component {

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
-    const dropdownItems= [
+    const dropdownItems = [
         <DropdownItem key="Username" isDisabled>
             <dl className='ins-c-dropdown-item__stack'>
                 <dt className="ins-c-dropdown-item__stack--header">Username:</dt>
@@ -46,13 +46,13 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
     ];
 
     // Dropdown cannot focus when a <DropdownItem> is wrapped in a Fragment, so we're going to just splice it into place instead.
-    if(isOrgAdmin) {
+    if (isOrgAdmin) {
         dropdownItems.splice(3, 0, <DropdownItem
             key="User management"
             href={`https://www.${window.insights.chrome.isProd ? '' : 'qa.' }redhat.com/wapps/ugc/protected/usermgt/userList.html`}
             target="_blank" rel='noopener noreferrer'>
                 User management
-        </DropdownItem>); 
+        </DropdownItem>);
     }
 
     return dropdownItems;

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
-    return [
+    const dropdownItems= [
         <DropdownItem key="Username" isDisabled>
             <dl className='ins-c-dropdown-item__stack'>
                 <dt className="ins-c-dropdown-item__stack--header">Username:</dt>
@@ -29,19 +29,9 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
             }
         </React.Fragment>,
         <DropdownSeparator key="separator" />,
-        <React.Fragment key="user management wrapper">
-            { isOrgAdmin &&
-                <DropdownItem
-                    key="User management"
-                    href={`https://www.${window.insights.chrome.isProd ? '' : 'qa.' }redhat.com/wapps/ugc/protected/usermgt/userList.html`}
-                    target="_blank" rel='noopener noreferrer'>
-                        User management
-                </DropdownItem>
-            }
-        </React.Fragment>,
         <DropdownItem
             key="My Profile"
-            href={`https://access.${window.insights.chrome.isProd ? '' : 'qa.'}redhat.com/user`}
+            href="https://access.redhat.com/user"
             target="_blank"
             rel='noopener noreferrer'>
                 My profile
@@ -54,6 +44,18 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
         </DropdownItem>,
         [...extraItems]
     ];
+
+    // Dropdown cannot focus when a <DropdownItem> is wrapped in a Fragment, so we're going to just splice it into place instead.
+    if(isOrgAdmin) {
+        dropdownItems.splice(3, 0, <DropdownItem
+            key="User management"
+            href={`https://www.${window.insights.chrome.isProd ? '' : 'qa.' }redhat.com/wapps/ugc/protected/usermgt/userList.html`}
+            target="_blank" rel='noopener noreferrer'>
+                User management
+        </DropdownItem>); 
+    }
+
+    return dropdownItems;
 }
 
 export class UserToggle extends Component {

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -31,7 +31,7 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
         <DropdownSeparator key="separator" />,
         <DropdownItem
             key="My Profile"
-            href="https://access.redhat.com/user"
+            href={`https://access.${window.insights.chrome.isProd ? '' : 'qa.'}redhat.com/user`}
             target="_blank"
             rel='noopener noreferrer'>
                 My profile

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -52,17 +52,6 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, extraItems) {
         </DropdownItem>,
         [...extraItems]
     ];
-
-    // Dropdown cannot focus when a <DropdownItem> is wrapped in a Fragment, so we're going to just splice it into place instead.
-    if (isOrgAdmin) {
-        dropdownItems.splice(3, 0, <DropdownItem
-            key="User management"
-            href={`https://www.${window.insights.chrome.isProd ? '' : 'qa.' }redhat.com/wapps/ugc/protected/usermgt/userList.html`}
-            target="_blank" rel='noopener noreferrer'>
-                User management
-        </DropdownItem>);
-    }
-
 }
 
 export class UserToggle extends Component {


### PR DESCRIPTION
There was a bug filed that `User management` could not be focused in the masthead dropdown. Patternfly's dropdown doesn't allow focusing elements that are wrapped in a `Fragment`. This should just splice that array and insert the `User management` one where it needs to be. Added a comment to explain the reasoning in the code too.