### PR TITLE
send the hash to the env instead

### DIFF
--- a/src/js/createCase.js
+++ b/src/js/createCase.js
@@ -59,7 +59,7 @@ export async function createSupportCase(userInfo, fields) {
       },
       sessionDetails: {
         createdBy: `${userInfo.user.username}`,
-        environment: `${window.insights.chrome.isBeta() ? 'Production Beta' : 'Production'}, ${currentHash}`,
+        environment: `Production ${window.insights.chrome.isBeta() ? 'Beta' : ''}, ${currentHash}`,
         ...(currentProduct && { product: currentProduct }),
         ...fields?.caseFields,
       },

--- a/src/js/createCase.js
+++ b/src/js/createCase.js
@@ -59,8 +59,7 @@ export async function createSupportCase(userInfo, fields) {
       },
       sessionDetails: {
         createdBy: `${userInfo.user.username}`,
-        environment: `${window.insights.chrome.isBeta() ? 'Production Beta' : 'Production'}`,
-        description: `${currentHash}`,
+        environment: `${window.insights.chrome.isBeta() ? 'Production Beta' : 'Production'}, ${currentHash}`,
         ...(currentProduct && { product: currentProduct }),
         ...fields?.caseFields,
       },

--- a/src/js/createCase.js
+++ b/src/js/createCase.js
@@ -59,7 +59,7 @@ export async function createSupportCase(userInfo, fields) {
       },
       sessionDetails: {
         createdBy: `${userInfo.user.username}`,
-        environment: `Production ${window.insights.chrome.isBeta() ? ' Beta' : ''}, ${currentHash}`,
+        environment: `Production${window.insights.chrome.isBeta() ? ' Beta' : ''}, ${currentHash}`,
         ...(currentProduct && { product: currentProduct }),
         ...fields?.caseFields,
       },

--- a/src/js/createCase.js
+++ b/src/js/createCase.js
@@ -59,7 +59,7 @@ export async function createSupportCase(userInfo, fields) {
       },
       sessionDetails: {
         createdBy: `${userInfo.user.username}`,
-        environment: `Production ${window.insights.chrome.isBeta() ? 'Beta' : ''}, ${currentHash}`,
+        environment: `Production ${window.insights.chrome.isBeta() ? ' Beta' : ''}, ${currentHash}`,
         ...(currentProduct && { product: currentProduct }),
         ...fields?.caseFields,
       },


### PR DESCRIPTION
Support webpage removes the "description" information on page load, so i'll just move that info over to the env (which doesn't get overwritten) instead