### PR TITLE
add styles for focus in masthead

### DIFF
--- a/src/js/App/Header/HeaderTests/__snapshots__/Tools.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/Tools.test.js.snap
@@ -5,6 +5,7 @@ exports[`Tools should render correctly 1`] = `
   widget-type="InsightsToolbar"
 >
   <Component
+    className="ins-c-toolbar__menu-buttons"
     visibility={
       Object {
         "default": "hidden",
@@ -17,6 +18,7 @@ exports[`Tools should render correctly 1`] = `
     </Component>
   </Component>
   <Component
+    className="ins-c-toolbar__menu-dropdown"
     visibility={
       Object {
         "default": "hidden",
@@ -31,6 +33,7 @@ exports[`Tools should render correctly 1`] = `
     </Component>
   </Component>
   <Component
+    className="ins-c-toolbar__menu-buttons"
     visibility={
       Object {
         "sm": "hidden",

--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -15,6 +15,8 @@ import UserIcon from './UserIcon';
 import ToolbarToggle from './ToolbarToggle';
 import InsightsAbout from './InsightsAbout';
 
+import './Tools.scss';
+
 const Tools = () => {
 
     {/* Set the state */}
@@ -82,7 +84,7 @@ const Tools = () => {
         <PageHeaderTools widget-type="InsightsToolbar">
 
             {/* Show tools on medium and above screens */}
-            <PageHeaderToolsGroup visibility={{ default: 'hidden', sm: 'visible' }}>
+            <PageHeaderToolsGroup className='ins-c-toolbar__menu-buttons' visibility={{ default: 'hidden', sm: 'visible' }}>
                 { !isSettingsDisabled &&
                     <PageHeaderToolsItem>
                         { <SettingsButton/> }
@@ -94,14 +96,14 @@ const Tools = () => {
             </PageHeaderToolsGroup>
 
             {/* Show full user dropdown on medium and above screens */}
-            <PageHeaderToolsGroup visibility={{ default: 'hidden', sm: 'visible' }}>
+            <PageHeaderToolsGroup className='ins-c-toolbar__menu-dropdown' visibility={{ default: 'hidden', sm: 'visible' }}>
                 <PageHeaderToolsItem>
                     <UserToggle className='ins-c-dropdown__user'/>
                 </PageHeaderToolsItem>
             </PageHeaderToolsGroup>
 
             {/* Collapse tools and user dropdown to kebab on small screens  */}
-            <PageHeaderToolsGroup visibility={{ sm: 'hidden' }}>
+            <PageHeaderToolsGroup className='ins-c-toolbar__menu-buttons' visibility={{ sm: 'hidden' }}>
                 <PageHeaderToolsItem>
                     <UserToggle isSmall extraItems={mobileDropdownItems.map((action, key) => (
                         <React.Fragment key={key}>

--- a/src/js/App/Header/Tools.scss
+++ b/src/js/App/Header/Tools.scss
@@ -1,0 +1,29 @@
+@mixin focus-styles {
+    z-index: -1;
+    position: absolute;
+    left: 50%;
+    content: "";
+    background-color: var(--pf-c-page__header-tools--c-button--m-selected--before--BackgroundColor);
+    border-radius: var(--pf-c-page__header-tools--c-button--m-selected--before--BorderRadius);
+    transform: translateX(-50%);
+}
+
+.pf-c-page__header {
+    .ins-c-toolbar__menu-buttons button:focus {
+        &:after {
+            top: 0;
+            width: var(--pf-c-page__header-tools--c-button--m-selected--before--Width);
+            height: var(--pf-c-page__header-tools--c-button--m-selected--before--Height);
+            @include focus-styles();
+        }
+    }
+
+    .ins-c-toolbar__menu-dropdown button:focus {
+        &:after {
+            @include focus-styles();
+            bottom: 0;
+            width: 100%;
+            height: 2px;
+        }
+    }
+}


### PR DESCRIPTION
Adds a focus state to items in the masthead

https://projects.engineering.redhat.com/browse/RHCLOUD-6421

PF does allow us to use a `isSelected` prop for these items, but IMO it's easier to just use the CSS with the native `:focus` selector instead of keeping track of the active item.

<img width="1028" alt="Screen Shot 2020-07-01 at 11 09 42 AM" src="https://user-images.githubusercontent.com/12520842/86262049-635c5600-bb8d-11ea-8568-045977076e75.png">

<img width="1028" alt="Screen Shot 2020-07-01 at 11 14 44 AM" src="https://user-images.githubusercontent.com/12520842/86262043-60f9fc00-bb8d-11ea-8291-908e3ae09626.png">