### PR TITLE
Enable global filter everywhere

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -5,9 +5,7 @@ import GlobalFilter from './GlobalFilter';
 
 const RootApp = ({ activeApp, activeLocation, appId, pageAction, pageObjectId, globalFilterHidden }) => {
   const isGlobalFilterEnabled =
-    !globalFilterHidden &&
-    (window?.insights?.chrome?.isBeta() || Boolean(localStorage.getItem('chrome:experimental:global-filter'))) &&
-    activeLocation === 'insights';
+    (!globalFilterHidden && activeLocation === 'insights') || Boolean(localStorage.getItem('chrome:experimental:global-filter'));
   return (
     <Fragment>
       <div


### PR DESCRIPTION
### Enable global filter on each eanvironmenr

With upcomming date of global filter release we have to remove the `isBeta` check and just show this filter on each page that isn't hiding it.