### PR TITLE
Fetch all permissions for all apps, not only for * (#653)

### DIFF
--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -122,8 +122,8 @@ export function bootstrap(libjwt, initFunc) {
             isBeta: () => {
                 return (window.location.pathname.split('/')[1] === 'beta' ? true : false);
             },
-            getUserPermissions: () => {
-                return fetchPermissions(libjwt.jwt.getEncodedToken());
+            getUserPermissions: (app = '') => {
+                return fetchPermissions(libjwt.jwt.getEncodedToken(), app);
             },
             init: initFunc
         },

--- a/src/js/rbac/fetchPermissions.js
+++ b/src/js/rbac/fetchPermissions.js
@@ -3,13 +3,13 @@ const log = require('../jwt/logger')('fetchPermissions.js');
 
 const perPage = 25;
 
-export const fetchPermissions = (userToken) => {
+export const fetchPermissions = (userToken, app = '') => {
     const rbacApi = createRbacAPI(userToken);
-    return rbacApi.getPrincipalAccess('*', undefined, perPage).then(({ data, meta }) => {
+    return rbacApi.getPrincipalAccess(app, undefined, perPage).then(({ data, meta }) => {
         if (meta.count > perPage) {
             return Promise.all(
                 [...new Array(Math.ceil(meta.count / perPage))]
-                .map((_empty, key) => rbacApi.getPrincipalAccess('*', undefined, perPage, (key + 1) * perPage)
+                .map((_empty, key) => rbacApi.getPrincipalAccess(app, undefined, perPage, (key + 1) * perPage)
                 .then(({ data }) => data))
             ).then(allAccess => allAccess.reduce((acc, curr) => ([...acc, ...curr]), data))
             .catch(error => log(error));

--- a/src/js/rbac/fetchPermissions.test.js
+++ b/src/js/rbac/fetchPermissions.test.js
@@ -3,13 +3,13 @@ import { mock } from '../../__mocks__/rbacApi';
 import mockedRbac from '../../../testdata/rbacAccess.json';
 
 it('should send all the paginated data as array', async () => {
-    mock.onGet('/api/rbac/v1/access/?application=*&limit=25').reply(200, mockedRbac);
+    mock.onGet('/api/rbac/v1/access/?application=&limit=25').reply(200, mockedRbac);
     const data = fetchPermissions('uSeRtOkEn');
     data.then(permissions => expect(permissions).toEqual(mockedRbac.data));
 });
 
 it('should send the data as array', async () => {
-    mock.onGet('/api/rbac/v1/access/?application=*&limit=50').reply(200, mockedRbac);
+    mock.onGet('/api/rbac/v1/access/?application=&limit=50').reply(200, mockedRbac);
     const data = fetchPermissions('uSeRtOkEn');
     data.then(permissions => expect(permissions).toEqual(mockedRbac.data));
 });


### PR DESCRIPTION
This unblocks permission check for remediations