### PR TITLE
add styles to show pen testing

### DIFF
--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -15,6 +15,7 @@ import RootApp from './App/RootApp';
 import debugFunctions from './debugFunctions';
 import NoAccess from './App/NoAccess';
 import { visibilityFunctions } from './consts';
+import Cookies from 'js-cookie';
 
 const log = require('./jwt/logger')('entry.js');
 const sourceOfTruth = require('./nav/sourceOfTruth');
@@ -130,6 +131,9 @@ export function bootstrap(libjwt, initFunc) {
             getUserPermissions: (app = '') => {
                 return fetchPermissions(libjwt.jwt.getEncodedToken(), app);
             },
+            isPenTest: () => {
+                return Cookies.get('x-rh-insights-pentest') ? true : false;
+            },
             visibilityFunctions,
             init: initFunc
         },
@@ -179,12 +183,17 @@ function loadChrome(user) {
 
             store.dispatch(appNavClick(defaultActive));
 
+            const penTestClasses = window.insights.chrome.isPenTest() ? 'ins-c-pen-test' : '';
+
             render(
                 <Provider store={store}>
                     { user ? <Header /> : <UnauthedHeader /> }
                 </Provider>,
                 document.querySelector('header')
             );
+
+            // Conditionally add classes if it's the pen testing environment
+            document.querySelector('header').classList.add(penTestClasses);
 
             if (document.querySelector('aside')) {
                 render(

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -167,5 +167,5 @@ aside {
 
 // Pen testing
 .ins-c-pen-test {
-    border-top: 3px solid #F0F
+    border-top: 3px solid #A18FFF;
 }

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -164,3 +164,8 @@ aside {
         margin-right: var(--pf-global--spacer--md);
     }
 }
+
+// Pen testing
+.ins-c-pen-test {
+    border-top: 3px solid #F0F
+}


### PR DESCRIPTION
![Screen Shot 2020-04-27 at 4 41 22 PM](https://user-images.githubusercontent.com/12520842/80418810-f7682380-88a5-11ea-9b14-12c08b64d825.png)

Adds a border-top when the pen testing environment is active