### PR TITLE
Trigger _satellite.pageBottom event on location change.

### DIFF
--- a/src/js/chrome.js
+++ b/src/js/chrome.js
@@ -4,6 +4,7 @@ import sentry from './sentry';
 import { rootApp, noAccess }   from './chrome/entry';
 import { navLoader } from './App/Sidenav';
 import createChromeInstance from './chrome/create-chrome';
+import registerUrlObserver from './url-observer';
 
 //Add redhat font to body
 document.querySelector('body').classList.add('pf-m-redhat-font');
@@ -30,3 +31,8 @@ libjwt.initPromise.then(() => {
 window.insights = window.insights || {};
 
 window.insights = createChromeInstance(libjwt, window.insights);
+
+if ((typeof _satellite !== 'undefined') && (typeof window._satellite.pageBottom === 'function')) {
+    window._satellite.pageBottom();
+    registerUrlObserver(window._satellite.pageBottom);
+}

--- a/src/js/url-observer.js
+++ b/src/js/url-observer.js
@@ -1,0 +1,36 @@
+/**
+ * Function that will register a location observer which will trigger an action after document.location.href change.
+ * We can't use "popstate" event listener because react apps are not using browser history but custom router history implementaion
+ * which are not using history go, push, pop functions that trigger popstate event.
+ * @param {Function} observeCallback callback that will be triggered after URL change
+ */
+const registerUrlObserver = (observeCallback) => {
+    /**
+   * We ignore hash changes
+   * Hashes only have frontend effect
+   */
+    let oldHref = document.location.href.replace(/#.*$/, '');
+
+    window.onload = function() {
+        const bodyList = document.querySelector('body');
+        const observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function() {
+                const newLocation = document.location.href.replace(/#.*$/, '');
+                if (oldHref !== newLocation) {
+                    oldHref = newLocation;
+                    observeCallback();
+                }
+
+            });
+
+        });
+        const config = {
+            childList: true,
+            subtree: true
+        };
+        observer.observe(bodyList, config);
+    };
+
+};
+
+export default registerUrlObserver;

--- a/src/pug/after.pug
+++ b/src/pug/after.pug
@@ -1,7 +1,1 @@
 script(src=`./apps/chrome/${ chromeJS }`)
-script(type='text/javascript').
-  if(window.location.hostname.split('.')[1] !== 'foo') {
-    if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {
-    _satellite.pageBottom();
-    }
-  }


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-9183

### Changes
- call  _satellite.pageBottom function on every location.href change apart from  URL hash changes

@ryelo @karelhala I am a noob when it comes to the chrome analytics. Is calling `_satellite.pageBottom` good enough? Or is there any other callback.

### Why we can't use main navigation events?
It does not register in app routing.

### Why we can't use "popstate" event listener?
The `popstate` event is triggered when you change history via browser `history` object. We are not using that. The only time this would be triggered is via the boBack or go buttons in the browser toolbar. Apps and chrome are using react custom history object. But we do not share this history so we can't listen to that history change either.

### MutationObserver
Instead of that, this uses the body mutation observer which is triggered on DOM changes. granted this is a bit more expensive but should not be noticeable because we are not doing any major changes, just checking URL and calling a callback once in a while.

@ryelo currently, this will trigger the analytics callback on every ULR change including query changes (`/foo?bar=1 -> /foo?bar=2` will trigger the event) with the exception of hash changes. Is that too much? Should we restrict it only to pathname changes?