### PR TITLE
Add isGlobalFilterEnabled pages blacklist.

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -14,6 +14,35 @@ global.MutationObserver = class {
 global.fetch = require('jest-fetch-mock');
 global.window = Object.create(window);
 
+/**
+ * To get around Error: Not implemented: navigation (except hash changes)
+ * Also enables spy and mock implementation on replace. Add missing attributes here.
+ */
+delete window.location;
+window.location = { replace: jest.fn(), pathname: 'https://localhost' };
+
+/**
+ * Mock local storage
+ */
+const localStorageMock = (() => {
+    let store = {};
+    return {
+        getItem: function(key) {
+            return store[key];
+        },
+        setItem: function(key, value) {
+            store[key] = value.toString();
+        },
+        clear: function() {
+            store = {};
+        },
+        removeItem: function(key) {
+            delete store[key];
+        }
+    };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
 global.window.insights = {
     ...window.insights || {},
     chrome: {

--- a/src/js/App/GlobalFilter/isGlobalFilterEnabled.js
+++ b/src/js/App/GlobalFilter/isGlobalFilterEnabled.js
@@ -1,0 +1,19 @@
+export const EXCLUDED_PAGES = ['insights/registration', 'insights/remediations'];
+
+/**
+ * Checks if the chrome should render global filter component
+ * @returns {boolean}
+ */
+const isGlobalFilterEnabled = () => {
+    const { pathname } = location;
+    if (!pathname.includes('insights')) {
+        return false;
+    }
+    if (EXCLUDED_PAGES.some(page => pathname.includes(page))) {
+        return false;
+    }
+
+    return window?.insights?.chrome?.isBeta() || Boolean(localStorage.getItem('chrome:experimental:global-filter'));
+};
+
+export default isGlobalFilterEnabled;

--- a/src/js/App/GlobalFilter/isGlobalFilterEnabled.test.js
+++ b/src/js/App/GlobalFilter/isGlobalFilterEnabled.test.js
@@ -1,0 +1,47 @@
+import isGlobalFilterEnabled, { EXCLUDED_PAGES } from './isGlobalFilterEnabled';
+
+describe('isGlobalFilterEnabled', () => {
+    let loc;
+    beforeEach(() => {
+        loc = location.pathanme;
+    });
+
+    afterEach(() => {
+        location.pathname = loc;
+    });
+    it('should return false if pathname does not include insights partial', () => {
+        location.pathname = 'foo';
+        expect(isGlobalFilterEnabled()).toEqual(false);
+    });
+
+    it('should return false if pathname includes excluded page', () => {
+        expect.assertions(EXCLUDED_PAGES.length);
+        EXCLUDED_PAGES.forEach(page => {
+            location.pathname = page;
+            expect(isGlobalFilterEnabled()).toEqual(false);
+        });
+    });
+
+    it('should return false if chrome is not beta', () => {
+        const isBetaSpy = jest.spyOn(window.insights.chrome, 'isBeta').mockReturnValueOnce(false);
+        location.pathname = 'insights/foo';
+        expect(isGlobalFilterEnabled()).toEqual(false);
+        isBetaSpy.mockRestore();
+    });
+
+    it('should return true if chrome is beta', () => {
+        const isBetaSpy = jest.spyOn(window.insights.chrome, 'isBeta').mockReturnValueOnce(true);
+        location.pathname = 'insights/foo';
+        expect(isGlobalFilterEnabled()).toEqual(true);
+        isBetaSpy.mockRestore();
+    });
+
+    it('should return true if chrome is not beta but chrome:experimental:global-filter is true', () => {
+        const isBetaSpy = jest.spyOn(window.insights.chrome, 'isBeta').mockReturnValueOnce(false);
+        const getItemSpy = jest.spyOn(window.localStorage, 'getItem').mockReturnValueOnce(true);
+        location.pathname = 'insights/foo';
+        expect(isGlobalFilterEnabled()).toEqual(true);
+        isBetaSpy.mockRestore();
+        getItemSpy.mockRestore();
+    });
+});

--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import GlobalFilter from './GlobalFilter';
+import isGlobalFilterEnabled from './GlobalFilter/isGlobalFilterEnabled';
 
 const RootApp = ({
     activeApp,
@@ -10,10 +11,6 @@ const RootApp = ({
     pageAction,
     pageObjectId
 }) => {
-    const isGlobalFilterEnabled = (
-        window?.insights?.chrome?.isBeta() || Boolean(localStorage.getItem('chrome:experimental:global-filter'))
-    ) &&
-    location.pathname.includes('insights');
     return (
         <Fragment>
             <div
@@ -24,7 +21,7 @@ const RootApp = ({
                 {...pageAction && { 'data-ouia-page-action': pageAction }}
                 {...pageObjectId && { 'data-ouia-page-object-id': pageObjectId }}
             >
-                {isGlobalFilterEnabled && <GlobalFilter />}
+                {isGlobalFilterEnabled() && <GlobalFilter />}
                 <main className="pf-c-page__main pf-l-page__main" id="root" role="main">
                     <section
                         className="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"


### PR DESCRIPTION
Based on an email thread by @iphands 

> I also noticed the component showing up on all pages in Insights...
even places it does not make sense.
>- Remediations
>- Registration Assistant

Any more applications that should hide the global nav? We could also define the list to the nav config, but I think for such a small change it would be to much unnecessary work to get it out fo the YAML.