### PR TITLE
Allow tags bookmarking trough hash value of location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3450,9 +3450,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "2.4.22",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.4.22.tgz",
-      "integrity": "sha512-MAzHDbyQmmUoOcx3rTIGHyLhPpE/XxfncJudEVEdPAXYB963zW+anPc+rTwJ06FXhmQ+ZaxHQzVrwNEy0kbjUw==",
+      "version": "2.4.23",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.4.23.tgz",
+      "integrity": "sha512-QJ/Tg0HgmSAA+URb26MQLmXO4wfExyyxUGtK+ZdTn+GwdNs/4Vv/TeGXw0jTNf12iROGJYbx9sb+SW9YzpdsmA==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0"

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@patternfly/react-icons": "^4.7.6",
     "@patternfly/react-table": "^4.16.20",
     "@redhat-cloud-services/entitlements-client": "^1.0.75",
-    "@redhat-cloud-services/frontend-components": "^2.4.22",
+    "@redhat-cloud-services/frontend-components": "^2.4.23",
     "@redhat-cloud-services/frontend-components-inventory": "^2.4.27",
     "@redhat-cloud-services/frontend-components-inventory-compliance": "^2.2.10",
     "@redhat-cloud-services/frontend-components-inventory-general-info": "^2.2.6",


### PR DESCRIPTION
### Update hash of location

In order to allow users to bookmark global filter values with tags and SIDs we have to update storing and retrieving value for it. This PR adds new function to build filtered by from array of strings and retrieves this value from URL hash. When no tags or SIDs are applied they are still present in the URL so we have backwards compatibility and allow sending URLs with empty SIDs/tags.

* only workloads hash = `#workloads=All+workloads&SIDs=&tags=`
* workloads and SIDs = `#workloads=All+workloads&SIDs=ABC&tags=`
* workloads and tags = `#workloads=All+workloads&SIDs=&tags=null%2Ftest-tag-total-04c40dec-58f0-4d54-a4a4-d391bc64da8e-0`
* workloads + tags + SIDs = `#workloads=All+workloads&SIDs=ABC&tags=null%2Ftest-tag-total-04c40dec-58f0-4d54-a4a4-d391bc64da8e-0`