### PR TITLE
Calculate only currently observed nav

### DIFF
--- a/src/js/nav/globalNav.test.js
+++ b/src/js/nav/globalNav.test.js
@@ -8,42 +8,43 @@ const globalNav = {
 
 describe('globalNav', () => {
   test('should work as expected', async () => {
-    expect(await navFunctions.getNavFromConfig(masterConfig)).toEqual(globalNav);
+    expect(await navFunctions.getNavFromConfig(masterConfig, 'appA')).toEqual(globalNav);
   });
 });
 
 describe('globalNav with permissions', () => {
-  let calculatedNav;
-  beforeAll(async () => {
-    calculatedNav = await navFunctions.getNavFromConfig(masterConfigPermissions);
-  });
-
-  test('appA', () => {
+  test('appA', async () => {
+    const calculatedNav = await navFunctions.getNavFromConfig(masterConfigPermissions, 'appA');
     expect(calculatedNav.appA.routes.length).toBe(1);
     expect(calculatedNav.appA.routes[0].id).toBe('subid2');
   });
 
-  test('appB', () => {
+  test('appB', async () => {
+    const calculatedNav = await navFunctions.getNavFromConfig(masterConfigPermissions, 'appB');
     expect(calculatedNav.appB.routes.length).toBe(1);
     expect(calculatedNav.appB.routes[0].id).toBe('subid1');
   });
 
-  test('appC', () => {
+  test('appC', async () => {
+    const calculatedNav = await navFunctions.getNavFromConfig(masterConfigPermissions, 'appC');
     expect(calculatedNav.appC.routes.length).toBe(1);
     expect(calculatedNav.appC.routes[0].id).toBe('subid2');
   });
 
-  test('appD', () => {
+  test('appD', async () => {
+    const calculatedNav = await navFunctions.getNavFromConfig(masterConfigPermissions, 'appD');
     expect(calculatedNav.appD.routes.length).toBe(2);
     expect(calculatedNav.appD.routes[0].id).toBe('subid1');
     expect(calculatedNav.appD.routes[1].id).toBe('insights');
   });
 
-  test('appF', () => {
+  test('appF', async () => {
+    const calculatedNav = await navFunctions.getNavFromConfig(masterConfigPermissions, 'appF');
     expect(calculatedNav.appF).not.toBeDefined();
   });
 
-  test('appG, should have empty navigation', () => {
+  test('appG, should have empty navigation', async () => {
+    const calculatedNav = await navFunctions.getNavFromConfig(masterConfigPermissions, 'appG');
     expect(calculatedNav.appG).not.toBeDefined();
   });
 });


### PR DESCRIPTION
### No need to calculate nav of other bundles

When user is in one bundle navigation is also calculated for other bundle, this is not correct as it can make the navigation loading slow and unresponsive. This PR calculates only currently observed navigation and further reduces rendering of navigation. This is really obvious if you directly hit any URL without any cache. Once you navigate between apps it's not so obvious as we are using cached navigation.

### Allow passing array of permissions

Some apps might require multiple checks before rendering navigation items so we have to check if permissions is array and not to wrap it in another array.