### PR TITLE
Fix highlight of duplicate sub-nav items

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following events can be observed:
 * `APP_NAVIGATION` - fired when the application navigation option is selected. `event.navId` can be used to access the id of the navigation option
 * `NAVIGATION_TOGGLE` - fired when user clicks on burger to hide navigation. No data are given.
 
-To activate certain app within your app (your app is using some kind of router and you want to activate certain part of navigation programatically) you can call function `insights.chrome.appNavClick({id: 'some-id'})` for first level nav and for second level navs you have to call `insights.chrome.appNavClick({id: 'ocp-on-aws', secondaryNav: true})`
+To activate certain app within your app (your app is using some kind of router and you want to activate certain part of navigation programatically) you can call function `insights.chrome.appNavClick({id: 'some-id'})` for first level nav and for second level navs you have to call `insights.chrome.appNavClick({id: 'ocp-on-aws', parentId: 'some-parent', secondaryNav: true})`
 
 You can also use Chrome to update a page action and object ID for OUIA. You can use `insights.chrome.appAction('action')` to activate a certain action, and `insights.chrome.appObjectId('object-id')` to activate a certain ID. For instance, if you want to open the "edit name" dialog for an entity with id=5, you should call `insights.chrome.appAction('edit-name')` and then `insights.chrome.appObjectId(5)`. Once the user is done editing, you have to call `insights.chrome.appAction()` and `insights.chrome.appObjectId()` in order to indicate that the action is done.
 

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -54,7 +54,9 @@ export function appNavClick(state, { payload }) {
         globalNav: payload.custom ? state.globalNav && state.globalNav.map(item => ({
             ...item,
             active: payload && (item.id === payload.id || item.title === payload.id)
-                || (item.subItems && item.subItems.some(({ id }) => id === payload.id) && item.id === state.appId)
+                || (item.subItems && item.subItems.some(
+                    ({ id }) => id === payload.id) && (item.id === state.appId || item.id === payload.parentId)
+                )
         })) : state.globalNav
     };
 }

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -54,7 +54,7 @@ export function appNavClick(state, { payload }) {
         globalNav: payload.custom ? state.globalNav && state.globalNav.map(item => ({
             ...item,
             active: payload && (item.id === payload.id || item.title === payload.id)
-                || (item.subItems && item.subItems.some(({ id }) => id === payload.id))
+                || (item.subItems && item.subItems.some(({ id }) => id === payload.id) && item.id === state.appId)
         })) : state.globalNav
     };
 }


### PR DESCRIPTION
This should fix the issue with multiple highlights when the sub-nav item name is already used by another top-level nav item.

![001](https://user-images.githubusercontent.com/50696716/84242180-bef07200-ab00-11ea-8397-46c3083ca152.png)

Needed for: https://github.com/RedHatInsights/cloud-services-config/pull/218

@karelhala 