### PR TITLE
Enable client side navigation between apps.

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -20,6 +20,7 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
     if (!remoteModule) {
       insightsContentRef.current.appendChild(contentElement);
       contentElement.hidden = false;
+      contentElement.style.display = 'initial';
     } else {
       contentElement.hidden = true;
       try {
@@ -49,7 +50,8 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
               <main role="main">
                 {typeof remoteModule !== 'undefined' && scalprum.initialized ? (
                   <ErrorBoundary>
-                    <ScalprumComponent {...remoteModule} />
+                    {/* Slcaprum component does not react on config changes. Hack it with key to force new instance until that is enabled. */}
+                    <ScalprumComponent key={remoteModule.appName} {...remoteModule} />
                   </ErrorBoundary>
                 ) : (
                   <Bullseye className="pf-u-p-xl">

--- a/src/js/App/Sidenav/ExpandableNav.js
+++ b/src/js/App/Sidenav/ExpandableNav.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { NavExpandable } from '@patternfly/react-core/dist/js/components/Nav/NavExpandable';
+import { NavExpandable } from '@patternfly/react-core';
 import NavigationItem from './NavigationItem';
 
 const ExpandableNav = ({ subItems, onClick, title, id, active, ignoreCase, activeLocation, activeApp }) => {

--- a/src/js/chrome/render-chrome.js
+++ b/src/js/chrome/render-chrome.js
@@ -19,6 +19,10 @@ const App = () => {
       name: 'advisor',
       manifestLocation: `${window.location.origin}/apps/advisor/fed-mods.json`,
     },
+    inventory: {
+      name: 'inventory',
+      manifestLocation: `${window.location.origin}/apps/inventory/fed-mods.json`,
+    },
     chrome: {
       name: 'chrome',
       manifestLocation: `${window.location.origin}/apps/chrome/js/fed-mods.json`,

--- a/src/pug/body.pug
+++ b/src/pug/body.pug
@@ -14,4 +14,5 @@ main(
     id="root"
     role="main"
     hidden="true"
+    style="display: none"
 )


### PR DESCRIPTION
### Changes
- allow client side navigation between chrome 2.0 ready apps
- back browser button (history pop method) is still doing a full page refresh
  - caused by initial app nav click which disrupts the history flow

back button routing scenario

```
# initial history events
/advisor -> automaticly to /advisor/recomendations -> automatically to /advisor/recomendations?somequery
# after browser back button
/advisor/recomendations?somequery -> /advisor/recomendations
# after browser back button
/advisor/recomendations -> /advisor
# unknown route is caught by advisor and redirected to fallback route
/advisor -> automaticly to /advisor/recomendations -> automatically to /advisor/recomendations?somequery
```
Now you are caught in an infinite back loop.

#### How to fix this in the future?
- don't use fallback routes in apps `<Route>...<` or `<Route path="*">..</`
- don't use `push` but `replace` method for fallback routes in apps (prefferable option)

### demo
- the dashboard is a legacy app
- advisor and inventory are chrome 2 ready

![chrome2 0-routing](https://user-images.githubusercontent.com/22619452/100364219-1aa2af00-2ffe-11eb-9b00-02059b7b4306.gif)
