### PR TITLE
Add workloads to bookmarkable part of URL

### DIFF
--- a/src/js/App/GlobalFilter/GlobalFilter.js
+++ b/src/js/App/GlobalFilter/GlobalFilter.js
@@ -8,8 +8,7 @@ import { Split, SplitItem } from '@patternfly/react-core/dist/js/layouts/Split';
 import { Chip, ChipGroup } from '@patternfly/react-core/dist/js/components/ChipGroup';
 import { Button } from '@patternfly/react-core/dist/js/components/Button';
 import TagsModal from './TagsModal';
-import { workloads, updateSelected, storeFilter, GLOBAL_FILTER_KEY, selectWorkloads } from './constants';
-import { decodeToken } from '../../jwt/jwt';
+import { workloads, updateSelected, storeFilter, generateFilter, selectWorkloads } from './constants';
 
 const GlobalFilter = () => {
     const [isOpen, setIsOpen] = useState(false);
@@ -39,13 +38,8 @@ const GlobalFilter = () => {
     useEffect(() => {
         if (!token && userLoaded) {
             (async () => {
-                // eslint-disable-next-line camelcase
-                const currToken = decodeToken(await insights.chrome.auth.getToken())?.session_state;
-                try {
-                    setValue(() => JSON.parse(localStorage.getItem(`${GLOBAL_FILTER_KEY}/${currToken}`) || '{}'));
-                } catch (e) {
-                    setValue(() => {});
-                }
+                const [data, currToken] = await generateFilter();
+                setValue(() => data);
                 setToken(() => currToken);
             })();
         } else if (userLoaded && token) {

--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -57,7 +57,7 @@ export function chromeInit(navResolver) {
         hideGlobalFilter: (isHidden) => store.dispatch(toggleGlobalFilter(isHidden)),
         globalFilterScope: (scope) => store.dispatch(globalFilterScope(scope)),
         mapGlobalFilter: (filter, encode = false) => flatMap(
-            Object.entries(filter),
+            Object.entries(filter || {}),
             ([namespace, item]) => Object.entries(item)
             .filter(([, { isSelected }]) => isSelected)
             .map(([groupKey, { item, value: tagValue }]) => `${


### PR DESCRIPTION
### https://issues.redhat.com/browse/RHCLOUD-9838

Users should be able to bookmark Workloads no matter what they chose previously. This PR adds workloads to URL on load so users can copy the URL and send it to someone, plus when user navigates to URL with workloads in URL it will override the previously selected value (meaning if I were o select all workloads and changed the workloads hash to SAP it will select SAP filer)