### PR TITLE
Fix global filter styling issues

### DIFF
--- a/src/js/App/GlobalFilter/GlobalFilter.js
+++ b/src/js/App/GlobalFilter/GlobalFilter.js
@@ -34,7 +34,7 @@ const GlobalFilter = () => {
         },
         undefined,
         'system',
-        'Manage tags'
+        'View more'
     );
     useEffect(() => {
         if (!token && userLoaded) {

--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -25,30 +25,32 @@ const RootApp = ({
                 {...pageAction && { 'data-ouia-page-action': pageAction }}
                 {...pageObjectId && { 'data-ouia-page-object-id': pageObjectId }}
             >
-                {isGlobalFilterEnabled && <GlobalFilter />}
-                <main className="pf-c-page__main pf-l-page__main" id="root" role="main">
-                    <section
-                        className="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
-                        widget-type="InsightsPageHeader"
-                    >
-                        <div className="pf-c-content">
-                            <h1
-                                className="pf-c-title pf-m-2xl ins-l-page__header--loading"
-                                widget-type='InsightsPageHeaderTitle'
-                            >
-                                <div className="ins-c-skeleton ins-c-skeleton__sm">
+                <div>
+                    {isGlobalFilterEnabled && <GlobalFilter />}
+                    <main className="pf-c-page__main pf-l-page__main" id="root" role="main">
+                        <section
+                            className="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
+                            widget-type="InsightsPageHeader"
+                        >
+                            <div className="pf-c-content">
+                                <h1
+                                    className="pf-c-title pf-m-2xl ins-l-page__header--loading"
+                                    widget-type='InsightsPageHeaderTitle'
+                                >
+                                    <div className="ins-c-skeleton ins-c-skeleton__sm">
                                     &nbsp;
-                                </div>
-                            </h1>
-                        </div>
-                    </section>
-                    <section className="pf-c-page__main-section pf-l-page__main-section--loading">
-                        <div className="ins-c-spinner ins-m-center" role="status">
-                            <span className="pf-u-screen-reader">Loading...</span>
-                        </div>
-                    </section>
-                </main>
-                <main className="pf-c-page__main" id="no-access"></main>
+                                    </div>
+                                </h1>
+                            </div>
+                        </section>
+                        <section className="pf-c-page__main-section pf-l-page__main-section--loading">
+                            <div className="ins-c-spinner ins-m-center" role="status">
+                                <span className="pf-u-screen-reader">Loading...</span>
+                            </div>
+                        </section>
+                    </main>
+                    <main className="pf-c-page__main" id="no-access"></main>
+                </div>
             </div>
             <aside className="pf-c-drawer__panel">
                 <div className="pf-c-drawer__panel-body" />

--- a/src/js/App/__snapshots__/RootApp.test.js.snap
+++ b/src/js/App/__snapshots__/RootApp.test.js.snap
@@ -6,49 +6,51 @@ Array [
     class="pf-c-drawer__content"
     data-ouia-safe="true"
   >
-    <main
-      class="pf-c-page__main pf-l-page__main"
-      id="root"
-      role="main"
-    >
-      <section
-        class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
-        widget-type="InsightsPageHeader"
+    <div>
+      <main
+        class="pf-c-page__main pf-l-page__main"
+        id="root"
+        role="main"
       >
-        <div
-          class="pf-c-content"
+        <section
+          class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
+          widget-type="InsightsPageHeader"
         >
-          <h1
-            class="pf-c-title pf-m-2xl ins-l-page__header--loading"
-            widget-type="InsightsPageHeaderTitle"
+          <div
+            class="pf-c-content"
           >
-            <div
-              class="ins-c-skeleton ins-c-skeleton__sm"
+            <h1
+              class="pf-c-title pf-m-2xl ins-l-page__header--loading"
+              widget-type="InsightsPageHeaderTitle"
             >
-               
-            </div>
-          </h1>
-        </div>
-      </section>
-      <section
-        class="pf-c-page__main-section pf-l-page__main-section--loading"
-      >
-        <div
-          class="ins-c-spinner ins-m-center"
-          role="status"
+              <div
+                class="ins-c-skeleton ins-c-skeleton__sm"
+              >
+                 
+              </div>
+            </h1>
+          </div>
+        </section>
+        <section
+          class="pf-c-page__main-section pf-l-page__main-section--loading"
         >
-          <span
-            class="pf-u-screen-reader"
+          <div
+            class="ins-c-spinner ins-m-center"
+            role="status"
           >
-            Loading...
-          </span>
-        </div>
-      </section>
-    </main>
-    <main
-      class="pf-c-page__main"
-      id="no-access"
-    />
+            <span
+              class="pf-u-screen-reader"
+            >
+              Loading...
+            </span>
+          </div>
+        </section>
+      </main>
+      <main
+        class="pf-c-page__main"
+        id="no-access"
+      />
+    </div>
   </div>,
   <aside
     class="pf-c-drawer__panel"
@@ -68,49 +70,51 @@ Array [
     data-ouia-page-type="some-app"
     data-ouia-safe="true"
   >
-    <main
-      class="pf-c-page__main pf-l-page__main"
-      id="root"
-      role="main"
-    >
-      <section
-        class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
-        widget-type="InsightsPageHeader"
+    <div>
+      <main
+        class="pf-c-page__main pf-l-page__main"
+        id="root"
+        role="main"
       >
-        <div
-          class="pf-c-content"
+        <section
+          class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
+          widget-type="InsightsPageHeader"
         >
-          <h1
-            class="pf-c-title pf-m-2xl ins-l-page__header--loading"
-            widget-type="InsightsPageHeaderTitle"
+          <div
+            class="pf-c-content"
           >
-            <div
-              class="ins-c-skeleton ins-c-skeleton__sm"
+            <h1
+              class="pf-c-title pf-m-2xl ins-l-page__header--loading"
+              widget-type="InsightsPageHeaderTitle"
             >
-               
-            </div>
-          </h1>
-        </div>
-      </section>
-      <section
-        class="pf-c-page__main-section pf-l-page__main-section--loading"
-      >
-        <div
-          class="ins-c-spinner ins-m-center"
-          role="status"
+              <div
+                class="ins-c-skeleton ins-c-skeleton__sm"
+              >
+                 
+              </div>
+            </h1>
+          </div>
+        </section>
+        <section
+          class="pf-c-page__main-section pf-l-page__main-section--loading"
         >
-          <span
-            class="pf-u-screen-reader"
+          <div
+            class="ins-c-spinner ins-m-center"
+            role="status"
           >
-            Loading...
-          </span>
-        </div>
-      </section>
-    </main>
-    <main
-      class="pf-c-page__main"
-      id="no-access"
-    />
+            <span
+              class="pf-u-screen-reader"
+            >
+              Loading...
+            </span>
+          </div>
+        </section>
+      </main>
+      <main
+        class="pf-c-page__main"
+        id="no-access"
+      />
+    </div>
   </div>,
   <aside
     class="pf-c-drawer__panel"
@@ -131,49 +135,51 @@ Array [
     data-ouia-page-type="some-app"
     data-ouia-safe="true"
   >
-    <main
-      class="pf-c-page__main pf-l-page__main"
-      id="root"
-      role="main"
-    >
-      <section
-        class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
-        widget-type="InsightsPageHeader"
+    <div>
+      <main
+        class="pf-c-page__main pf-l-page__main"
+        id="root"
+        role="main"
       >
-        <div
-          class="pf-c-content"
+        <section
+          class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
+          widget-type="InsightsPageHeader"
         >
-          <h1
-            class="pf-c-title pf-m-2xl ins-l-page__header--loading"
-            widget-type="InsightsPageHeaderTitle"
+          <div
+            class="pf-c-content"
           >
-            <div
-              class="ins-c-skeleton ins-c-skeleton__sm"
+            <h1
+              class="pf-c-title pf-m-2xl ins-l-page__header--loading"
+              widget-type="InsightsPageHeaderTitle"
             >
-               
-            </div>
-          </h1>
-        </div>
-      </section>
-      <section
-        class="pf-c-page__main-section pf-l-page__main-section--loading"
-      >
-        <div
-          class="ins-c-spinner ins-m-center"
-          role="status"
+              <div
+                class="ins-c-skeleton ins-c-skeleton__sm"
+              >
+                 
+              </div>
+            </h1>
+          </div>
+        </section>
+        <section
+          class="pf-c-page__main-section pf-l-page__main-section--loading"
         >
-          <span
-            class="pf-u-screen-reader"
+          <div
+            class="ins-c-spinner ins-m-center"
+            role="status"
           >
-            Loading...
-          </span>
-        </div>
-      </section>
-    </main>
-    <main
-      class="pf-c-page__main"
-      id="no-access"
-    />
+            <span
+              class="pf-u-screen-reader"
+            >
+              Loading...
+            </span>
+          </div>
+        </section>
+      </main>
+      <main
+        class="pf-c-page__main"
+        id="no-access"
+      />
+    </div>
   </div>,
   <aside
     class="pf-c-drawer__panel"
@@ -194,49 +200,51 @@ Array [
     data-ouia-page-type="some-app"
     data-ouia-safe="true"
   >
-    <main
-      class="pf-c-page__main pf-l-page__main"
-      id="root"
-      role="main"
-    >
-      <section
-        class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
-        widget-type="InsightsPageHeader"
+    <div>
+      <main
+        class="pf-c-page__main pf-l-page__main"
+        id="root"
+        role="main"
       >
-        <div
-          class="pf-c-content"
+        <section
+          class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
+          widget-type="InsightsPageHeader"
         >
-          <h1
-            class="pf-c-title pf-m-2xl ins-l-page__header--loading"
-            widget-type="InsightsPageHeaderTitle"
+          <div
+            class="pf-c-content"
           >
-            <div
-              class="ins-c-skeleton ins-c-skeleton__sm"
+            <h1
+              class="pf-c-title pf-m-2xl ins-l-page__header--loading"
+              widget-type="InsightsPageHeaderTitle"
             >
-               
-            </div>
-          </h1>
-        </div>
-      </section>
-      <section
-        class="pf-c-page__main-section pf-l-page__main-section--loading"
-      >
-        <div
-          class="ins-c-spinner ins-m-center"
-          role="status"
+              <div
+                class="ins-c-skeleton ins-c-skeleton__sm"
+              >
+                 
+              </div>
+            </h1>
+          </div>
+        </section>
+        <section
+          class="pf-c-page__main-section pf-l-page__main-section--loading"
         >
-          <span
-            class="pf-u-screen-reader"
+          <div
+            class="ins-c-spinner ins-m-center"
+            role="status"
           >
-            Loading...
-          </span>
-        </div>
-      </section>
-    </main>
-    <main
-      class="pf-c-page__main"
-      id="no-access"
-    />
+            <span
+              class="pf-u-screen-reader"
+            >
+              Loading...
+            </span>
+          </div>
+        </section>
+      </main>
+      <main
+        class="pf-c-page__main"
+        id="no-access"
+      />
+    </div>
   </div>,
   <aside
     class="pf-c-drawer__panel"
@@ -258,49 +266,51 @@ Array [
     data-ouia-page-type="some-app"
     data-ouia-safe="true"
   >
-    <main
-      class="pf-c-page__main pf-l-page__main"
-      id="root"
-      role="main"
-    >
-      <section
-        class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
-        widget-type="InsightsPageHeader"
+    <div>
+      <main
+        class="pf-c-page__main pf-l-page__main"
+        id="root"
+        role="main"
       >
-        <div
-          class="pf-c-content"
+        <section
+          class="pf-m-light pf-c-page-header pf-c-page__main-section pf-m-light"
+          widget-type="InsightsPageHeader"
         >
-          <h1
-            class="pf-c-title pf-m-2xl ins-l-page__header--loading"
-            widget-type="InsightsPageHeaderTitle"
+          <div
+            class="pf-c-content"
           >
-            <div
-              class="ins-c-skeleton ins-c-skeleton__sm"
+            <h1
+              class="pf-c-title pf-m-2xl ins-l-page__header--loading"
+              widget-type="InsightsPageHeaderTitle"
             >
-               
-            </div>
-          </h1>
-        </div>
-      </section>
-      <section
-        class="pf-c-page__main-section pf-l-page__main-section--loading"
-      >
-        <div
-          class="ins-c-spinner ins-m-center"
-          role="status"
+              <div
+                class="ins-c-skeleton ins-c-skeleton__sm"
+              >
+                 
+              </div>
+            </h1>
+          </div>
+        </section>
+        <section
+          class="pf-c-page__main-section pf-l-page__main-section--loading"
         >
-          <span
-            class="pf-u-screen-reader"
+          <div
+            class="ins-c-spinner ins-m-center"
+            role="status"
           >
-            Loading...
-          </span>
-        </div>
-      </section>
-    </main>
-    <main
-      class="pf-c-page__main"
-      id="no-access"
-    />
+            <span
+              class="pf-u-screen-reader"
+            >
+              Loading...
+            </span>
+          </div>
+        </section>
+      </main>
+      <main
+        class="pf-c-page__main"
+        id="no-access"
+      />
+    </div>
   </div>,
   <aside
     class="pf-c-drawer__panel"

--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -58,7 +58,7 @@ export function chromeInit(navResolver) {
         hideGlobalFilter: (isHidden) => store.dispatch(toggleGlobalFilter(isHidden)),
         globalFilterScope: (scope) => store.dispatch(globalFilterScope(scope)),
         mapGlobalFilter: (filter, encode = false) => flatMap(
-            Object.entries(filter),
+            Object.entries(filter || {}),
             ([namespace, item]) => Object.entries(item)
             .filter(([, { isSelected }]) => isSelected)
             .map(([groupKey, { item, value: tagValue }]) => `${


### PR DESCRIPTION
### Global filter fixes

There was a user review of global filter and a few requests came from it:
* Global filter should not be sticky

![animation](https://user-images.githubusercontent.com/3439771/95335308-89417700-08af-11eb-9a15-39a355c84bd0.gif)

* Rename `Manage tags` to `View more`

![Screenshot from 2020-10-07 15-13-00](https://user-images.githubusercontent.com/3439771/95335378-9fe7ce00-08af-11eb-8cd3-d95031cc017c.png)
