### PR TITLE
Enable old apps within chrome 2.0

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -31,7 +31,6 @@ const plugins = [
       { 'react-router-dom': { singleton: true, requiredVersion: deps['react-router-dom'] } },
       { '@patternfly/react-table': { singleton: true } },
       { '@patternfly/react-core': { singleton: true } },
-      { 'react-redux': { singleton: true } },
     ],
   }),
   ChunkMapper,

--- a/src/js/App/GlobalFilter/tagsApi.js
+++ b/src/js/App/GlobalFilter/tagsApi.js
@@ -2,9 +2,24 @@
 import instance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
 import { flatTags, INVENTORY_API_BASE } from './constants';
 import { TagsApi, SapSystemApi } from '@redhat-cloud-services/host-inventory-client';
-import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 export const tags = new TagsApi(undefined, INVENTORY_API_BASE, instance);
 export const sap = new SapSystemApi(undefined, INVENTORY_API_BASE, instance);
+
+/**
+ * This has to be pulled out of FEC for a while until we split react and non react helper functions
+ */
+export const generateFilter = (data, path = 'filter', options) =>
+  Object.entries(data || {}).reduce((acc, [key, value]) => {
+    const newPath = `${path || ''}[${key}]${Array.isArray(value) ? `${options?.arrayEnhancer ? `[${options.arrayEnhancer}]` : ''}[]` : ''}`;
+    if (value instanceof Function || value instanceof Date) {
+      return acc;
+    }
+
+    return {
+      ...acc,
+      ...(Array.isArray(value) || typeof value !== 'object' ? { [newPath]: value } : generateFilter(value, newPath, options)),
+    };
+  }, {});
 
 const buildFilter = (workloads, SID) => ({
   system_profile: {

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -1,34 +1,3 @@
-import auth from './auth';
-import analytics from './analytics';
-import sentry from './sentry';
-import { rootApp, noAccess } from './chrome/entry';
-import createChromeInstance from './chrome/create-chrome';
-import registerUrlObserver from './url-observer';
-
-// start auth asap
-const libjwt = auth();
-
-function noop() {}
-
+import renderChrome from './chrome/render-chrome';
 // render root app
-rootApp();
-
-libjwt.initPromise.then(() => {
-  libjwt.jwt
-    .getUserInfo()
-    .then((...data) => {
-      analytics(...data);
-      sentry(...data);
-      noAccess();
-    })
-    .catch(noop);
-});
-
-window.insights = window.insights || {};
-
-window.insights = createChromeInstance(libjwt, window.insights);
-
-if (typeof _satellite !== 'undefined' && typeof window._satellite.pageBottom === 'function') {
-  window._satellite.pageBottom();
-  registerUrlObserver(window._satellite.pageBottom);
-}
+renderChrome();

--- a/src/js/chrome.js
+++ b/src/js/chrome.js
@@ -1,4 +1,34 @@
+import auth from './auth';
+import analytics from './analytics';
+import sentry from './sentry';
+import createChromeInstance from './chrome/create-chrome';
+import registerUrlObserver from './url-observer';
+
+// start auth asap
+const libjwt = auth();
+
+function noop() {}
+
 //Add redhat font to body
 document.querySelector('body').classList.add('pf-m-redhat-font');
+
+libjwt.initPromise.then(() => {
+  libjwt.jwt
+    .getUserInfo()
+    .then((...data) => {
+      analytics(...data);
+      sentry(...data);
+    })
+    .catch(noop);
+});
+
+window.insights = window.insights || {};
+
+window.insights = createChromeInstance(libjwt, window.insights);
+
+if (typeof _satellite !== 'undefined' && typeof window._satellite.pageBottom === 'function') {
+  window._satellite.pageBottom();
+  registerUrlObserver(window._satellite.pageBottom);
+}
 
 import('./bootstrap');

--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -1,13 +1,7 @@
-import React from 'react';
-import * as ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
 import { globalFilterScope, toggleGlobalFilter } from '../redux/actions';
 import { spinUpStore } from '../redux-config';
-import loadInventory from '../inventory/index';
-import loadRemediations from '../remediations';
 import qe from './iqeEnablement';
 import consts from '../consts';
-import RootApp from '../App/RootApp';
 import { visibilityFunctions } from '../consts';
 import Cookies from 'js-cookie';
 import { getUrl } from '../utils';
@@ -103,36 +97,6 @@ export function bootstrap(libjwt, initFunc, getUser) {
       visibilityFunctions,
       init: initFunc,
     },
-    loadInventory,
-    experimental: {
-      loadRemediations,
-    },
+    experimental: {},
   };
-}
-
-const App = () => {
-  const config = {
-    advisor: {
-      name: 'advisor',
-      manifestLocation: `${window.location.origin}/apps/advisor/fed-mods.json`,
-    },
-    chrome: {
-      name: 'chrome',
-      manifestLocation: `${window.location.origin}/apps/chrome/js/fed-mods.json`,
-    },
-  };
-  return <RootApp config={config} />;
-};
-
-export function rootApp() {
-  const { store } = spinUpStore();
-  const pageRoot = document.querySelector('.pf-c-page__drawer');
-  if (pageRoot) {
-    ReactDOM.render(
-      <Provider store={store}>
-        <App />
-      </Provider>,
-      pageRoot
-    );
-  }
 }

--- a/src/js/chrome/render-chrome.js
+++ b/src/js/chrome/render-chrome.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { spinUpStore } from '../redux-config';
+import RootApp from '../App/RootApp';
+
+import loadInventory from '../inventory/index';
+import loadRemediations from '../remediations';
+
+/**
+ * This has to be posponed in order to let shared react modules to initialize
+ */
+window.insights.loadInventory = loadInventory;
+window.insights.experimental.loadRemediations = loadRemediations;
+
+const App = () => {
+  const config = {
+    advisor: {
+      name: 'advisor',
+      manifestLocation: `${window.location.origin}/apps/advisor/fed-mods.json`,
+    },
+    chrome: {
+      name: 'chrome',
+      manifestLocation: `${window.location.origin}/apps/chrome/js/fed-mods.json`,
+    },
+  };
+  return <RootApp config={config} />;
+};
+
+function renderChrome() {
+  const { store } = spinUpStore();
+  const pageRoot = document.querySelector('.pf-c-page__drawer');
+  if (pageRoot) {
+    ReactDOM.render(
+      <Provider store={store}>
+        <App />
+      </Provider>,
+      pageRoot
+    );
+  }
+}
+
+export default renderChrome;

--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -78,6 +78,7 @@ async function getAppData(appId, propName, masterConfig) {
     return {
       title: app.frontend.title || app.title,
       ignoreCase: app.ignoreCase,
+      ...(app?.frontend?.module && { module: app.frontend.module }),
       ...(!app.frontend.suppress_id && { id: appId }),
       ...(app.frontend.reload && { reload: app.frontend.reload }),
       ...(routes?.length > 0 && { [propName]: routes }),

--- a/src/js/redux/action-types.js
+++ b/src/js/redux/action-types.js
@@ -7,6 +7,7 @@ export const CLEAR_ACTIVE = '@@chrome/app-clear-active';
 
 export const GLOBAL_NAV_IDENT = '@@chrome/identify-app';
 export const CHROME_NAV_UPDATE = '@@chrome/app-nav-update';
+export const CHROME_NAV_SECTION_UPDATE = '@@chrome/nav-section-update';
 
 export const CHROME_PAGE_ACTION = '@@chrome/app-page-action';
 export const CHROME_PAGE_OBJECT = '@@chrome/app-object-id';

--- a/src/js/redux/actions.js
+++ b/src/js/redux/actions.js
@@ -52,6 +52,10 @@ export function chromeNavUpdate(newNav) {
   return { type: actionTypes.CHROME_NAV_UPDATE, payload: newNav };
 }
 
+export function chromeNavSectionUpdate(newSection) {
+  return { type: actionTypes.CHROME_NAV_SECTION_UPDATE, payload: newSection };
+}
+
 export function appAction(action) {
   return { type: actionTypes.CHROME_PAGE_ACTION, payload: action };
 }

--- a/src/js/redux/index.js
+++ b/src/js/redux/index.js
@@ -10,6 +10,7 @@ import {
   navUpdateReducer,
   onPageAction,
   onPageObjectId,
+  navUpdateSection,
 } from './reducers';
 import {
   onGetAllTags,
@@ -38,6 +39,7 @@ import {
   GLOBAL_FILTER_SCOPE,
   GLOBAL_FILTER_TOGGLE,
   GLOBAL_FILTER_UPDATE,
+  CHROME_NAV_SECTION_UPDATE,
 } from './action-types';
 
 const reducers = {
@@ -48,6 +50,7 @@ const reducers = {
   [NAVIGATION_TOGGLE]: navToggleReducer,
   [USER_LOGIN]: loginReducer,
   [CHROME_NAV_UPDATE]: navUpdateReducer,
+  [CHROME_NAV_SECTION_UPDATE]: navUpdateSection,
   [CHROME_PAGE_ACTION]: onPageAction,
   [CHROME_PAGE_OBJECT]: onPageObjectId,
 };

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -34,10 +34,21 @@ export function navUpdateReducer(state, { payload: { activeSection, globalNav, .
   return {
     ...state,
     ...payload,
+    activeSection,
     globalNav: globalNav.map((app) => ({
       ...app,
       active: activeSection && (app.title === activeSection.title || app.id === activeSection.id),
     })),
+  };
+}
+
+export function navUpdateSection(state, { payload }) {
+  if (!payload) {
+    return state;
+  }
+  return {
+    ...state,
+    activeSection: payload,
   };
 }
 

--- a/src/pug/body.pug
+++ b/src/pug/body.pug
@@ -9,3 +9,9 @@ div.pf-c-page.pf-m-redhat-font#page
                 .ins-c-spinner.ins-m-center(role='status')
                     span(class="pf-u-screen-reader") Loading...
 include after.pug
+
+main(
+    id="root"
+    role="main"
+    hidden="true"
+)


### PR DESCRIPTION
Example of remote module config: https://github.com/RedHatInsights/cloud-services-config/pull/317
I fully expect it to change

### How does this work?
- thanks to webpack module sharing, chrome render is now always slower than legacy app render, therefore the app root element does not exist when the app tries to render. We need to dot his
   1. provide hidden HTML element statically to HTML template to serve as the app root
   2. once the chrome is rendered get the element
   3. remove the hidden property and inject it into the chrome scaffolding

### Chrome bootstrap split
In order to successfully load chrome, we need to
  - make sure that any there are no references to any of the shared modules before the async `import('./bootstrap')`
  - move the `createFilter` helper function to chrome codebase because the library helper file is referencing react
  - move the `loadInventory` and `loadRemediations` to the **bootstrap** file because they are referencing shared modules
  - stop sharing redux as it's crucial to have chrome store ASAP (we might change it in the future)

### Result
Chrome can now run both legacy apps and chrome 2.0 ready apps :tada: 