### PR TITLE
Disable inventory RBAC on production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3590,9 +3590,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.2.3.tgz",
-      "integrity": "sha512-s0/StB4ryzywGBuH2MtcJeleUX+nyFmMX1RG8lG1JJX1OcLV+EjijKG1JSZLtigxNewKqJ2dv3h7zp6M+gTQgQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.2.4.tgz",
+      "integrity": "sha512-Fhc4G8cIQVgwfA7AJCv6ri3tGvmTpjcQbRGelWiCdlkcxn/c4oC4hMnvKdAPr8HFPzug1D9vEP9Ojw/kvhZ7UA==",
       "requires": {
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@redhat-cloud-services/frontend-components-inventory-vulnerabilities": "^1.47.0",
     "@redhat-cloud-services/frontend-components-notifications": "^2.2.2",
     "@redhat-cloud-services/frontend-components-remediations": "^2.2.3",
-    "@redhat-cloud-services/frontend-components-utilities": "^2.2.3",
+    "@redhat-cloud-services/frontend-components-utilities": "^2.2.4",
     "@redhat-cloud-services/keycloak-js": "0.0.3",
     "@redhat-cloud-services/rbac-client": "^1.0.75",
     "@sentry/browser": "^5.17.0",

--- a/src/js/App/GlobalFilter/GlobalFilter.js
+++ b/src/js/App/GlobalFilter/GlobalFilter.js
@@ -7,11 +7,17 @@ import { fetchAllTags, globalFilterChange } from '../../redux/actions';
 import { Split, SplitItem } from '@patternfly/react-core/dist/js/layouts/Split';
 import { Chip, ChipGroup } from '@patternfly/react-core/dist/js/components/ChipGroup';
 import { Button } from '@patternfly/react-core/dist/js/components/Button';
+import { Tooltip } from '@patternfly/react-core/dist/js/components/Tooltip';
 import TagsModal from './TagsModal';
 import { workloads, updateSelected, storeFilter, GLOBAL_FILTER_KEY, selectWorkloads } from './constants';
 import { decodeToken } from '../../jwt/jwt';
 
 const GlobalFilter = () => {
+    const [hasAccess, setHasAccess] = useState(undefined);
+
+    // TODO: remove once RBAC inventory in prod!
+    const isAllowed = () => window.insights?.chrome?.isProd || hasAccess;
+
     const [isOpen, setIsOpen] = useState(false);
     const [token, setToken] = useState();
     const dispatch = useDispatch();
@@ -37,6 +43,16 @@ const GlobalFilter = () => {
         'Manage tags'
     );
     useEffect(() => {
+        (async () => {
+            const permissions = await window.insights?.chrome?.getUserPermissions('inventory');
+            setHasAccess(permissions?.some(item => [
+                'inventory:*:*',
+                'inventory:*:read',
+                'inventory:hosts:read'
+            ].includes(item?.permission || item)));
+        })();
+    }, [userLoaded]);
+    useEffect(() => {
         if (!token && userLoaded) {
             (async () => {
                 // eslint-disable-next-line camelcase
@@ -48,7 +64,7 @@ const GlobalFilter = () => {
                 }
                 setToken(() => currToken);
             })();
-        } else if (userLoaded && token) {
+        } else if (userLoaded && token && isAllowed()) {
             storeFilter(selectedTags, token);
             dispatch(fetchAllTags({
                 registeredWith: filterScope,
@@ -56,10 +72,10 @@ const GlobalFilter = () => {
                 search: filterTagsBy
             }));
         }
-    }, [selectedTags, filterScope, filterTagsBy, userLoaded]);
+    }, [selectedTags, filterScope, filterTagsBy, userLoaded, isAllowed()]);
 
     useEffect(() => {
-        if (userLoaded && token) {
+        if (userLoaded && token && isAllowed()) {
             if (!Object.values(selectedTags?.[workloads?.[0]?.name] || {})?.some(({ isSelected } = {}) => isSelected)) {
                 setValue({
                     ...selectedTags || {},
@@ -72,52 +88,62 @@ const GlobalFilter = () => {
                 dispatch(globalFilterChange(selectedTags));
             }
         }
-    }, [selectedTags]);
+    }, [selectedTags, isAllowed()]);
 
     const workloadsChip = chips?.splice(chips?.findIndex(({ key }) => key === 'Workloads'), 1);
     chips?.splice(0, 0, ...workloadsChip || []);
+    const GroupFilterWrapper = isAllowed() ? Fragment : Tooltip;
     return <Fragment>
         <Split hasGutter className="ins-c-chrome__global-filter">
             <SplitItem>
-                {userLoaded ?
-                    <GroupFilter
-                        {...filter}
-                        placeholder="Search tags"
-                    /> :
+                {(userLoaded && isAllowed() !== undefined) ?
+                    <GroupFilterWrapper
+                        position="right"
+                        content="You do not have the required inventory permissions to perform this action"
+                    >
+                        <GroupFilter
+                            {...filter}
+                            isDisabled={!isAllowed()}
+                            placeholder="Search tags"
+                        />
+                    </GroupFilterWrapper>
+                    :
                     <Skeleton size={SkeletonSize.xl}/>
                 }
             </SplitItem>
-            <SplitItem isFilled>
-                {chips?.length > 0 && (
-                    <Fragment>
-                        {chips.map(({ category, chips }, key) => (
-                            <ChipGroup
-                                key={key}
-                                categoryName={category}
-                                className={category === 'Workloads' ? 'ins-m-sticky' : ''}
-                            >
-                                {chips?.map(({ key: tagKey, value }, chipKey) => (
-                                    <Chip
-                                        key={chipKey}
-                                        className={tagKey === 'All workloads' ? 'ins-m-permanent' : ''}
-                                        onClick={() => setValue(() => updateSelected(
-                                            selectedTags,
-                                            category,
-                                            tagKey,
-                                            value,
-                                            false
-                                        ))}
-                                    >
-                                        {tagKey}
-                                        {value ? `=${value}` : ''}
-                                    </Chip>
-                                ))}
-                            </ChipGroup>
-                        ))}
-                        <Button variant="link" onClick={() => setValue(() => ({}))}>Clear filters</Button>
-                    </Fragment>
-                )}
-            </SplitItem>
+            {isAllowed() && (
+                <SplitItem isFilled>
+                    {chips?.length > 0 && (
+                        <Fragment>
+                            {chips.map(({ category, chips }, key) => (
+                                <ChipGroup
+                                    key={key}
+                                    categoryName={category}
+                                    className={category === 'Workloads' ? 'ins-m-sticky' : ''}
+                                >
+                                    {chips?.map(({ key: tagKey, value }, chipKey) => (
+                                        <Chip
+                                            key={chipKey}
+                                            className={tagKey === 'All workloads' ? 'ins-m-permanent' : ''}
+                                            onClick={() => setValue(() => updateSelected(
+                                                selectedTags,
+                                                category,
+                                                tagKey,
+                                                value,
+                                                false
+                                            ))}
+                                        >
+                                            {tagKey}
+                                            {value ? `=${value}` : ''}
+                                        </Chip>
+                                    ))}
+                                </ChipGroup>
+                            ))}
+                            <Button variant="link" onClick={() => setValue(() => ({}))}>Clear filters</Button>
+                        </Fragment>
+                    )}
+                </SplitItem>
+            )}
         </Split>
         {
             isOpen &&

--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -58,7 +58,7 @@ export function chromeInit(navResolver) {
         hideGlobalFilter: (isHidden) => store.dispatch(toggleGlobalFilter(isHidden)),
         globalFilterScope: (scope) => store.dispatch(globalFilterScope(scope)),
         mapGlobalFilter: (filter, encode = false) => flatMap(
-            Object.entries(filter),
+            Object.entries(filter || {}),
             ([namespace, item]) => Object.entries(item)
             .filter(([, { isSelected }]) => isSelected)
             .map(([groupKey, { item, value: tagValue }]) => `${

--- a/src/js/inventory/index.js
+++ b/src/js/inventory/index.js
@@ -49,16 +49,21 @@ export default async (dependencies) => {
 
     return {
         ...invData,
-        inventoryConnector: (store) => invData.inventoryConnector(store, isDetailsEnabled ? {
-            componentMapper: RenderWrapper.default,
-            appList: [
-                { title: 'General information', name: 'general_information', pageId: 'inventory' },
-                { title: 'Advisor', name: 'advisor', pageId: 'insights' },
-                { title: 'Vulnerability', name: 'vulnerabilities', pageId: 'vulnerability' },
-                { title: 'Compliance', name: 'compliance' },
-                { title: 'Patch', name: 'patch' }
-            ]
-        } : undefined, drawerEnabled ? RenderWrapper.default : undefined),
+        inventoryConnector: (store) => invData.inventoryConnector(
+            store,
+            isDetailsEnabled ? {
+                componentMapper: RenderWrapper.default,
+                appList: [
+                    { title: 'General information', name: 'general_information', pageId: 'inventory' },
+                    { title: 'Advisor', name: 'advisor', pageId: 'insights' },
+                    { title: 'Vulnerability', name: 'vulnerabilities', pageId: 'vulnerability' },
+                    { title: 'Compliance', name: 'compliance' },
+                    { title: 'Patch', name: 'patch' }
+                ]
+            } : undefined,
+            drawerEnabled ? RenderWrapper.default : undefined,
+            !insights.chrome.isProd()
+        ),
         mergeWithDetail: (redux) => ({
             ...invData.mergeWithDetail(redux),
             ...(isDetailsEnabled || drawerEnabled) && { systemProfileStore: systemProfileStore.default },

--- a/src/js/inventory/index.js
+++ b/src/js/inventory/index.js
@@ -62,7 +62,7 @@ export default async (dependencies) => {
                 ]
             } : undefined,
             drawerEnabled ? RenderWrapper.default : undefined,
-            !insights.chrome.isProd()
+            !insights.chrome.isProd // TODO: remove once RBAC inventory in prod!
         ),
         mergeWithDetail: (redux) => ({
             ...invData.mergeWithDetail(redux),


### PR DESCRIPTION
### Inventory RBAC is not supported in prod

Currently inventory RBAC is not supported in production and inventory component allows turning it off so let's do that for production.

### Global filter disabled

If user has no permission to perform hosts actions we have to disable the global filter and show them the information and we can't show users any filters.