### PR TITLE
Rewrite header and landing-header.pug

### DIFF
--- a/src/pug/header.pug
+++ b/src/pug/header.pug
@@ -21,3 +21,4 @@ header.pf-c-page__header(role='banner')
                         span.pf-c-dropdown__toggle-text Logging in...
                         img.pf-c-dropdown__toggle-icon(src='apps/chrome/assets/images/overflow-actions-lg.svg')
         img.pf-c-avatar(src='apps/chrome/assets/images/img_avatar.svg' alt='Avatar Image')
+        

--- a/src/pug/header.pug
+++ b/src/pug/header.pug
@@ -2,22 +2,22 @@ header.pf-c-page__header(role='banner')
     .pf-c-page__header-brand.ins-c-page__header-brand--loading
         .pf-c-page__header-brand-toggle
             button.pf-c-button.pf-m-plain(aria-label='Toggle primary navigation' widget-type='InsightsNavToggle' type='button')
-                img(src="apps/chrome/assets/images/primary-nav-hamburger-toggle.svg")
+                img(src='apps/chrome/assets/images/primary-nav-hamburger-toggle.svg')
         a.pf-c-page__header-brand-link(href='#')
-            img.pf-c-brand(src="apps/chrome/assets/images/logo.svg" alt='cloud.redhat.com logo')
+            img.pf-c-brand(src='apps/chrome/assets/images/logo.svg' alt='cloud.redhat.com logo')
     .pf-c-page__header-tools(widget-type='InsightsToolbar')
         .pf-c-page__header-tools-group.pf-m-icons
             //- button.pf-c-button.pf-m-plain(aria-label='Settings' widget-type='SettingsButton' type='button')
-            //-     img(src="apps/chrome/assets/images/settings-button.svg")
+            //-     img(src='apps/chrome/assets/images/settings-button.svg')
             button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
-                img(src="apps/chrome/assets/images/faq-button.svg")
+                img(src='apps/chrome/assets/images/faq-button.svg')
         .pf-c-page__header-tools-group
             .pf-c-dropdown.pf-u-hidden-on-lg(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                 button.pf-c-dropdown__toggle.pf-m-plain(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
-                    img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
+                    img(src='apps/chrome/assets/images/overflow-actions-sm.svg')
             .pf-m-user
                 .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                     .pf-c-dropdown__toggle.pf-m-plain(aria-expanded='false')
                         span.pf-c-dropdown__toggle-text Logging in...
-                        img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
-        img.pf-c-avatar(src="apps/chrome/assets/images/img_avatar.svg" alt="Avatar Image")
+                        img.pf-c-dropdown__toggle-icon(src='apps/chrome/assets/images/overflow-actions-lg.svg')
+        img.pf-c-avatar(src='apps/chrome/assets/images/img_avatar.svg' alt='Avatar Image')

--- a/src/pug/header.pug
+++ b/src/pug/header.pug
@@ -1,27 +1,23 @@
-header.pf-c-page__header.pf-l-page__header(role="banner")
-    .pf-c-page__header-brand.pf-l-page__header-brand.ins-c-page__header-brand--loading
+header.pf-c-page__header(role='banner')
+    .pf-c-page__header-brand.ins-c-page__header-brand--loading
         .pf-c-page__header-brand-toggle
             button.pf-c-button.pf-m-plain(aria-label='Toggle primary navigation' widget-type='InsightsNavToggle' type='button')
                 img(src="apps/chrome/assets/images/primary-nav-hamburger-toggle.svg")
-        a.pf-c-page__header-brand-link.pf-l-page__header-brand-link(href='#')
-            img(src="apps/chrome/assets/images/logo.svg")
-    .pf-c-page__header-tools.pf-l-page__header-tools(widget-type='InsightsToolbar')
-        .pf-l-toolbar.ins-c-header-toolbar__loading
-            .pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
-                //- .pf-l-toolbar__item(data-key='0')
-                //-     button.pf-c-button.pf-m-plain(aria-label='Settings' widget-type='SettingsButton' type='button')
-                //-         img(src="apps/chrome/assets/images/settings-button.svg")
-                .pf-l-toolbar__item(data-key='1')
-                    button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
-                        img(src="apps/chrome/assets/images/faq-button.svg")
-            .pf-l-toolbar__group
-                .pf-l-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
-                    .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
-                        button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-1(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
-                            img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
-                .pf-l-toolbar__item.pf-u-screen-reader.pf-u-visible-on-lg
-                    .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
-                        button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-1(type='button' aria-expanded='false' aria-haspopup='true')
-                            span.pf-c-dropdown__toggle-text Logging in...
-                            img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
+        a.pf-c-page__header-brand-link(href='#')
+            img.pf-c-brand(src="apps/chrome/assets/images/logo.svg" alt='cloud.redhat.com logo')
+    .pf-c-page__header-tools(widget-type='InsightsToolbar')
+        .pf-c-page__header-tools-group.pf-m-icons
+            //- button.pf-c-button.pf-m-plain(aria-label='Settings' widget-type='SettingsButton' type='button')
+            //-     img(src="apps/chrome/assets/images/settings-button.svg")
+            button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
+                img(src="apps/chrome/assets/images/faq-button.svg")
+        .pf-c-page__header-tools-group
+            .pf-c-dropdown.pf-u-hidden-on-lg(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
+                button.pf-c-dropdown__toggle.pf-m-plain(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
+                    img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
+            .pf-m-user
+                .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
+                    .pf-c-dropdown__toggle.pf-m-plain(aria-expanded='false')
+                        span.pf-c-dropdown__toggle-text Logging in...
+                        img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
         img.pf-c-avatar(src="apps/chrome/assets/images/img_avatar.svg" alt="Avatar Image")

--- a/src/pug/header.pug
+++ b/src/pug/header.pug
@@ -21,4 +21,3 @@ header.pf-c-page__header(role='banner')
                         span.pf-c-dropdown__toggle-text Logging in...
                         img.pf-c-dropdown__toggle-icon(src='apps/chrome/assets/images/overflow-actions-lg.svg')
         img.pf-c-avatar(src='apps/chrome/assets/images/img_avatar.svg' alt='Avatar Image')
-        

--- a/src/pug/landing-header.pug
+++ b/src/pug/landing-header.pug
@@ -18,4 +18,3 @@ header.pf-c-page__header(role='banner')
                         span.pf-c-dropdown__toggle-text Logging in...
                         img.pf-c-dropdown__toggle-icon(src='apps/chrome/assets/images/overflow-actions-lg.svg')
         img.pf-c-avatar(src='apps/chrome/assets/images/img_avatar.svg' alt='Avatar Image')
-        

--- a/src/pug/landing-header.pug
+++ b/src/pug/landing-header.pug
@@ -1,20 +1,20 @@
 header.pf-c-page__header(role='banner')
     .pf-c-page__header-brand.ins-c-page__header-brand--loading
         a.pf-c-page__header-brand-link(href='#')
-            img.pf-c-brand(src="apps/chrome/assets/images/logo.svg" alt='cloud.redhat.com logo')
+            img.pf-c-brand(src='apps/chrome/assets/images/logo.svg' alt='cloud.redhat.com logo')
     .pf-c-page__header-tools(widget-type='InsightsToolbar')
         .pf-c-page__header-tools-group.pf-m-icons
             //- button.pf-c-button.pf-m-plain(aria-label='Settings' widget-type='SettingsButton' type='button')
-            //-     img(src="apps/chrome/assets/images/settings-button.svg")
+            //-     img(src='apps/chrome/assets/images/settings-button.svg')
             button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
-                img(src="apps/chrome/assets/images/faq-button.svg")
+                img(src='apps/chrome/assets/images/faq-button.svg')
         .pf-c-page__header-tools-group
             .pf-c-dropdown.pf-u-hidden-on-lg(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                 button.pf-c-dropdown__toggle.pf-m-plain(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
-                    img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
+                    img(src='apps/chrome/assets/images/overflow-actions-sm.svg')
             .pf-m-user
                 .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
                     .pf-c-dropdown__toggle.pf-m-plain(aria-expanded='false')
                         span.pf-c-dropdown__toggle-text Logging in...
-                        img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
-        img.pf-c-avatar(src="apps/chrome/assets/images/img_avatar.svg" alt="Avatar Image")
+                        img.pf-c-dropdown__toggle-icon(src='apps/chrome/assets/images/overflow-actions-lg.svg')
+        img.pf-c-avatar(src='apps/chrome/assets/images/img_avatar.svg' alt='Avatar Image')

--- a/src/pug/landing-header.pug
+++ b/src/pug/landing-header.pug
@@ -18,3 +18,4 @@ header.pf-c-page__header(role='banner')
                         span.pf-c-dropdown__toggle-text Logging in...
                         img.pf-c-dropdown__toggle-icon(src='apps/chrome/assets/images/overflow-actions-lg.svg')
         img.pf-c-avatar(src='apps/chrome/assets/images/img_avatar.svg' alt='Avatar Image')
+        

--- a/src/pug/landing-header.pug
+++ b/src/pug/landing-header.pug
@@ -1,27 +1,20 @@
-header.pf-c-page__header.pf-l-page__header(role="banner")
-    .pf-c-page__header-brand.pf-l-page__header-brand
-        .pf-c-page__header-brand-toggle(hidden)
-            button.pf-c-button.pf-m-plain(type='button')
-                img(src="apps/chrome/assets/images/primary-nav-hamburger-toggle.svg")
-        a.pf-c-page__header-brand-link.pf-l-page__header-brand-link(href='#')
-            img(src="apps/chrome/assets/images/logo.svg")
-    .pf-c-page__header-tools.pf-l-page__header-tools(widget-type='InsightsToolbar')
-        .pf-l-toolbar
-            .pf-l-toolbar__group.pf-u-screen-reader.pf-u-visible-on-lg
-                //- .pf-l-toolbar__item(data-key='0')
-                //-     button.pf-c-button.pf-m-plain(aria-label='Settings' widget-type='SettingsButton' type='button')
-                //-         img(src="apps/chrome/assets/images/settings-button.svg")
-                .pf-l-toolbar__item(data-key='1')
-                    button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
-                        img(src="apps/chrome/assets/images/faq-button.svg")
-            .pf-l-toolbar__group
-                .pf-l-toolbar__item.pf-u-hidden-on-lg.pf-u-mr-0
-                    .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
-                        button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-1(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
-                            img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
-                .pf-l-toolbar__item.pf-u-screen-reader.pf-u-visible-on-lg
-                    .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
-                        button.pf-c-dropdown__toggle.pf-m-plain#pf-toggle-id-2(type='button' aria-expanded='false' aria-haspopup='true')
-                            span.pf-c-dropdown__toggle-text Logging in...
-                            img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
+header.pf-c-page__header(role='banner')
+    .pf-c-page__header-brand.ins-c-page__header-brand--loading
+        a.pf-c-page__header-brand-link(href='#')
+            img.pf-c-brand(src="apps/chrome/assets/images/logo.svg" alt='cloud.redhat.com logo')
+    .pf-c-page__header-tools(widget-type='InsightsToolbar')
+        .pf-c-page__header-tools-group.pf-m-icons
+            //- button.pf-c-button.pf-m-plain(aria-label='Settings' widget-type='SettingsButton' type='button')
+            //-     img(src="apps/chrome/assets/images/settings-button.svg")
+            button.pf-c-button.pf-m-plain(aria-label='Overflow FAQ' widget-type='InsightsFAQ' type='button')
+                img(src="apps/chrome/assets/images/faq-button.svg")
+        .pf-c-page__header-tools-group
+            .pf-c-dropdown.pf-u-hidden-on-lg(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
+                button.pf-c-dropdown__toggle.pf-m-plain(aria-label='Actions' type='button' aria-expanded='false' aria-haspopup='true')
+                    img(src="apps/chrome/assets/images/overflow-actions-sm.svg")
+            .pf-m-user
+                .pf-c-dropdown(aria-label='Overflow actions' widget-type='InsightsOverflowActions')
+                    .pf-c-dropdown__toggle.pf-m-plain(aria-expanded='false')
+                        span.pf-c-dropdown__toggle-text Logging in...
+                        img.pf-c-dropdown__toggle-icon(src="apps/chrome/assets/images/overflow-actions-lg.svg")
         img.pf-c-avatar(src="apps/chrome/assets/images/img_avatar.svg" alt="Avatar Image")

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -37,8 +37,6 @@ aside {
     overflow: auto !important;
 }
 
-.ins-c-header-toolbar__loading { padding: 0; }
-
 .pf-c-about-modal-box__logo {
     display: none;
 }


### PR DESCRIPTION
Turns out we were using a deprecated component in the pug files which is why sometimes you'd get the stacking of the icons above the `logging in...` text.

I tested this locally both using header and landing-header, but please test with an app & the landing page, respectively.