### PR TITLE
Pass all previous data when connecting to global filter

### DIFF
--- a/src/js/chrome.test.js
+++ b/src/js/chrome.test.js
@@ -91,6 +91,16 @@ describe('Chrome API', () => {
             actions.globalFilterChange()
         );
         expect(callback).toHaveBeenCalled();
+        expect(callback.mock.calls.length).toBe(2);
+    });
+
+    test('should call callback without action triggered', () => {
+        const callback = jest.fn();
+        const chrome = chromeInit(getMockLibJwt());
+        chrome.on('GLOBAL_FILTER_UPDATE', callback);
+
+        expect(callback).toHaveBeenCalled();
+        expect(callback.mock.calls.length).toBe(1);
     });
 
     test('allows for an event GLOBAL_FILTER_UPDATE to be unregistered', () => {
@@ -101,7 +111,7 @@ describe('Chrome API', () => {
         chrome.$internal.store.dispatch(
             actions.globalFilterChange()
         );
-        expect(callback).not.toHaveBeenCalled();
+        expect(callback.mock.calls.length).toBe(1);
     });
 
     test('hides global filter', () => {

--- a/src/js/redux/index.js
+++ b/src/js/redux/index.js
@@ -13,7 +13,8 @@ import {
     onGetAllTags,
     onGetAllTagsPending,
     onSetGlobalFilterScope,
-    onGlobalFilterToggle
+    onGlobalFilterToggle,
+    onTagSelect
 } from './reducers';
 import {
     CLICK_ACTION,
@@ -27,7 +28,8 @@ import {
     CHROME_PAGE_OBJECT,
     CHROME_GET_ALL_TAGS,
     GLOBAL_FILTER_SCOPE,
-    GLOBAL_FILTER_TOGGLE
+    GLOBAL_FILTER_TOGGLE,
+    GLOBAL_FILTER_UPDATE
 } from './action-types';
 
 const reducers = {
@@ -43,7 +45,8 @@ const reducers = {
     [`${CHROME_GET_ALL_TAGS}_FULFILLED`]: onGetAllTags,
     [`${CHROME_GET_ALL_TAGS}_PENDING`]: onGetAllTagsPending,
     [GLOBAL_FILTER_SCOPE]: onSetGlobalFilterScope,
-    [GLOBAL_FILTER_TOGGLE]: onGlobalFilterToggle
+    [GLOBAL_FILTER_TOGGLE]: onGlobalFilterToggle,
+    [GLOBAL_FILTER_UPDATE]: onTagSelect
 };
 
 export default function() {

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -154,3 +154,10 @@ export function onGlobalFilterToggle(state, { payload }) {
         globalFilterHidden: payload.isHidden
     };
 }
+
+export function onTagSelect(state, { payload }) {
+    return {
+        ...state,
+        selectedTags: payload
+    };
+}


### PR DESCRIPTION
### No event when connecting to global filter

If consumers connect to global filter it doesn't fire on connect. Meaning if user selects something on one app, swtiches to other app this selection is not communicated to the second app.

With this PR such issue goes away, this is achieved by returning listener and a selector from public events. Listener is function that is fired when event happens and selector is lodash get to receive data from redux store.