### PR TITLE
remove font awesome dependency

### DIFF
--- a/src/pug/sidebar-new.pug
+++ b/src/pug/sidebar-new.pug
@@ -3,7 +3,7 @@ aside.pf-c-page__sidebar.pf-l-page__sidebar#ins-c-sidebar.ins-c-sidebar--loading
     .pf-l-split.ins-c-navigation__header
         .pf-l-split__item.ins-c-page__home-icon
             a
-                i.fas.fa-home.fa-lg
+                img(src='apps/frontend-assets/platform-icons/home.svg' type='image/svg+xml' alt='home icon').ins-c-loading-icon__home
         .pf-l-split__item.pf-m-main.pf-u-display-flex.pf-u-align-items-center.ins-c-navigation__header-name--loading.ins-c-navigation__header-title__wrapper
             .ins-c-skeleton.ins-c-skeleton__lg.ins-m-dark &nbsp;
     nav.pf-c-nav(aria-label='Insights Global Navigation', data-ouia-safe='false')

--- a/src/pug/templates/head-block.pug
+++ b/src/pug/templates/head-block.pug
@@ -2,7 +2,6 @@ meta(http-equiv="x-ua-compatible" content="ie=edge")
 meta(name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no")
 base(href=`${ release === 'insights' ? '/' : '/beta/'}`)
 link(rel="icon"  type="image/png" href="https://access.redhat.com/webassets/avalon/g/favicon.ico")
-link(rel='stylesheet', href='https://use.fontawesome.com/releases/v5.0.10/css/all.css', integrity='sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg', crossorigin='anonymous')
 link(rel='stylesheet', href=`./apps/chrome/${ chrome }`)
 //- Add sentry here so other apps can use it
 script(src="https://browser.sentry-cdn.com/5.3.0/bundle.min.js", crossorigin="anonymous")

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -152,6 +152,13 @@ aside {
     .pf-c-button.pf-m-plain { top: 2px; }
 }
 
+.ins-c-loading-icon__home {
+    // This height and width are not PF variables. This will take an adjustment to the SVG itself
+    height: 34px;
+    width: 34px;
+    vertical-align: -0.1875em;
+}
+
 .ins-c-navigation__header-name--loading { width: 100%; }
 
 // abstract this


### PR DESCRIPTION
We imported the entire font awesome dependency just for the home icon in the pug files. This should kill that dependency and then use the *new* assets library to use that icon. Woo!