### PR TITLE
Guard and cache fetchPermission chrome API.

### DIFF
--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -16,7 +16,7 @@ import { visibilityFunctions } from './consts';
 import Cookies from 'js-cookie';
 import logger from './jwt/logger';
 import sourceOfTruth from './nav/sourceOfTruth';
-import { fetchPermissions } from './rbac/fetchPermissions';
+import { createFetchPermissionsWatcher } from './rbac/fetchPermissions';
 import { getUrl } from './utils';
 import flatMap from 'lodash/flatMap';
 import { headerLoader } from './App/Header';
@@ -54,7 +54,6 @@ export function chromeInit(libjwt) {
     const { identifyApp, appNavClick, clearActive, appAction, appObjectId, chromeNavUpdate } = actions;
 
     let chromeCache;
-
     // Init JWT first.
     const jwtResolver = libjwt.initPromise
     .then(async () => {
@@ -128,34 +127,40 @@ export function chromeInit(libjwt) {
 }
 
 export function bootstrap(libjwt, initFunc) {
+    const getUser = () => {
+        // here we need to init the qe plugin
+        // the "contract" is we will do this before anyone
+        // calls/finishes getUser
+        // this only does something if the correct localstorage
+        // vars are set
+
+        qe.init();
+
+        return libjwt.initPromise
+        .then(libjwt.jwt.getUserInfo)
+        .catch(() => {
+            libjwt.jwt.logoutAllTabs();
+        });
+    };
+    const permissionCache = new CacheAdapter(
+        'permission-store',
+        `${decodeToken(libjwt.jwt.getEncodedToken())?.session_state}-permission-store`
+    );
+    const fetchPermissions = createFetchPermissionsWatcher(permissionCache);
     return {
         chrome: {
             auth: {
                 getOfflineToken: () => libjwt.getOfflineToken(),
                 doOffline: () => libjwt.jwt.doOffline(consts.noAuthParam, consts.offlineToken),
                 getToken: () => libjwt.jwt.getUserInfo().then(() => libjwt.jwt.getEncodedToken()),
-                getUser: () => {
-                    // here we need to init the qe plugin
-                    // the "contract" is we will do this before anyone
-                    // calls/finishes getUser
-                    // this only does something if the correct localstorage
-                    // vars are set
-
-                    qe.init();
-
-                    return libjwt.initPromise
-                    .then(libjwt.jwt.getUserInfo)
-                    .catch(() => {
-                        libjwt.jwt.logoutAllTabs();
-                    });
-                },
+                getUser,
                 qe: qe,
                 logout: (bounce) => libjwt.jwt.logoutAllTabs(bounce),
                 login: () => libjwt.jwt.login()
             },
             isProd: window.location.host === 'cloud.redhat.com',
             isBeta: () => (window.location.pathname.split('/')[1] === 'beta' ? true : false),
-            getUserPermissions: (app = '') => fetchPermissions(libjwt.jwt.getEncodedToken(), app),
+            getUserPermissions: (app = '') => getUser().then(() => fetchPermissions(libjwt.jwt.getEncodedToken(), app)),
             isPenTest: () => Cookies.get('x-rh-insights-pentest') ? true : false,
             getBundle: () => getUrl('bundle'),
             getApp: () => getUrl('app'),

--- a/src/js/jwt/__mocks__/jwt.js
+++ b/src/js/jwt/__mocks__/jwt.js
@@ -1,0 +1,4 @@
+/* eslint-disable camelcase */
+export const decodeToken = (x) => ({
+    session_state: x
+});

--- a/src/js/rbac/fetchPermissions.test.js
+++ b/src/js/rbac/fetchPermissions.test.js
@@ -6,25 +6,35 @@ jest.mock('./rbac', () => () => {
     });
 });
 
-import { fetchPermissions } from './fetchPermissions';
-import './rbac';
+import { createFetchPermissionsWatcher } from './fetchPermissions';
 
-it('should send all the paginated data as array', async () => {
-    const data = fetchPermissions('uSeRtOkEn');
-    expect.assertions(1);
-    return data.then(permissions => expect(permissions).toEqual(mockedRbac.data));
+jest.mock('../jwt/jwt');
+
+describe('fetchPermissions', () => {
+    let fetchPermissions;
+    beforeEach(() => {
+        const cache = { getItem: () => undefined, setItem: () => undefined };
+        fetchPermissions = createFetchPermissionsWatcher(cache);
+    });
+
+    it('should send all the paginated data as array', async () => {
+        const data = fetchPermissions('uSeRtOkEn');
+        expect.assertions(1);
+        return data.then(permissions => expect(permissions).toEqual(mockedRbac.data));
+    });
+
+    it('should send the data as array', async () => {
+        const data = fetchPermissions('uSeRtOkEn');
+        expect.assertions(1);
+        return data.then(permissions => expect(permissions).toEqual(mockedRbac.data));
+    });
+
+    it('should not call any rbac', async () => {
+        const previousGetBundle = global.insights.chrome.getBundle;
+        global.window.insights.chrome.getBundle = () => 'openshift';
+        const data = await fetchPermissions('uSeRtOkEn');
+        expect(data).not.toEqual(mockedRbac.data);
+        global.window.insights.chrome.getBundle = previousGetBundle;
+    });
 });
 
-it('should send the data as array', async () => {
-    const data = fetchPermissions('uSeRtOkEn');
-    expect.assertions(1);
-    return data.then(permissions => expect(permissions).toEqual(mockedRbac.data));
-});
-
-it('should not call any rbac', async () => {
-    const previousGetBundle = global.insights.chrome.getBundle;
-    global.window.insights.chrome.getBundle = () => 'openshift';
-    const data = await fetchPermissions('uSeRtOkEn');
-    expect(data).not.toEqual(mockedRbac.data);
-    global.window.insights.chrome.getBundle = previousGetBundle;
-});


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-9200

### Changes
- adds a guard for `fetchPermission` chrome API call
  - invoking fetchPermission x > 1 times will always result only in one API call.
- use maximum page size for the `fetchPermission` config
  - previously the page size was 25, now it's 100
  - this change alone reduces the number of calls 4x
- cache the `fetchPermission` call
  - this will remove many rbac API calls when switching between apps
  - the cache is invalidated after 10 minutes