### PR TITLE
Allow external react and react-redux

### DIFF
--- a/config/react-external.js
+++ b/config/react-external.js
@@ -1,3 +1,3 @@
-const { React } = require('../src/js/externalDependencies');
+const { customReact } = require('../src/js/externalDependencies');
 
-module.exports = React;
+module.exports = customReact;

--- a/config/react-redux-external.js
+++ b/config/react-redux-external.js
@@ -1,0 +1,3 @@
+const { reactRedux } = require('../src/js/externalDependencies');
+
+module.exports = reactRedux;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8362,23 +8362,23 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.1.2.tgz",
-      "integrity": "sha512-F4PnNSGuk6Sdfs7ivxY/b73RkQwWM50IGUHIFDMVQM2IrCkFi24Nt6mBBTk2ZlGV4pvZ0Wr3lVOgPz6b00I4Jg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.3.0.tgz",
+      "integrity": "sha512-+uLghO9L6Aty9URpEieMBypjFAWB5MBXpXn1MQBZaDRcWXeZGJYcoC/XmD1stBCm7nBDgeVn5f2VHH5KAgCAJw==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0"
       }
     },
     "@redhat-cloud-services/frontend-components-inventory": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory/-/frontend-components-inventory-2.1.2.tgz",
-      "integrity": "sha512-jx6EkHf0qP5Yq/rsGhe2+M2Gdnvw4FLZUO5jNTY3qwYjs0LfHM4eL3uKgfzgxDwHHb8SfBpGcvyNiu9cC4jmeQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory/-/frontend-components-inventory-2.2.0.tgz",
+      "integrity": "sha512-xY9bBStgxMf2Z6fbHepxsf8bwn1gDlTP8hKSLniOfF9Stq+/MT6iw5U5OY1kUkmFdPKkRmzVALAtESX6TQm9dA==",
       "requires": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-notifications": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
-        "@redhat-cloud-services/host-inventory-client": "1.0.61",
+        "@redhat-cloud-services/host-inventory-client": "1.0.66",
         "axios": "^0.19.0"
       }
     },
@@ -8439,9 +8439,9 @@
       }
     },
     "@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.61",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.61.tgz",
-      "integrity": "sha512-R2wi0ZJ7ER3aXAalQa8pGXThJuMbb/SZR2tKdDXpOmPNw93dY6n6mezxNfpcbRf610fwt4/QGELFVdmt2D1l7w==",
+      "version": "1.0.66",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.66.tgz",
+      "integrity": "sha512-L1bpLE8Ikm7yMcgGSPNRyicqnQ7HneeTAFRFsa/XCGEGkEBXadA2POoY09g3Q4jbz0mgc2aSKViK3FUEDe079g==",
       "requires": {
         "axios": "^0.19.2"
       }
@@ -28023,16 +28023,14 @@
       }
     },
     "sanitize-html": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.0.tgz",
-      "integrity": "sha512-U1btucGeYVpg0GoK43jPpe/bDCV4cBOGuxzv5NBd0bOjyZdMKY0n98S/vNlO1wVwre0VCj8H3hbzE7gD2+RjKA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.1.tgz",
+      "integrity": "sha512-C+N7E+7ikYaLHdb9lEkQaFOgmj+9ddZ311Ixs/QsBsoLD411/vdLweiFyGqrswUVgLqagOS5NCDxcEPH7trObQ==",
       "requires": {
-        "chalk": "^2.4.1",
         "htmlparser2": "^4.1.0",
         "lodash": "^4.17.15",
         "postcss": "^7.0.27",
-        "srcset": "^2.0.1",
-        "xtend": "^4.0.1"
+        "srcset": "^2.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -28051,6 +28049,16 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "dom-serializer": {
@@ -28109,16 +28117,6 @@
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
             "supports-color": "^6.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "source-map": {
@@ -28127,9 +28125,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -117,8 +117,8 @@
     "@patternfly/react-core": "^4.18.5",
     "@patternfly/react-icons": "^3.15.16",
     "@redhat-cloud-services/entitlements-client": "^1.0.67",
-    "@redhat-cloud-services/frontend-components": "2.1.2",
-    "@redhat-cloud-services/frontend-components-inventory": "2.1.2",
+    "@redhat-cloud-services/frontend-components": "2.3.0",
+    "@redhat-cloud-services/frontend-components-inventory": "2.2.0",
     "@redhat-cloud-services/frontend-components-notifications": "^2.1.0",
     "@redhat-cloud-services/frontend-components-remediations": "2.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "2.1.0",
@@ -155,9 +155,11 @@
     "url-parse": "^1.4.7"
   },
   "alias": {
+    "PFReactTable": "./config/patternfly-table-externals.js",
     "@patternfly/react-table": "./config/patternfly-table-externals.js",
+    "customReact": "./config/react-external.js",
+    "reactRedux": "./config/react-redux-external.js",
     "react-router-dom": "./config/react-router-dom-externals.js",
-    "patternfly-react": "./config/patternfly-react-externals.js",
     "graphql": "./config/graphql-externals.js"
   },
   "insights": {

--- a/src/js/externalDependencies.js
+++ b/src/js/externalDependencies.js
@@ -1,9 +1,13 @@
 export let ReactRouterDOM;
 export let PFReact;
 export let PFReactTable;
+export let customReact;
+export let reactRedux;
 
-export default function setDependencies({ reactRouterDom, pfReact, pfReactTable }) {
+export default function setDependencies({ reactRouterDom, pfReact, pfReactTable, React, react, ReactRedux }) {
     ReactRouterDOM = reactRouterDom || ReactRouterDOM;
     PFReact = pfReact || PFReact;
     PFReactTable = pfReactTable || PFReactTable || {};
+    customReact = React || react || customReact;
+    reactRedux = ReactRedux || reactRedux;
 }


### PR DESCRIPTION
This PR should not break how is inventory loaded and such. However it has to be merged before https://github.com/RedHatInsights/frontend-components/pull/538 in order to properly load react and react-redux.