### PR TITLE
Fix typo when removing old cache from localStorage

### DIFF
--- a/src/js/jwt/jwt.js
+++ b/src/js/jwt/jwt.js
@@ -212,7 +212,9 @@ function logout(bounce) {
 
     const isBeta = (window.location.pathname.split('/')[1] === 'beta' ? '/beta' : '');
     const keys = Object.keys(localStorage).filter(key => (
-        key.endsWith('/api/entitlements/v1/services' || key.endsWith('/config/main.yml')) || key.startsWith('kc-callback')
+        key.endsWith('/api/entitlements/v1/services') ||
+        key.endsWith('/config/main.yml') ||
+        key.startsWith('kc-callback')
     ));
     deleteLocalStorageItems(keys);
     // Redirect to logout

--- a/src/js/nav/sourceOfTruth.js
+++ b/src/js/nav/sourceOfTruth.js
@@ -11,7 +11,6 @@ module.exports = (cachePrefix) => {
         if (response && response.request && response.request.fromCache !== true) {
             const last = lastActive('/config/main.yml', 'fallback');
             const keys = Object.keys(localStorage).filter(key => key.endsWith('config/main.yml') && key !== last);
-            localStorage.setItem('test', keys.length);
             deleteLocalStorageItems(keys);
         }
 


### PR DESCRIPTION
There was missing bracket and one extra bracket when filtering localStorage keys.