### PR TITLE
only init noAccess on pages with getUser

### DIFF
--- a/src/js/chrome.js
+++ b/src/js/chrome.js
@@ -17,6 +17,7 @@ libjwt.initPromise.then(() => {
     libjwt.jwt.getUserInfo().then((...data) => {
         analytics(...data);
         sentry(...data);
+        noAccess();
     }).catch(noop);
 });
 
@@ -33,5 +34,3 @@ window.insights = {
     ...window.insights,
     ...bootstrap(libjwt, init)
 };
-
-noAccess();

--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -15,6 +15,7 @@ import RootApp from './App/RootApp';
 import debugFunctions from './debugFunctions';
 import NoAccess from './App/NoAccess';
 
+const log = require('./jwt/logger')('entry.js');
 const sourceOfTruth = require('./nav/sourceOfTruth');
 
 // used for translating event names exposed publicly to internal event names
@@ -238,5 +239,5 @@ export function noAccess() {
             );
         }
     })
-    .catch(window.console.log('Error fetching user entitlements!'));
+    .catch(log('Error fetching user entitlements!'));
 }


### PR DESCRIPTION
Right now, errors are thrown on `404, Logout, and '/'` (which are pages where a user object isn't required). This moves the init inside of the `getUser` so that this doesn't happen.