### PR TITLE
Fix navigation text alignment.

### DIFF
--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -100,6 +100,7 @@ export class Navigation extends Component {
                             if (!(item.disabled_on_stable && window.location.pathname.indexOf('/beta') === -1)) {
                                 if (item.subItems) {
                                     return <NavExpandable
+                                        className="ins-m-navigation-align"
                                         title={item.title}
                                         ouia-nav-group={item.id}
                                         itemID={item.id}

--- a/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
@@ -244,7 +244,7 @@ exports[`Navigation should render corectly 1`] = `
     ariaRightScroll="Scroll right"
   >
     <NavExpandable
-      className=""
+      className="ins-m-navigation-align"
       groupId={null}
       id=""
       isActive={true}
@@ -351,7 +351,7 @@ exports[`Navigation should render correctly 2 1`] = `
     ariaRightScroll="Scroll right"
   >
     <NavExpandable
-      className=""
+      className="ins-m-navigation-align"
       groupId={null}
       id=""
       isActive={true}

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -178,3 +178,10 @@ section.ins-c-app-switcher--loading {
       .ins-c-tagfilter__option-value { max-width: 360px; }
     }
 }
+
+// PF navigation text alignment fix
+.ins-m-navigation-align {
+    .pf-c-nav__link {
+        text-align: inherit;
+    }
+}


### PR DESCRIPTION
After the last PF update the alignment on multi-line navigation items is busted.

### Before
![Pasted_Image_9_11_20__10_16_AM (1)](https://user-images.githubusercontent.com/22619452/92939172-bc7a1d00-f44d-11ea-95b6-6d20c9a5c84e.png)

### After
![screenshot-ci foo redhat com_1337-2020 09 11-16_41_12](https://user-images.githubusercontent.com/22619452/92939178-be43e080-f44d-11ea-858e-dec0890a7aa9.png)
