### PR TITLE
Fix undefined session_state when creating permission cache.

### DIFF
--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -127,6 +127,7 @@ export function chromeInit(libjwt) {
 }
 
 export function bootstrap(libjwt, initFunc) {
+    let permissionCache;
     const getUser = () => {
         // here we need to init the qe plugin
         // the "contract" is we will do this before anyone
@@ -138,14 +139,17 @@ export function bootstrap(libjwt, initFunc) {
 
         return libjwt.initPromise
         .then(libjwt.jwt.getUserInfo)
+        .then((data) => {
+            permissionCache = new CacheAdapter(
+                'permission-store',
+                `${decodeToken(libjwt.jwt.getEncodedToken())?.session_state}-permission-store`
+            );
+            return data;
+        })
         .catch(() => {
             libjwt.jwt.logoutAllTabs();
         });
     };
-    const permissionCache = new CacheAdapter(
-        'permission-store',
-        `${decodeToken(libjwt.jwt.getEncodedToken())?.session_state}-permission-store`
-    );
     const fetchPermissions = createFetchPermissionsWatcher(permissionCache);
     return {
         chrome: {

--- a/src/js/rbac/fetchPermissions.js
+++ b/src/js/rbac/fetchPermissions.js
@@ -27,14 +27,23 @@ export const createFetchPermissionsWatcher = (cache) => {
         if (insights.chrome.getBundle() === 'openshift') {
             return Promise.resolve([]);
         }
-        const permissions = await cache.getItem('permissions');
-        if (permissions) {
-            return permissions;
+        let permissions;
+        try {
+            permissions = await cache.getItem('permissions');
+            if (permissions) {
+                return permissions;
+            }
+        } catch (_error) {
+            // ignore error and get permissions from promise
         }
         if (typeof currentCall === 'undefined') {
             currentCall = fetchPermissions(userToken, app).then((data) => {
                 currentCall = undefined;
-                cache.setItem('permissions', data);
+                try {
+                    cache.setItem('permissions', data);
+                } catch (_error) {
+                    // ignore error and do not set cache
+                }
                 return data;
             });
         }


### PR DESCRIPTION
There was an issue when calling the chrome.init function. 

`libjwt.jwt.getEncodedToken()` could sometimes return an `undefined` if the user was not properly authenticated. That caused the decoded token to throw an error and permission cache was not created which leads to runtime errors. I have delayed the cache initialization after the user data is always available. This can sometimes cause the permission cache to be undefined when its called. I've also added try catch blocks there to prevent unvated cache runtime errors.

This should be good enough until we have the global chrome cache in place.