### PR TITLE
Change buttons in headers to links

### DIFF
--- a/src/js/App/Header/HeaderTests/__snapshots__/Tools.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/Tools.test.js.snap
@@ -48,8 +48,10 @@ exports[`Tools should render correctly 1`] = `
             </React.Fragment>,
             <React.Fragment>
               <Unknown
-                component="button"
-                onClick={[Function]}
+                component="a"
+                href="http://localhost/settings/rbac/"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Settings
               </Unknown>
@@ -61,22 +63,30 @@ exports[`Tools should render correctly 1`] = `
             </React.Fragment>,
             <React.Fragment>
               <Unknown
-                component="button"
+                component="a"
+                href="https://access.redhat.com/support"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Customer support
               </Unknown>
             </React.Fragment>,
             <React.Fragment>
               <Unknown
-                component="button"
+                component="a"
+                href="https://www.redhat.com/en/services/training-and-certification"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Training
               </Unknown>
             </React.Fragment>,
             <React.Fragment>
               <Unknown
-                component="button"
-                onClick={[Function]}
+                component="a"
+                href="http://localhost/docs/api"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 API documentation
               </Unknown>

--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -28,11 +28,14 @@ const Tools = () => {
 
     {/* button that should redirect a user to RBAC with an account */}
     const SettingsButton = () => (
-        <Button variant="plain"
+        <Button
+            variant="plain"
             aria-label="Go to settings"
             widget-type='SettingsButton'
             className='ins-c-toolbar__button-settings'
-            onClick={() => window.location.href = `${document.baseURI}settings/rbac/`}>
+            href={`${document.baseURI}settings/rbac/`}
+            component="a"
+        >
             <CogIcon/>
         </Button>
     );
@@ -47,7 +50,7 @@ const Tools = () => {
             url: 'https://www.redhat.com/en/services/training-and-certification'
         }, {
             title: 'API documentation',
-            onClick: () => window.location.href = `${document.baseURI}docs/api`
+            url: `${document.baseURI}docs/api`
         }, {
             title: 'About',
             onClick: () => setIsModalOpen(true)
@@ -59,7 +62,7 @@ const Tools = () => {
         { title: 'separator' },
         {
             title: 'Settings',
-            onClick: () => window.location.href = `${document.baseURI}settings/rbac/`
+            url: `${document.baseURI}settings/rbac/`
         },
         { title: 'separator' },
         ...aboutMenuDropdownItems
@@ -107,7 +110,21 @@ const Tools = () => {
                         <React.Fragment key={key}>
                             { action.title === 'separator'
                                 ? <Divider component="li"/>
-                                : <DropdownItem component="button" onClick={action.onClick}>{action.title}</DropdownItem>
+                                : (<DropdownItem
+                                    {...(action.onClick
+                                        ? {
+                                            component: 'button',
+                                            onClick: action.onClick
+                                        } : {
+                                            href: action.url,
+                                            component: 'a',
+                                            target: '_blank',
+                                            rel: 'noopener noreferrer'
+                                        }
+                                    )}
+                                >
+                                    {action.title}
+                                </DropdownItem>)
                             }
                         </React.Fragment>
                     ))} />


### PR DESCRIPTION
fixes #891

JIRA https://projects.engineering.redhat.com/browse/RHCLOUD-8092

This PR changes buttons to links to make the sire more accessible.

- also **fixes links on smaller screens** in the dropdown. Dropdown items weren't receiving `url` prop and they didn't have any `onClick` function, so they didn't work at all.

@karelhala

Not sure if we want to open links in new tabs by default on smaller screens...