### PR TITLE
update scss to load styles

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -4,18 +4,10 @@ $pf-global--image-path: './assets/images/';
 @import 'node_modules/@patternfly/patternfly/patternfly-base.scss';
 
 // Components
-@import 'node_modules/@patternfly/patternfly/components/Toolbar/toolbar.scss';
-@import 'node_modules/@patternfly/patternfly/components/Page/page.scss';
-@import 'node_modules/@patternfly/patternfly/components/BackgroundImage/background-image.scss';
-@import 'node_modules/@patternfly/patternfly/components/Nav/nav.scss';
-@import 'node_modules/@patternfly/patternfly/components/Button/button.scss';
-@import 'node_modules/@patternfly/patternfly/components/Dropdown/dropdown.scss';
-@import 'node_modules/@patternfly/patternfly/components/Avatar/avatar.scss';
-@import 'node_modules/@patternfly/patternfly/components/Title/title.scss';
+@import 'node_modules/@patternfly/patternfly/components/_all.scss';
 
 // Layouts
-@import 'node_modules/@patternfly/patternfly/layouts/Split/split.scss';
-@import 'node_modules/@patternfly/patternfly/layouts/Flex/flex.scss';
+@import 'node_modules/@patternfly/patternfly/layouts/_all.scss';
 
 @import 'node_modules/@redhat-cloud-services/frontend-components/components/Spinner';
 @import 'node_modules/@redhat-cloud-services/frontend-components/components/Skeleton';

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -16,7 +16,6 @@ $pf-global--image-path: './assets/images/';
 @import 'node_modules/@patternfly/patternfly/components/ModalBox/modal-box.scss';
 @import 'node_modules/@patternfly/patternfly/components/Backdrop/backdrop.scss';
 @import 'node_modules/@patternfly/patternfly/components/Switch/switch.scss';
-@import 'node_modules/@patternfly/patternfly/components/BackgroundImage/background-image.scss';
 
 // Layouts
 @import 'node_modules/@patternfly/patternfly/layouts/Split/split.scss';

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -3,12 +3,26 @@ $pf-global--image-path: './assets/images/';
 
 @import 'node_modules/@patternfly/patternfly/patternfly-base.scss';
 
-// We need to import component styles and layouts because these could be reset by apps and we don't want that
 // Components
-@import 'node_modules/@patternfly/patternfly/components/_all.scss';
+@import 'node_modules/@patternfly/patternfly/components/Toolbar/toolbar.scss';
+@import 'node_modules/@patternfly/patternfly/components/Page/page.scss';
+@import 'node_modules/@patternfly/patternfly/components/BackgroundImage/background-image.scss';
+@import 'node_modules/@patternfly/patternfly/components/Nav/nav.scss';
+@import 'node_modules/@patternfly/patternfly/components/Button/button.scss';
+@import 'node_modules/@patternfly/patternfly/components/Dropdown/dropdown.scss';
+@import 'node_modules/@patternfly/patternfly/components/Avatar/avatar.scss';
+@import 'node_modules/@patternfly/patternfly/components/Title/title.scss';
+@import 'node_modules/@patternfly/patternfly/components/AboutModalBox/about-modal-box.scss';
+@import 'node_modules/@patternfly/patternfly/components/ModalBox/modal-box.scss';
+@import 'node_modules/@patternfly/patternfly/components/Backdrop/backdrop.scss';
+@import 'node_modules/@patternfly/patternfly/components/Switch/switch.scss';
+@import 'node_modules/@patternfly/patternfly/components/BackgroundImage/background-image.scss';
+
 
 // Layouts
-@import 'node_modules/@patternfly/patternfly/layouts/_all.scss';
+@import 'node_modules/@patternfly/patternfly/layouts/Split/split.scss';
+@import 'node_modules/@patternfly/patternfly/layouts/Flex/flex.scss';
+@import 'node_modules/@patternfly/patternfly/layouts/Bullseye/bullseye.scss';
 
 @import 'node_modules/@redhat-cloud-services/frontend-components/components/Spinner';
 @import 'node_modules/@redhat-cloud-services/frontend-components/components/Skeleton';

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -3,6 +3,7 @@ $pf-global--image-path: './assets/images/';
 
 @import 'node_modules/@patternfly/patternfly/patternfly-base.scss';
 
+// We need to import component styles and layouts because these could be reset by apps and we don't want that
 // Components
 @import 'node_modules/@patternfly/patternfly/components/_all.scss';
 

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -18,7 +18,6 @@ $pf-global--image-path: './assets/images/';
 @import 'node_modules/@patternfly/patternfly/components/Switch/switch.scss';
 @import 'node_modules/@patternfly/patternfly/components/BackgroundImage/background-image.scss';
 
-
 // Layouts
 @import 'node_modules/@patternfly/patternfly/layouts/Split/split.scss';
 @import 'node_modules/@patternfly/patternfly/layouts/Flex/flex.scss';


### PR DESCRIPTION
So here's what happened:

In some cases, chrome was not loading styles correctly. Depending on how apps would handle importing, the styles would be reset on load, and therefore making styles not load entirely for some components in chrome.

This mainly affected modals, and some hot loaded components. 

This was also the reason we had been importing select components inside of chrome.scss

Updating this to include the components and layouts seems to fix this issue. We could do these one by one, but at this point we're already including a ton of files.

This also fixes the modals not working in some places.

We should blast an email and message once we verify this is working to apps to double check their styles because this could be a breaking change.