### PR TITLE
Add link to RHCP case management in OCM

### DIFF
--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -8,9 +8,9 @@ import NavigationItem from './NavigationItem';
 const basepath = document.baseURI;
 
 const openshiftLinks = {
-    operatorhub: {
-        title: 'OperatorHub.io',
-        link: 'https://operatorhub.io/'
+    supportcases: {
+        title: 'Support Cases',
+        link: 'https://access.redhat.com/support/cases'
     },
     feedback: {
         title: 'Cluster Manager Feedback',

--- a/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
@@ -393,12 +393,12 @@ exports[`Navigation should render corectly 1`] = `
       Documentation
     </NavItem>
     <NavItem
-      key="operatorhub"
+      key="supportcases"
       rel="noopener noreferrer"
       target="_blank"
-      to="https://operatorhub.io/"
+      to="https://access.redhat.com/support/cases"
     >
-      OperatorHub.io
+      Support Cases
     </NavItem>
     <NavItem
       key="feedback"
@@ -501,12 +501,12 @@ exports[`Navigation should render correctly 2 1`] = `
       Documentation
     </NavItem>
     <NavItem
-      key="operatorhub"
+      key="supportcases"
       rel="noopener noreferrer"
       target="_blank"
-      to="https://operatorhub.io/"
+      to="https://access.redhat.com/support/cases"
     >
-      OperatorHub.io
+      Support Cases
     </NavItem>
     <NavItem
       key="feedback"


### PR DESCRIPTION
We want to remove the "OperatorHub.io" link and replace it with "Support Cases".

new title: Support Cases
new link: https://access.redhat.com/support/cases