### PR TITLE
Fix inventory routing.

### DIFF
--- a/src/js/inventory/modules/AsyncInventory.js
+++ b/src/js/inventory/modules/AsyncInventory.js
@@ -4,7 +4,7 @@ import setDependencies from '../../externalDependencies';
 import * as pfReact from '@patternfly/react-core';
 import * as pfReactTable from '@patternfly/react-table';
 import * as ReactRedux from 'react-redux';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import '../inventoryStyles';
 import { allDetails, drawer } from '../accountNumbers.json';
 


### PR DESCRIPTION
BrowserRouter **does not accept history prop**. It creates its own history via `history.createBrowserHisoty`. We have to use the default router and pass it history instance on our own,

Browser router is basically just a wrapper around this
```jsx
const history = history.createBrowserHisotry()

// ingores history prop
const BrowserRouter = ({children, basename}) => <Router basename={basename} history={history}>{children}</Router>
```

So we have to use the default router and configure it with a custom history instance.