### PR TITLE
Enable dynamic navigation items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ List of available permissions methods:
  * `isProd` - test if current environment is production (prod-beta and prod-stable)
  * `isBeta` - test if current environment is beta (ci-beta, qa-beta and prod-beta)
  * `hasPermissions` - test if current user has rbac role permissions ['app:scope:permission']
+ * `apiRequest` - call custom API endpoint to test if the item should be displayed
+
+ ### apiRequest example
+ ```yml
+ app:
+  title: App title
+  api:
+    versions:
+      - v1
+  frontend:
+    paths:
+      - /foo/bar
+    sub_apps:
+      - id: sub-app-one
+        title: sub-app-one
+      - id: dynamic-sub-app
+        title: dynamic-sub-app
+        permissions:
+        method: apiRequest
+        args: # acceps all axios request config options https://github.com/axios/axios#request-config
+        - url: "/request/url"
+          foo: bar
+
+ ```
 
 ## Global filter
 

--- a/src/js/App/Sidenav/ExpandableNav.js
+++ b/src/js/App/Sidenav/ExpandableNav.js
@@ -1,32 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { NavExpandable } from '@patternfly/react-core/dist/js/components/Nav/NavExpandable';
 import NavigationItem from './NavigationItem';
-import axios from 'axios';
 
-const asyncNavMethod = (url, config = {}) =>
-  window.insights.chrome.auth.getUser().then(() => {
-    axios({
-      url,
-      ...config,
-      method: config.method || 'GET',
-    });
-  });
-
-const NavigationApplication = ({ subItems, onClick, title, id, active, ignoreCase, dynamic, activeLocation, activeApp }) => {
-  const [dynamicSubItems, setDynamicSubItems] = useState();
-  useEffect(() => {
-    if (dynamic) {
-      asyncNavMethod(dynamic.url, dynamic.config).then(setDynamicSubItems);
-    }
-  }, []);
-
-  const completeSubItems = [...(subItems || []), ...(dynamicSubItems || [])];
-
-  if (completeSubItems.length > 0) {
+const ExpandableNav = ({ subItems, onClick, title, id, active, ignoreCase, activeLocation, activeApp }) => {
+  if (subItems?.length > 0) {
     return (
       <NavExpandable className="ins-m-navigation-align" title={title} id={id} itemID={id} ouiaId={id} isActive={active} isExpanded={active}>
-        {completeSubItems.map((subItem, subKey) => (
+        {subItems.map((subItem, subKey) => (
           <NavigationItem
             ignoreCase={subItem.ignoreCase}
             itemID={subItem.reload || subItem.id}
@@ -54,7 +35,7 @@ const NavigationApplication = ({ subItems, onClick, title, id, active, ignoreCas
   );
 };
 
-NavigationApplication.propTypes = {
+ExpandableNav.propTypes = {
   subItems: PropTypes.array,
   onClick: PropTypes.func.isRequired,
   title: PropTypes.node.isRequired,
@@ -63,12 +44,6 @@ NavigationApplication.propTypes = {
   activeLocation: PropTypes.string.isRequired,
   activeApp: PropTypes.string,
   active: PropTypes.bool,
-  dynamic: PropTypes.shape({
-    config: PropTypes.object,
-    method: PropTypes.oneOf(['async']).isRequired,
-    url: PropTypes.string.isRequired,
-    args: PropTypes.any,
-  }),
 };
 
-export default NavigationApplication;
+export default ExpandableNav;

--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -8,7 +8,7 @@ import { appNavClick, clearActive } from '../../redux/actions';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 import './Navigation.scss';
-import NavigationApplication from './NavigationApplication';
+import ExpandableNav from './ExpandableNav';
 
 const basepath = document.baseURI;
 
@@ -109,7 +109,7 @@ export const Navigation = ({ settings, activeApp, activeLocation, onNavigate, on
     <Nav aria-label="Insights Global Navigation" data-ouia-safe="true">
       <NavList>
         {settings?.map((item) => (
-          <NavigationApplication
+          <ExpandableNav
             activeLocation={activeLocation}
             activeApp={activeApp}
             key={item.id}

--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -15,10 +15,12 @@ const basepath = document.baseURI;
 const extraLinks = {
   insights: [
     {
+      id: 'extra-inssubs',
       title: 'Subscription Watch',
       link: './subscriptions/',
     },
     {
+      id: 'extra-docs',
       url: 'https://access.redhat.com/documentation/en-us/red_hat_insights/',
       title: 'Documentation',
       external: true,
@@ -26,6 +28,7 @@ const extraLinks = {
   ],
   subscriptions: [
     {
+      id: 'extra-subs',
       url: 'https://access.redhat.com/products/subscription-central',
       title: 'Documentation',
       external: true,
@@ -33,6 +36,7 @@ const extraLinks = {
   ],
   'cost-management': [
     {
+      id: 'extra-cost-management',
       url: 'https://access.redhat.com/documentation/en-us/openshift_container_platform/#category-cost-management',
       title: 'Documentation',
       external: true,
@@ -40,6 +44,7 @@ const extraLinks = {
   ],
   ansible: [
     {
+      id: 'extra-ansible',
       url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
       title: 'Documentation',
       external: true,
@@ -47,18 +52,22 @@ const extraLinks = {
   ],
   openshift: [
     {
+      id: 'extra-openshift-support',
       title: 'Support Cases',
       link: 'https://access.redhat.com/support/cases',
     },
     {
+      id: 'extra-openshift-cm',
       title: 'Cluster Manager Feedback',
       link: 'mailto:ocm-feedback@redhat.com',
     },
     {
+      id: 'extra-openshift-marketplace',
       title: 'Red Hat Marketplace',
       link: 'https://marketplace.redhat.com',
     },
     {
+      id: 'extra-openshift-docs',
       url: 'https://docs.openshift.com/dedicated/4/',
       title: 'Documentation',
       external: true,

--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import { Nav } from '@patternfly/react-core/dist/js/components/Nav/Nav';
 import { NavItem } from '@patternfly/react-core/dist/js/components/Nav/NavItem';
-import { NavExpandable } from '@patternfly/react-core/dist/js/components/Nav/NavExpandable';
 import { NavList } from '@patternfly/react-core/dist/js/components/Nav/NavList';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { appNavClick, clearActive } from '../../redux/actions';
-import NavigationItem from './NavigationItem';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 import './Navigation.scss';
+import NavigationApplication from './NavigationApplication';
 
 const basepath = document.baseURI;
 
@@ -100,47 +99,19 @@ export const Navigation = ({ settings, activeApp, activeLocation, onNavigate, on
   return (
     <Nav aria-label="Insights Global Navigation" data-ouia-safe="true">
       <NavList>
-        {settings?.map((item, key) =>
-          item.subItems ? (
-            <NavExpandable
-              className="ins-m-navigation-align"
-              title={item.title}
-              itemID={item.id}
-              ouiaId={item.id}
-              key={key}
-              isActive={item.active}
-              isExpanded={item.active}
-            >
-              {item.subItems.map((subItem, subKey) => (
-                <NavigationItem
-                  ignoreCase={subItem.ignoreCase}
-                  itemID={subItem.reload || subItem.id}
-                  ouiaId={subItem.reload || subItem.id}
-                  key={subKey}
-                  title={subItem.title}
-                  parent={subItem.reload ? activeLocation : `${activeLocation}${item.id ? `/${item.id}` : ''}`}
-                  isActive={item.active && subItem.id === activeApp}
-                  onClick={(event) => onClick(event, subItem, item)}
-                />
-              ))}
-            </NavExpandable>
-          ) : (
-            <NavigationItem
-              ignoreCase={item.ignoreCase}
-              itemID={item.id}
-              ouiaId={item.id}
-              key={key}
-              title={item.title}
-              parent={activeLocation}
-              isActive={item.active || item.id === activeApp}
-              onClick={(event) => onClick(event, item)}
-            />
-          )
-        )}
-        {extraLinks[activeLocation]?.map?.((item, key) => (
+        {settings?.map((item) => (
+          <NavigationApplication
+            activeLocation={activeLocation}
+            activeApp={activeApp}
+            key={item.id}
+            {...item}
+            onClick={(event, subItem) => (item.subItems ? onClick(event, subItem, item) : onClick(event, item))}
+          />
+        ))}
+        {extraLinks[activeLocation]?.map?.((item) => (
           <NavItem
             className="ins-c-navigation__additional-links"
-            key={key}
+            key={item.id}
             to={item.url || item.link}
             ouiaId={item.id}
             target="_blank"

--- a/src/js/App/Sidenav/Navigation.test.js
+++ b/src/js/App/Sidenav/Navigation.test.js
@@ -55,9 +55,7 @@ describe('Navigation', () => {
     const mockClick = jest.fn();
     const store = mockStore(initialState);
     const wrapper = mount(<Navigation onSelect={mockSelect} onClick={mockClick} store={store} {...props} />);
-    Date.now = jest.fn(() => 1482363367071);
     expect(toJson(wrapper)).toMatchSnapshot();
-    console.log(wrapper.debug());
     wrapper.find(`[itemID='someID']`).simulate('click', { persist: jest.fn() });
     wrapper.find(`[itemID='rules']`).simulate('click', { persist: jest.fn() });
     wrapper.find(`[aria-label='Insights Global Navigation']`).simulate('select', { groupId: 'someID1', itemID: 'someID2' });

--- a/src/js/App/Sidenav/Navigation.test.js
+++ b/src/js/App/Sidenav/Navigation.test.js
@@ -54,8 +54,10 @@ describe('Navigation', () => {
     const mockSelect = jest.fn();
     const mockClick = jest.fn();
     const store = mockStore(initialState);
-    const wrapper = shallow(<Navigation onSelect={mockSelect} onClick={mockClick} store={store} {...props} />);
+    const wrapper = mount(<Navigation onSelect={mockSelect} onClick={mockClick} store={store} {...props} />);
+    Date.now = jest.fn(() => 1482363367071);
     expect(toJson(wrapper)).toMatchSnapshot();
+    console.log(wrapper.debug());
     wrapper.find(`[itemID='someID']`).simulate('click', { persist: jest.fn() });
     wrapper.find(`[itemID='rules']`).simulate('click', { persist: jest.fn() });
     wrapper.find(`[aria-label='Insights Global Navigation']`).simulate('select', { groupId: 'someID1', itemID: 'someID2' });
@@ -72,7 +74,7 @@ describe('Navigation', () => {
     const mockClear = jest.fn();
     const wrapper = shallow(<Navigation onSelect={mockSelect} onClick={mockClick} onNavigate={mockNavigate} onClearActive={mockClear} {...props} />);
     expect(toJson(wrapper, { mode: 'deep' })).toMatchSnapshot();
-    wrapper.find(`[itemID='rules']`).simulate('click', { persist: jest.fn() });
+    wrapper.find('#rules').simulate('click', { persist: jest.fn() });
   });
 });
 

--- a/src/js/App/Sidenav/NavigationApplication.js
+++ b/src/js/App/Sidenav/NavigationApplication.js
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { NavExpandable } from '@patternfly/react-core/dist/js/components/Nav/NavExpandable';
+import NavigationItem from './NavigationItem';
+import axios from 'axios';
+
+const asyncNavMethod = (url, config = {}) =>
+  window.insights.chrome.auth.getUser().then(() => {
+    axios({
+      url,
+      ...config,
+      method: config.method || 'GET',
+    });
+  });
+
+const NavigationApplication = ({ subItems, onClick, title, id, active, ignoreCase, dynamic, activeLocation, activeApp }) => {
+  const [dynamicSubItems, setDynamicSubItems] = useState();
+  useEffect(() => {
+    if (dynamic) {
+      asyncNavMethod(dynamic.url, dynamic.config).then(setDynamicSubItems);
+    }
+  }, []);
+
+  const completeSubItems = [...(subItems || []), ...(dynamicSubItems || [])];
+
+  if (completeSubItems.length > 0) {
+    return (
+      <NavExpandable className="ins-m-navigation-align" title={title} id={id} itemID={id} ouiaId={id} isActive={active} isExpanded={active}>
+        {completeSubItems.map((subItem, subKey) => (
+          <NavigationItem
+            ignoreCase={subItem.ignoreCase}
+            itemID={subItem.reload || subItem.id}
+            ouiaId={subItem.reload || subItem.id}
+            key={subKey}
+            title={subItem.title}
+            parent={subItem.reload ? activeLocation : `${activeLocation}${id ? `/${id}` : ''}`}
+            isActive={active && subItem.id === activeApp}
+            onClick={(event) => onClick(event, subItem)}
+          />
+        ))}
+      </NavExpandable>
+    );
+  }
+  return (
+    <NavigationItem
+      ignoreCase={ignoreCase}
+      itemID={id}
+      ouiaId={id}
+      title={title}
+      parent={activeLocation}
+      isActive={active || id === activeApp}
+      onClick={onClick}
+    />
+  );
+};
+
+NavigationApplication.propTypes = {
+  subItems: PropTypes.array,
+  onClick: PropTypes.func.isRequired,
+  title: PropTypes.node.isRequired,
+  id: PropTypes.string.isRequired,
+  ignoreCase: PropTypes.bool,
+  activeLocation: PropTypes.string.isRequired,
+  activeApp: PropTypes.string,
+  active: PropTypes.bool,
+  dynamic: PropTypes.shape({
+    config: PropTypes.object,
+    method: PropTypes.oneOf(['async']).isRequired,
+    url: PropTypes.string.isRequired,
+    args: PropTypes.any,
+  }),
+};
+
+export default NavigationApplication;

--- a/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
@@ -74,7 +74,7 @@ exports[`ConnectedNavigation mapDispatchToProps function fires 1`] = `
       <nav
         aria-label="Local"
         className="pf-c-nav"
-        data-ouia-component-id={3}
+        data-ouia-component-id={5}
         data-ouia-component-type="PF4/Nav"
         data-ouia-safe="true"
       >
@@ -86,31 +86,71 @@ exports[`ConnectedNavigation mapDispatchToProps function fires 1`] = `
             className="pf-c-nav__list"
             onScroll={[Function]}
           >
-            <NavigationItem
-              isActive={false}
-              key="0"
+            <NavigationApplication
+              activeApp="someApp"
+              activeLocation="someLocation"
+              ansible={
+                Object {
+                  "id": "ansible",
+                  "routes": Array [],
+                  "title": "Red Hat Ansible Automation Platform",
+                }
+              }
+              docs={
+                Object {
+                  "id": "docs",
+                  "routes": Array [],
+                  "title": "Documentation",
+                }
+              }
+              insights={
+                Object {
+                  "id": "insights",
+                  "routes": Array [],
+                  "title": "Red Hat Insights",
+                }
+              }
               onClick={[Function]}
-              parent="someLocation"
+              openshift={
+                Object {
+                  "id": "openshift",
+                  "routes": Array [],
+                  "title": "Red Hat Openshift Cluster Manager",
+                }
+              }
+              staging={
+                Object {
+                  "id": "staging",
+                  "routes": Array [],
+                  "title": "Staging Bundle",
+                }
+              }
             >
-              <NavItem
-                className=""
+              <NavigationItem
                 isActive={false}
                 onClick={[Function]}
-                preventDefault={true}
-                to="http://localhost/someLocation/undefined"
+                parent="someLocation"
               >
-                <li
-                  className="pf-c-nav__item"
+                <NavItem
+                  className=""
+                  isActive={false}
+                  onClick={[Function]}
+                  preventDefault={true}
+                  to="http://localhost/someLocation/undefined"
                 >
-                  <a
-                    aria-current={null}
-                    className="pf-c-nav__link"
-                    href="http://localhost/someLocation/undefined"
-                    onClick={[Function]}
-                  />
-                </li>
-              </NavItem>
-            </NavigationItem>
+                  <li
+                    className="pf-c-nav__item"
+                  >
+                    <a
+                      aria-current={null}
+                      className="pf-c-nav__link"
+                      href="http://localhost/someLocation/undefined"
+                      onClick={[Function]}
+                    />
+                  </li>
+                </NavItem>
+              </NavigationItem>
+            </NavigationApplication>
           </ul>
         </NavList>
       </nav>
@@ -184,7 +224,7 @@ exports[`ConnectedNavigation should render correctly with initial state 1`] = `
         <nav
           aria-label="Local"
           className="pf-c-nav"
-          data-ouia-component-id={1}
+          data-ouia-component-id={3}
           data-ouia-component-type="PF4/Nav"
           data-ouia-safe="true"
         >
@@ -196,31 +236,71 @@ exports[`ConnectedNavigation should render correctly with initial state 1`] = `
               className="pf-c-nav__list"
               onScroll={[Function]}
             >
-              <NavigationItem
-                isActive={false}
-                key="0"
+              <NavigationApplication
+                activeApp="someApp"
+                activeLocation="someLocation"
+                ansible={
+                  Object {
+                    "id": "ansible",
+                    "routes": Array [],
+                    "title": "Red Hat Ansible Automation Platform",
+                  }
+                }
+                docs={
+                  Object {
+                    "id": "docs",
+                    "routes": Array [],
+                    "title": "Documentation",
+                  }
+                }
+                insights={
+                  Object {
+                    "id": "insights",
+                    "routes": Array [],
+                    "title": "Red Hat Insights",
+                  }
+                }
                 onClick={[Function]}
-                parent="someLocation"
+                openshift={
+                  Object {
+                    "id": "openshift",
+                    "routes": Array [],
+                    "title": "Red Hat Openshift Cluster Manager",
+                  }
+                }
+                staging={
+                  Object {
+                    "id": "staging",
+                    "routes": Array [],
+                    "title": "Staging Bundle",
+                  }
+                }
               >
-                <NavItem
-                  className=""
+                <NavigationItem
                   isActive={false}
                   onClick={[Function]}
-                  preventDefault={true}
-                  to="http://localhost/someLocation/undefined"
+                  parent="someLocation"
                 >
-                  <li
-                    className="pf-c-nav__item"
+                  <NavItem
+                    className=""
+                    isActive={false}
+                    onClick={[Function]}
+                    preventDefault={true}
+                    to="http://localhost/someLocation/undefined"
                   >
-                    <a
-                      aria-current={null}
-                      className="pf-c-nav__link"
-                      href="http://localhost/someLocation/undefined"
-                      onClick={[Function]}
-                    />
-                  </li>
-                </NavItem>
-              </NavigationItem>
+                    <li
+                      className="pf-c-nav__item"
+                    >
+                      <a
+                        aria-current={null}
+                        className="pf-c-nav__link"
+                        href="http://localhost/someLocation/undefined"
+                        onClick={[Function]}
+                      />
+                    </li>
+                  </NavItem>
+                </NavigationItem>
+              </NavigationApplication>
             </ul>
           </NavList>
         </nav>
@@ -231,123 +311,503 @@ exports[`ConnectedNavigation should render correctly with initial state 1`] = `
 `;
 
 exports[`Navigation should render corectly 1`] = `
-<Nav
-  aria-label="Insights Global Navigation"
-  data-ouia-safe="true"
-  onSelect={[Function]}
-  onToggle={[Function]}
-  ouiaSafe={true}
-  theme="dark"
+<Navigation
+  activeApp="someApp"
+  activeGroup="someID"
+  activeLocation="openshift"
+  appId="overview"
+  documentation="someDocs"
+  onClick={[MockFunction]}
+  onNavigate={[MockFunction]}
+  onSelect={[MockFunction]}
+  settings={
+    Array [
+      Object {
+        "active": true,
+        "group": "insights",
+        "id": "overview",
+        "subItems": Array [
+          Object {
+            "default": true,
+            "id": "someID",
+            "title": "Clusters",
+          },
+        ],
+        "title": "Overview",
+      },
+      Object {
+        "active": false,
+        "group": "insights",
+        "id": "rules",
+        "title": "Rules",
+      },
+      Object {
+        "active": false,
+        "group": "insights",
+        "id": "topics",
+        "title": "Topics",
+      },
+      Object {
+        "active": false,
+        "id": "inventory",
+        "title": "Inventory",
+      },
+      Object {
+        "active": false,
+        "id": "remediations",
+        "title": "Remediations",
+      },
+    ]
+  }
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
 >
-  <NavList
-    ariaLeftScroll="Scroll left"
-    ariaRightScroll="Scroll right"
+  <Nav
+    aria-label="Insights Global Navigation"
+    data-ouia-safe="true"
+    onSelect={[Function]}
+    onToggle={[Function]}
+    ouiaSafe={true}
+    theme="dark"
   >
-    <NavExpandable
-      className="ins-m-navigation-align"
-      groupId={null}
-      id=""
-      isActive={true}
-      isExpanded={true}
-      itemID="overview"
-      key="0"
-      ouiaId="overview"
-      srText=""
-      title="Overview"
+    <nav
+      aria-label="Local"
+      className="pf-c-nav"
+      data-ouia-component-id={1}
+      data-ouia-component-type="PF4/Nav"
+      data-ouia-safe="true"
     >
-      <NavigationItem
-        isActive={false}
-        itemID="someID"
-        key="0"
-        onClick={[Function]}
-        ouiaId="someID"
-        parent="openshift/overview"
-        title="Clusters"
-      />
-    </NavExpandable>
-    <NavigationItem
-      isActive={false}
-      itemID="rules"
-      key="1"
-      onClick={[Function]}
-      ouiaId="rules"
-      parent="openshift"
-      title="Rules"
-    />
-    <NavigationItem
-      isActive={false}
-      itemID="topics"
-      key="2"
-      onClick={[Function]}
-      ouiaId="topics"
-      parent="openshift"
-      title="Topics"
-    />
-    <NavigationItem
-      isActive={false}
-      itemID="inventory"
-      key="3"
-      onClick={[Function]}
-      ouiaId="inventory"
-      parent="openshift"
-      title="Inventory"
-    />
-    <NavigationItem
-      isActive={false}
-      itemID="remediations"
-      key="4"
-      onClick={[Function]}
-      ouiaId="remediations"
-      parent="openshift"
-      title="Remediations"
-    />
-    <NavItem
-      className="ins-c-navigation__additional-links"
-      key="0"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="https://access.redhat.com/support/cases"
-    >
-      Support Cases
-       
-    </NavItem>
-    <NavItem
-      className="ins-c-navigation__additional-links"
-      key="1"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="mailto:ocm-feedback@redhat.com"
-    >
-      Cluster Manager Feedback
-       
-    </NavItem>
-    <NavItem
-      className="ins-c-navigation__additional-links"
-      key="2"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="https://marketplace.redhat.com"
-    >
-      Red Hat Marketplace
-       
-    </NavItem>
-    <NavItem
-      className="ins-c-navigation__additional-links"
-      key="3"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="https://docs.openshift.com/dedicated/4/"
-    >
-      Documentation
-       
-      <ExternalLinkAltIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
-    </NavItem>
-  </NavList>
-</Nav>
+      <NavList
+        ariaLeftScroll="Scroll left"
+        ariaRightScroll="Scroll right"
+      >
+        <ul
+          className="pf-c-nav__list"
+          onScroll={[Function]}
+        >
+          <NavigationApplication
+            active={true}
+            activeApp="someApp"
+            activeLocation="openshift"
+            group="insights"
+            id="overview"
+            key="overview"
+            onClick={[Function]}
+            subItems={
+              Array [
+                Object {
+                  "default": true,
+                  "id": "someID",
+                  "title": "Clusters",
+                },
+              ]
+            }
+            title="Overview"
+          >
+            <NavExpandable
+              className="ins-m-navigation-align"
+              groupId={null}
+              id="overview"
+              isActive={true}
+              isExpanded={true}
+              itemID="overview"
+              ouiaId="overview"
+              srText=""
+              title="Overview"
+            >
+              <li
+                className="pf-c-nav__item pf-m-expandable pf-m-expanded pf-m-current ins-m-navigation-align"
+                itemID="overview"
+                onClick={[Function]}
+                ouiaId="overview"
+              >
+                <button
+                  aria-expanded={true}
+                  className="pf-c-nav__link"
+                  id="overview"
+                  onClick={[Function]}
+                  onMouseDown={[Function]}
+                >
+                  Overview
+                  <span
+                    className="pf-c-nav__toggle"
+                  >
+                    <span
+                      className="pf-c-nav__toggle-icon"
+                    >
+                      <AngleRightIcon
+                        aria-hidden="true"
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                          />
+                        </svg>
+                      </AngleRightIcon>
+                    </span>
+                  </span>
+                </button>
+                <section
+                  aria-labelledby="overview"
+                  className="pf-c-nav__subnav"
+                  hidden={null}
+                >
+                  <ul
+                    className="pf-c-nav__list"
+                  >
+                    <NavigationItem
+                      isActive={false}
+                      itemID="someID"
+                      key="0"
+                      onClick={[Function]}
+                      ouiaId="someID"
+                      parent="openshift/overview"
+                      title="Clusters"
+                    >
+                      <NavItem
+                        className=""
+                        isActive={false}
+                        itemId="someID"
+                        onClick={[Function]}
+                        ouiaId="someID"
+                        preventDefault={true}
+                        to="http://localhost/openshift/overview/someID"
+                      >
+                        <li
+                          className="pf-c-nav__item"
+                        >
+                          <a
+                            aria-current={null}
+                            className="pf-c-nav__link"
+                            href="http://localhost/openshift/overview/someID"
+                            onClick={[Function]}
+                            ouiaId="someID"
+                          >
+                            Clusters
+                          </a>
+                        </li>
+                      </NavItem>
+                    </NavigationItem>
+                  </ul>
+                </section>
+              </li>
+            </NavExpandable>
+          </NavigationApplication>
+          <NavigationApplication
+            active={false}
+            activeApp="someApp"
+            activeLocation="openshift"
+            group="insights"
+            id="rules"
+            key="rules"
+            onClick={[Function]}
+            title="Rules"
+          >
+            <NavigationItem
+              isActive={false}
+              itemID="rules"
+              onClick={[Function]}
+              ouiaId="rules"
+              parent="openshift"
+              title="Rules"
+            >
+              <NavItem
+                className=""
+                isActive={false}
+                itemId="rules"
+                onClick={[Function]}
+                ouiaId="rules"
+                preventDefault={true}
+                to="http://localhost/openshift/rules"
+              >
+                <li
+                  className="pf-c-nav__item"
+                >
+                  <a
+                    aria-current={null}
+                    className="pf-c-nav__link"
+                    href="http://localhost/openshift/rules"
+                    onClick={[Function]}
+                    ouiaId="rules"
+                  >
+                    Rules
+                  </a>
+                </li>
+              </NavItem>
+            </NavigationItem>
+          </NavigationApplication>
+          <NavigationApplication
+            active={false}
+            activeApp="someApp"
+            activeLocation="openshift"
+            group="insights"
+            id="topics"
+            key="topics"
+            onClick={[Function]}
+            title="Topics"
+          >
+            <NavigationItem
+              isActive={false}
+              itemID="topics"
+              onClick={[Function]}
+              ouiaId="topics"
+              parent="openshift"
+              title="Topics"
+            >
+              <NavItem
+                className=""
+                isActive={false}
+                itemId="topics"
+                onClick={[Function]}
+                ouiaId="topics"
+                preventDefault={true}
+                to="http://localhost/openshift/topics"
+              >
+                <li
+                  className="pf-c-nav__item"
+                >
+                  <a
+                    aria-current={null}
+                    className="pf-c-nav__link"
+                    href="http://localhost/openshift/topics"
+                    onClick={[Function]}
+                    ouiaId="topics"
+                  >
+                    Topics
+                  </a>
+                </li>
+              </NavItem>
+            </NavigationItem>
+          </NavigationApplication>
+          <NavigationApplication
+            active={false}
+            activeApp="someApp"
+            activeLocation="openshift"
+            id="inventory"
+            key="inventory"
+            onClick={[Function]}
+            title="Inventory"
+          >
+            <NavigationItem
+              isActive={false}
+              itemID="inventory"
+              onClick={[Function]}
+              ouiaId="inventory"
+              parent="openshift"
+              title="Inventory"
+            >
+              <NavItem
+                className=""
+                isActive={false}
+                itemId="inventory"
+                onClick={[Function]}
+                ouiaId="inventory"
+                preventDefault={true}
+                to="http://localhost/openshift/inventory"
+              >
+                <li
+                  className="pf-c-nav__item"
+                >
+                  <a
+                    aria-current={null}
+                    className="pf-c-nav__link"
+                    href="http://localhost/openshift/inventory"
+                    onClick={[Function]}
+                    ouiaId="inventory"
+                  >
+                    Inventory
+                  </a>
+                </li>
+              </NavItem>
+            </NavigationItem>
+          </NavigationApplication>
+          <NavigationApplication
+            active={false}
+            activeApp="someApp"
+            activeLocation="openshift"
+            id="remediations"
+            key="remediations"
+            onClick={[Function]}
+            title="Remediations"
+          >
+            <NavigationItem
+              isActive={false}
+              itemID="remediations"
+              onClick={[Function]}
+              ouiaId="remediations"
+              parent="openshift"
+              title="Remediations"
+            >
+              <NavItem
+                className=""
+                isActive={false}
+                itemId="remediations"
+                onClick={[Function]}
+                ouiaId="remediations"
+                preventDefault={true}
+                to="http://localhost/openshift/remediations"
+              >
+                <li
+                  className="pf-c-nav__item"
+                >
+                  <a
+                    aria-current={null}
+                    className="pf-c-nav__link"
+                    href="http://localhost/openshift/remediations"
+                    onClick={[Function]}
+                    ouiaId="remediations"
+                  >
+                    Remediations
+                  </a>
+                </li>
+              </NavItem>
+            </NavigationItem>
+          </NavigationApplication>
+          <NavItem
+            className="ins-c-navigation__additional-links"
+            key="0"
+            rel="noopener noreferrer"
+            target="_blank"
+            to="https://access.redhat.com/support/cases"
+          >
+            <li
+              className="pf-c-nav__item ins-c-navigation__additional-links"
+            >
+              <a
+                aria-current={null}
+                className="pf-c-nav__link ins-c-navigation__additional-links"
+                href="https://access.redhat.com/support/cases"
+                onClick={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Support Cases
+                 
+              </a>
+            </li>
+          </NavItem>
+          <NavItem
+            className="ins-c-navigation__additional-links"
+            key="1"
+            rel="noopener noreferrer"
+            target="_blank"
+            to="mailto:ocm-feedback@redhat.com"
+          >
+            <li
+              className="pf-c-nav__item ins-c-navigation__additional-links"
+            >
+              <a
+                aria-current={null}
+                className="pf-c-nav__link ins-c-navigation__additional-links"
+                href="mailto:ocm-feedback@redhat.com"
+                onClick={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Cluster Manager Feedback
+                 
+              </a>
+            </li>
+          </NavItem>
+          <NavItem
+            className="ins-c-navigation__additional-links"
+            key="2"
+            rel="noopener noreferrer"
+            target="_blank"
+            to="https://marketplace.redhat.com"
+          >
+            <li
+              className="pf-c-nav__item ins-c-navigation__additional-links"
+            >
+              <a
+                aria-current={null}
+                className="pf-c-nav__link ins-c-navigation__additional-links"
+                href="https://marketplace.redhat.com"
+                onClick={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Red Hat Marketplace
+                 
+              </a>
+            </li>
+          </NavItem>
+          <NavItem
+            className="ins-c-navigation__additional-links"
+            key="3"
+            rel="noopener noreferrer"
+            target="_blank"
+            to="https://docs.openshift.com/dedicated/4/"
+          >
+            <li
+              className="pf-c-nav__item ins-c-navigation__additional-links"
+            >
+              <a
+                aria-current={null}
+                className="pf-c-nav__link ins-c-navigation__additional-links"
+                href="https://docs.openshift.com/dedicated/4/"
+                onClick={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Documentation
+                 
+                <ExternalLinkAltIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                    />
+                  </svg>
+                </ExternalLinkAltIcon>
+              </a>
+            </li>
+          </NavItem>
+        </ul>
+      </NavList>
+    </nav>
+  </Nav>
+</Navigation>
 `;
 
 exports[`Navigation should render correctly 2 1`] = `
@@ -363,62 +823,61 @@ exports[`Navigation should render correctly 2 1`] = `
     ariaLeftScroll="Scroll left"
     ariaRightScroll="Scroll right"
   >
-    <NavExpandable
-      className="ins-m-navigation-align"
-      groupId={null}
-      id=""
-      isActive={true}
-      isExpanded={true}
-      itemID="overview"
-      key="0"
-      ouiaId="overview"
-      srText=""
-      title="Overview"
-    >
-      <NavigationItem
-        isActive={false}
-        itemID="someID"
-        key="0"
-        onClick={[Function]}
-        ouiaId="someID"
-        parent="openshift/overview"
-        title="Clusters"
-      />
-    </NavExpandable>
-    <NavigationItem
-      isActive={false}
-      itemID="rules"
-      key="1"
+    <NavigationApplication
+      active={true}
+      activeApp="someApp"
+      activeLocation="openshift"
+      group="insights"
+      id="overview"
+      key="overview"
       onClick={[Function]}
-      ouiaId="rules"
-      parent="openshift"
+      subItems={
+        Array [
+          Object {
+            "default": true,
+            "id": "someID",
+            "title": "Clusters",
+          },
+        ]
+      }
+      title="Overview"
+    />
+    <NavigationApplication
+      active={false}
+      activeApp="someApp"
+      activeLocation="openshift"
+      group="insights"
+      id="rules"
+      key="rules"
+      onClick={[Function]}
       title="Rules"
     />
-    <NavigationItem
-      isActive={false}
-      itemID="topics"
-      key="2"
+    <NavigationApplication
+      active={false}
+      activeApp="someApp"
+      activeLocation="openshift"
+      group="insights"
+      id="topics"
+      key="topics"
       onClick={[Function]}
-      ouiaId="topics"
-      parent="openshift"
       title="Topics"
     />
-    <NavigationItem
-      isActive={false}
-      itemID="inventory"
-      key="3"
+    <NavigationApplication
+      active={false}
+      activeApp="someApp"
+      activeLocation="openshift"
+      id="inventory"
+      key="inventory"
       onClick={[Function]}
-      ouiaId="inventory"
-      parent="openshift"
       title="Inventory"
     />
-    <NavigationItem
-      isActive={false}
-      itemID="remediations"
-      key="4"
+    <NavigationApplication
+      active={false}
+      activeApp="someApp"
+      activeLocation="openshift"
+      id="remediations"
+      key="remediations"
       onClick={[Function]}
-      ouiaId="remediations"
-      parent="openshift"
       title="Remediations"
     />
     <NavItem

--- a/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
@@ -86,7 +86,7 @@ exports[`ConnectedNavigation mapDispatchToProps function fires 1`] = `
             className="pf-c-nav__list"
             onScroll={[Function]}
           >
-            <NavigationApplication
+            <ExpandableNav
               activeApp="someApp"
               activeLocation="someLocation"
               ansible={
@@ -150,7 +150,7 @@ exports[`ConnectedNavigation mapDispatchToProps function fires 1`] = `
                   </li>
                 </NavItem>
               </NavigationItem>
-            </NavigationApplication>
+            </ExpandableNav>
           </ul>
         </NavList>
       </nav>
@@ -236,7 +236,7 @@ exports[`ConnectedNavigation should render correctly with initial state 1`] = `
               className="pf-c-nav__list"
               onScroll={[Function]}
             >
-              <NavigationApplication
+              <ExpandableNav
                 activeApp="someApp"
                 activeLocation="someLocation"
                 ansible={
@@ -300,7 +300,7 @@ exports[`ConnectedNavigation should render correctly with initial state 1`] = `
                     </li>
                   </NavItem>
                 </NavigationItem>
-              </NavigationApplication>
+              </ExpandableNav>
             </ul>
           </NavList>
         </nav>
@@ -393,7 +393,7 @@ exports[`Navigation should render corectly 1`] = `
           className="pf-c-nav__list"
           onScroll={[Function]}
         >
-          <NavigationApplication
+          <ExpandableNav
             active={true}
             activeApp="someApp"
             activeLocation="openshift"
@@ -516,8 +516,8 @@ exports[`Navigation should render corectly 1`] = `
                 </section>
               </li>
             </NavExpandable>
-          </NavigationApplication>
-          <NavigationApplication
+          </ExpandableNav>
+          <ExpandableNav
             active={false}
             activeApp="someApp"
             activeLocation="openshift"
@@ -559,8 +559,8 @@ exports[`Navigation should render corectly 1`] = `
                 </li>
               </NavItem>
             </NavigationItem>
-          </NavigationApplication>
-          <NavigationApplication
+          </ExpandableNav>
+          <ExpandableNav
             active={false}
             activeApp="someApp"
             activeLocation="openshift"
@@ -602,8 +602,8 @@ exports[`Navigation should render corectly 1`] = `
                 </li>
               </NavItem>
             </NavigationItem>
-          </NavigationApplication>
-          <NavigationApplication
+          </ExpandableNav>
+          <ExpandableNav
             active={false}
             activeApp="someApp"
             activeLocation="openshift"
@@ -644,8 +644,8 @@ exports[`Navigation should render corectly 1`] = `
                 </li>
               </NavItem>
             </NavigationItem>
-          </NavigationApplication>
-          <NavigationApplication
+          </ExpandableNav>
+          <ExpandableNav
             active={false}
             activeApp="someApp"
             activeLocation="openshift"
@@ -686,7 +686,7 @@ exports[`Navigation should render corectly 1`] = `
                 </li>
               </NavItem>
             </NavigationItem>
-          </NavigationApplication>
+          </ExpandableNav>
           <NavItem
             className="ins-c-navigation__additional-links"
             key="extra-openshift-support"
@@ -831,7 +831,7 @@ exports[`Navigation should render correctly 2 1`] = `
     ariaLeftScroll="Scroll left"
     ariaRightScroll="Scroll right"
   >
-    <NavigationApplication
+    <ExpandableNav
       active={true}
       activeApp="someApp"
       activeLocation="openshift"
@@ -850,7 +850,7 @@ exports[`Navigation should render correctly 2 1`] = `
       }
       title="Overview"
     />
-    <NavigationApplication
+    <ExpandableNav
       active={false}
       activeApp="someApp"
       activeLocation="openshift"
@@ -860,7 +860,7 @@ exports[`Navigation should render correctly 2 1`] = `
       onClick={[Function]}
       title="Rules"
     />
-    <NavigationApplication
+    <ExpandableNav
       active={false}
       activeApp="someApp"
       activeLocation="openshift"
@@ -870,7 +870,7 @@ exports[`Navigation should render correctly 2 1`] = `
       onClick={[Function]}
       title="Topics"
     />
-    <NavigationApplication
+    <ExpandableNav
       active={false}
       activeApp="someApp"
       activeLocation="openshift"
@@ -879,7 +879,7 @@ exports[`Navigation should render correctly 2 1`] = `
       onClick={[Function]}
       title="Inventory"
     />
-    <NavigationApplication
+    <ExpandableNav
       active={false}
       activeApp="someApp"
       activeLocation="openshift"

--- a/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
@@ -689,7 +689,8 @@ exports[`Navigation should render corectly 1`] = `
           </NavigationApplication>
           <NavItem
             className="ins-c-navigation__additional-links"
-            key="0"
+            key="extra-openshift-support"
+            ouiaId="extra-openshift-support"
             rel="noopener noreferrer"
             target="_blank"
             to="https://access.redhat.com/support/cases"
@@ -702,6 +703,7 @@ exports[`Navigation should render corectly 1`] = `
                 className="pf-c-nav__link ins-c-navigation__additional-links"
                 href="https://access.redhat.com/support/cases"
                 onClick={[Function]}
+                ouiaId="extra-openshift-support"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -712,7 +714,8 @@ exports[`Navigation should render corectly 1`] = `
           </NavItem>
           <NavItem
             className="ins-c-navigation__additional-links"
-            key="1"
+            key="extra-openshift-cm"
+            ouiaId="extra-openshift-cm"
             rel="noopener noreferrer"
             target="_blank"
             to="mailto:ocm-feedback@redhat.com"
@@ -725,6 +728,7 @@ exports[`Navigation should render corectly 1`] = `
                 className="pf-c-nav__link ins-c-navigation__additional-links"
                 href="mailto:ocm-feedback@redhat.com"
                 onClick={[Function]}
+                ouiaId="extra-openshift-cm"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -735,7 +739,8 @@ exports[`Navigation should render corectly 1`] = `
           </NavItem>
           <NavItem
             className="ins-c-navigation__additional-links"
-            key="2"
+            key="extra-openshift-marketplace"
+            ouiaId="extra-openshift-marketplace"
             rel="noopener noreferrer"
             target="_blank"
             to="https://marketplace.redhat.com"
@@ -748,6 +753,7 @@ exports[`Navigation should render corectly 1`] = `
                 className="pf-c-nav__link ins-c-navigation__additional-links"
                 href="https://marketplace.redhat.com"
                 onClick={[Function]}
+                ouiaId="extra-openshift-marketplace"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -758,7 +764,8 @@ exports[`Navigation should render corectly 1`] = `
           </NavItem>
           <NavItem
             className="ins-c-navigation__additional-links"
-            key="3"
+            key="extra-openshift-docs"
+            ouiaId="extra-openshift-docs"
             rel="noopener noreferrer"
             target="_blank"
             to="https://docs.openshift.com/dedicated/4/"
@@ -771,6 +778,7 @@ exports[`Navigation should render corectly 1`] = `
                 className="pf-c-nav__link ins-c-navigation__additional-links"
                 href="https://docs.openshift.com/dedicated/4/"
                 onClick={[Function]}
+                ouiaId="extra-openshift-docs"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -882,7 +890,8 @@ exports[`Navigation should render correctly 2 1`] = `
     />
     <NavItem
       className="ins-c-navigation__additional-links"
-      key="0"
+      key="extra-openshift-support"
+      ouiaId="extra-openshift-support"
       rel="noopener noreferrer"
       target="_blank"
       to="https://access.redhat.com/support/cases"
@@ -892,7 +901,8 @@ exports[`Navigation should render correctly 2 1`] = `
     </NavItem>
     <NavItem
       className="ins-c-navigation__additional-links"
-      key="1"
+      key="extra-openshift-cm"
+      ouiaId="extra-openshift-cm"
       rel="noopener noreferrer"
       target="_blank"
       to="mailto:ocm-feedback@redhat.com"
@@ -902,7 +912,8 @@ exports[`Navigation should render correctly 2 1`] = `
     </NavItem>
     <NavItem
       className="ins-c-navigation__additional-links"
-      key="2"
+      key="extra-openshift-marketplace"
+      ouiaId="extra-openshift-marketplace"
       rel="noopener noreferrer"
       target="_blank"
       to="https://marketplace.redhat.com"
@@ -912,7 +923,8 @@ exports[`Navigation should render correctly 2 1`] = `
     </NavItem>
     <NavItem
       className="ins-c-navigation__additional-links"
-      key="3"
+      key="extra-openshift-docs"
+      ouiaId="extra-openshift-docs"
       rel="noopener noreferrer"
       target="_blank"
       to="https://docs.openshift.com/dedicated/4/"

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -44,14 +44,12 @@ export const visibilityFunctions = {
     const userPermissions = await insights.chrome.getUserPermissions();
     return userPermissions && permissions.every((item) => userPermissions.find(({ permission }) => permission === item));
   },
-  apiRequest: async ({ url, method, ...options }) => {
-    // TODO: add caching
-    return instance.axios({
+  apiRequest: async ({ url, method, ...options }) =>
+    instance({
       url,
       method: method || 'GET',
       ...options,
-    });
-  },
+    }),
 };
 
 export const isVisible = (limitedApps, app, visibility) => {

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -50,7 +50,7 @@ export const visibilityFunctions = {
       url,
       method: method || 'GET',
       ...options,
-    }).then((response) => (accessor ? get(response?.data || response || {}, accessor) : (response?.data || response)),
+    }).then((response) => (accessor ? get(response?.data || response || {}, accessor) : response?.data || response)),
 };
 
 export const isVisible = (limitedApps, app, visibility) => {

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -1,4 +1,5 @@
 import instance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
+import get from 'lodash/get';
 
 const obj = {
   noAuthParam: 'noauth',
@@ -44,12 +45,12 @@ export const visibilityFunctions = {
     const userPermissions = await insights.chrome.getUserPermissions();
     return userPermissions && permissions.every((item) => userPermissions.find(({ permission }) => permission === item));
   },
-  apiRequest: async ({ url, method, ...options }) =>
+  apiRequest: async ({ url, method, accessor, ...options }) =>
     instance({
       url,
       method: method || 'GET',
       ...options,
-    }),
+    }).then((response) => (accessor ? get(response?.data || {}, accessor) : response)),
 };
 
 export const isVisible = (limitedApps, app, visibility) => {

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -50,7 +50,7 @@ export const visibilityFunctions = {
       url,
       method: method || 'GET',
       ...options,
-    }).then((response) => (accessor ? get(response?.data || {}, accessor) : response)),
+    }).then((response) => (accessor ? get(response?.data || response || {}, accessor) : (response?.data || response)),
 };
 
 export const isVisible = (limitedApps, app, visibility) => {

--- a/src/js/nav/globalNav.test.js
+++ b/src/js/nav/globalNav.test.js
@@ -87,7 +87,7 @@ describe('global nav with API restricted sub items', () => {
       { id: 'sub-app-two', title: 'sub-app-two' },
     ];
     axiosSpy.mockImplementationOnce(() => Promise.resolve(true));
-    const nav = await navFunctions.getNavFromConfig(mockAsyncNavDefinition);
+    const nav = await navFunctions.getNavFromConfig(mockAsyncNavDefinition, 'asyncApp');
     expect(nav.asyncApp.routes).toEqual(expectedRoutes);
     expect(axiosSpy).toHaveBeenCalledWith({ foo: 'bar', method: 'GET', url: '/request/url' });
   });
@@ -95,7 +95,7 @@ describe('global nav with API restricted sub items', () => {
   test('should not display sub item with negative API response', async () => {
     const expectedRoutes = [{ id: 'sub-app-two', title: 'sub-app-two' }];
     axiosSpy.mockImplementationOnce(() => Promise.resolve(false));
-    const nav = await navFunctions.getNavFromConfig(mockAsyncNavDefinition);
+    const nav = await navFunctions.getNavFromConfig(mockAsyncNavDefinition, 'asyncApp');
     expect(nav.asyncApp.routes).toEqual(expectedRoutes);
     expect(axiosSpy).toHaveBeenCalledWith({ foo: 'bar', method: 'GET', url: '/request/url' });
   });

--- a/src/js/nav/globalNav.test.js
+++ b/src/js/nav/globalNav.test.js
@@ -1,6 +1,8 @@
 const masterConfig = require('../../../testdata/masterConfig.json');
 const masterConfigPermissions = require('../../../testdata/masterConfigPermissions.json');
 const navFunctions = require('./globalNav');
+
+import * as instance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
 // eslint-disable-next-line max-len
 const globalNav = {
   appA: { title: 'title1', ignoreCase: undefined, id: 'appA', routes: [{ id: 'subid1', ignoreCase: undefined, title: 'subtitle1' }] },
@@ -45,5 +47,55 @@ describe('globalNav with permissions', () => {
 
   test('appG, should have empty navigation', () => {
     expect(calculatedNav.appG).not.toBeDefined();
+  });
+});
+
+describe('global nav with API restricted sub items', () => {
+  const axiosSpy = jest.spyOn(instance, 'default');
+  const mockAsyncNavDefinition = {
+    asyncApp: {
+      top_level: 'top-level',
+      frontend: {
+        title: 'async-app',
+        sub_apps: [
+          {
+            id: 'sub-app-one',
+            title: 'sub-app-one',
+            permissions: {
+              method: 'apiRequest',
+              args: [{ url: '/request/url', foo: 'bar' }],
+            },
+          },
+          {
+            id: 'sub-app-two',
+            title: 'sub-app-two',
+          },
+        ],
+      },
+      title: 'appF',
+    },
+  };
+
+  afterEach(() => {
+    axiosSpy.mockReset();
+  });
+
+  test('should display sub item with positive API response', async () => {
+    const expectedRoutes = [
+      { id: 'sub-app-one', title: 'sub-app-one' },
+      { id: 'sub-app-two', title: 'sub-app-two' },
+    ];
+    axiosSpy.mockImplementationOnce(() => Promise.resolve(true));
+    const nav = await navFunctions.getNavFromConfig(mockAsyncNavDefinition);
+    expect(nav.asyncApp.routes).toEqual(expectedRoutes);
+    expect(axiosSpy).toHaveBeenCalledWith({ foo: 'bar', method: 'GET', url: '/request/url' });
+  });
+
+  test('should not display sub item with negative API response', async () => {
+    const expectedRoutes = [{ id: 'sub-app-two', title: 'sub-app-two' }];
+    axiosSpy.mockImplementationOnce(() => Promise.resolve(false));
+    const nav = await navFunctions.getNavFromConfig(mockAsyncNavDefinition);
+    expect(nav.asyncApp.routes).toEqual(expectedRoutes);
+    expect(axiosSpy).toHaveBeenCalledWith({ foo: 'bar', method: 'GET', url: '/request/url' });
   });
 });


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-9479

I have added two there are two options:
- Each item can use the `apiRequest` API call to check its visibility
- The root item can have a dynamic attribute. That will make an API call and expects the resolved value to be a partial nav schema.
  - I don't think that this option is reasonable because it will make a mess in the navigation, but it's still an option

Even if we delete the second option I would still like to keep the nav item extracted into a separate component because it will save us some rendering cycles.

I have also changed the nav keys to be the actual id, not the array index. Again that should give react better change to prevent unnecessary renders.

### TODO
- [x] docs