### PR TITLE
Update PF react core in order to fix global filter select bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3120,17 +3120,34 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.32.1.tgz",
-      "integrity": "sha512-4FrKJvMfjHjWtmvGu1QVxo/nCdUgePlkdNzMs91r0wdL16CpfoQVtZcfZe4343fRAQ2ObeYfZ2GuiwvS1sw8Og==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.47.0.tgz",
+      "integrity": "sha512-Qw6pBzBf4p3juOCeSRwHyYbTgNW8LG8PZc/xf7BonBrtWwIrpuo7PpqfSEmQDoZ5NjqGmaQpqFZ9vtsTU/Yvow==",
       "requires": {
-        "@patternfly/react-icons": "^4.5.0",
-        "@patternfly/react-styles": "^4.5.0",
-        "@patternfly/react-tokens": "^4.6.0",
+        "@patternfly/react-icons": "^4.7.4",
+        "@patternfly/react-styles": "^4.7.3",
+        "@patternfly/react-tokens": "^4.9.6",
         "focus-trap": "4.0.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@patternfly/react-icons": {
+          "version": "4.7.4",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.7.4.tgz",
+          "integrity": "sha512-j+N582TJ1MBZWePwP5wFc+qIlGSPkAtnv+pupiAewTWeJnd8TzogoUzlqUHnJNNn8x2Ktrsa561g23HYIIkRWg=="
+        },
+        "@patternfly/react-styles": {
+          "version": "4.7.3",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.7.3.tgz",
+          "integrity": "sha512-p59J4ceql/nUeS6CqwiceBDhFZ1UzBC0BlqxmaBpjSdcxZhRlYoOeCfFZJpJzFDmNTKCxFrvWihXBHgx82h2Hg=="
+        },
+        "@patternfly/react-tokens": {
+          "version": "4.9.6",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.9.6.tgz",
+          "integrity": "sha512-HxJ49yDar5+PEVQGvXd3WKuDTXhm5opYg7wU9lNlh72+8TPXw1gIxTO8WIfPhjWxwEwwukVb2Cd/yTSYK81rdg=="
+        }
       }
     },
     "@patternfly/react-icons": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "^4.23.3",
-    "@patternfly/react-core": "^4.18.5",
+    "@patternfly/react-core": "^4.47.0",
     "@patternfly/react-icons": "^4.4.2",
     "@patternfly/react-table": "^4.12.1",
     "@redhat-cloud-services/entitlements-client": "^1.0.67",


### PR DESCRIPTION
PF recently fixed an issue in selects where if empty children were passed to select the UI would just break (worked previously and stopped working with current version so I had to increase the version)