### PR TITLE
Reconfigures insights documentation link as per bu request 🙇🏽💋🦾

### DIFF
--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -1,14 +1,15 @@
-import React from 'react';
-import { Nav } from '@patternfly/react-core/dist/js/components/Nav/Nav';
+import './Navigation.scss';
+
+import { Nav, NavExpandable } from '@patternfly/react-core/dist/js/components/Nav/index';
+import { appNavClick, clearActive } from '../../redux/actions';
+
+import ExpandableNav from './ExpandableNav';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { NavItem } from '@patternfly/react-core/dist/js/components/Nav/NavItem';
 import { NavList } from '@patternfly/react-core/dist/js/components/Nav/NavList';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
-import { appNavClick, clearActive } from '../../redux/actions';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-
-import './Navigation.scss';
-import ExpandableNav from './ExpandableNav';
 
 const basepath = document.baseURI;
 
@@ -20,10 +21,14 @@ const extraLinks = {
       link: './subscriptions/',
     },
     {
-      id: 'extra-docs',
-      url: 'https://access.redhat.com/documentation/en-us/red_hat_insights/',
+      expandable: true,
+      id: 'extra-expandable-docs',
       title: 'Documentation',
-      external: true,
+      subItems: [
+        { id: 'extra-docs', url: 'https://access.redhat.com/documentation/en-us/red_hat_insights/', title: 'Product Documentation', external: true },
+        { id: 'extra-security', url: './security/insights', title: 'Security' },
+        { id: 'extra-docs', url: './docs/api', title: 'APIs' },
+      ],
     },
   ],
   subscriptions: [
@@ -75,6 +80,20 @@ const extraLinks = {
   ],
 };
 
+const NavItemLink = ({ id, title, external, url, link }) => (
+  <NavItem className="ins-c-navigation__additional-links" key={id} to={url || link} ouiaId={id}>
+    {title} {external && <ExternalLinkAltIcon />}
+  </NavItem>
+);
+
+NavItemLink.propTypes = {
+  id: PropTypes.string,
+  title: PropTypes.string,
+  url: PropTypes.string,
+  external: PropTypes.bool,
+  link: PropTypes.string,
+};
+
 export const Navigation = ({ settings, activeApp, activeLocation, onNavigate, onClearActive, activeGroup, appId }) => {
   const onClick = (event, item, parent) => {
     const isMetaKey = event.ctrlKey || event.metaKey || event.which === 2;
@@ -117,18 +136,17 @@ export const Navigation = ({ settings, activeApp, activeLocation, onNavigate, on
             onClick={(event, subItem) => (item.subItems ? onClick(event, subItem, item) : onClick(event, item))}
           />
         ))}
-        {extraLinks[activeLocation]?.map?.((item) => (
-          <NavItem
-            className="ins-c-navigation__additional-links"
-            key={item.id}
-            to={item.url || item.link}
-            ouiaId={item.id}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {item.title} {item.external && <ExternalLinkAltIcon />}
-          </NavItem>
-        ))}
+        {extraLinks[activeLocation]?.map?.((item) =>
+          item?.expandable && activeLocation === 'insights' ? (
+            <NavExpandable title={item.title}>
+              {item?.subItems?.map((item) => (
+                <NavItemLink key={item.id} {...item} />
+              ))}
+            </NavExpandable>
+          ) : (
+            <NavItemLink key={item.id} {...item} />
+          )
+        )}
       </NavList>
     </Nav>
   );

--- a/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/Navigation.test.js.snap
@@ -687,130 +687,143 @@ exports[`Navigation should render corectly 1`] = `
               </NavItem>
             </NavigationItem>
           </ExpandableNav>
-          <NavItem
-            className="ins-c-navigation__additional-links"
+          <NavItemLink
+            id="extra-openshift-support"
             key="extra-openshift-support"
-            ouiaId="extra-openshift-support"
-            rel="noopener noreferrer"
-            target="_blank"
-            to="https://access.redhat.com/support/cases"
+            link="https://access.redhat.com/support/cases"
+            title="Support Cases"
           >
-            <li
-              className="pf-c-nav__item ins-c-navigation__additional-links"
+            <NavItem
+              className="ins-c-navigation__additional-links"
+              key="extra-openshift-support"
+              ouiaId="extra-openshift-support"
+              to="https://access.redhat.com/support/cases"
             >
-              <a
-                aria-current={null}
-                className="pf-c-nav__link ins-c-navigation__additional-links"
-                href="https://access.redhat.com/support/cases"
-                onClick={[Function]}
-                ouiaId="extra-openshift-support"
-                rel="noopener noreferrer"
-                target="_blank"
+              <li
+                className="pf-c-nav__item ins-c-navigation__additional-links"
               >
-                Support Cases
-                 
-              </a>
-            </li>
-          </NavItem>
-          <NavItem
-            className="ins-c-navigation__additional-links"
-            key="extra-openshift-cm"
-            ouiaId="extra-openshift-cm"
-            rel="noopener noreferrer"
-            target="_blank"
-            to="mailto:ocm-feedback@redhat.com"
-          >
-            <li
-              className="pf-c-nav__item ins-c-navigation__additional-links"
-            >
-              <a
-                aria-current={null}
-                className="pf-c-nav__link ins-c-navigation__additional-links"
-                href="mailto:ocm-feedback@redhat.com"
-                onClick={[Function]}
-                ouiaId="extra-openshift-cm"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Cluster Manager Feedback
-                 
-              </a>
-            </li>
-          </NavItem>
-          <NavItem
-            className="ins-c-navigation__additional-links"
-            key="extra-openshift-marketplace"
-            ouiaId="extra-openshift-marketplace"
-            rel="noopener noreferrer"
-            target="_blank"
-            to="https://marketplace.redhat.com"
-          >
-            <li
-              className="pf-c-nav__item ins-c-navigation__additional-links"
-            >
-              <a
-                aria-current={null}
-                className="pf-c-nav__link ins-c-navigation__additional-links"
-                href="https://marketplace.redhat.com"
-                onClick={[Function]}
-                ouiaId="extra-openshift-marketplace"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Red Hat Marketplace
-                 
-              </a>
-            </li>
-          </NavItem>
-          <NavItem
-            className="ins-c-navigation__additional-links"
-            key="extra-openshift-docs"
-            ouiaId="extra-openshift-docs"
-            rel="noopener noreferrer"
-            target="_blank"
-            to="https://docs.openshift.com/dedicated/4/"
-          >
-            <li
-              className="pf-c-nav__item ins-c-navigation__additional-links"
-            >
-              <a
-                aria-current={null}
-                className="pf-c-nav__link ins-c-navigation__additional-links"
-                href="https://docs.openshift.com/dedicated/4/"
-                onClick={[Function]}
-                ouiaId="extra-openshift-docs"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Documentation
-                 
-                <ExternalLinkAltIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
+                <a
+                  aria-current={null}
+                  className="pf-c-nav__link ins-c-navigation__additional-links"
+                  href="https://access.redhat.com/support/cases"
+                  onClick={[Function]}
+                  ouiaId="extra-openshift-support"
                 >
-                  <svg
-                    aria-hidden={true}
-                    aria-labelledby={null}
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style={
-                      Object {
-                        "verticalAlign": "-0.125em",
-                      }
-                    }
-                    viewBox="0 0 512 512"
-                    width="1em"
+                  Support Cases
+                   
+                </a>
+              </li>
+            </NavItem>
+          </NavItemLink>
+          <NavItemLink
+            id="extra-openshift-cm"
+            key="extra-openshift-cm"
+            link="mailto:ocm-feedback@redhat.com"
+            title="Cluster Manager Feedback"
+          >
+            <NavItem
+              className="ins-c-navigation__additional-links"
+              key="extra-openshift-cm"
+              ouiaId="extra-openshift-cm"
+              to="mailto:ocm-feedback@redhat.com"
+            >
+              <li
+                className="pf-c-nav__item ins-c-navigation__additional-links"
+              >
+                <a
+                  aria-current={null}
+                  className="pf-c-nav__link ins-c-navigation__additional-links"
+                  href="mailto:ocm-feedback@redhat.com"
+                  onClick={[Function]}
+                  ouiaId="extra-openshift-cm"
+                >
+                  Cluster Manager Feedback
+                   
+                </a>
+              </li>
+            </NavItem>
+          </NavItemLink>
+          <NavItemLink
+            id="extra-openshift-marketplace"
+            key="extra-openshift-marketplace"
+            link="https://marketplace.redhat.com"
+            title="Red Hat Marketplace"
+          >
+            <NavItem
+              className="ins-c-navigation__additional-links"
+              key="extra-openshift-marketplace"
+              ouiaId="extra-openshift-marketplace"
+              to="https://marketplace.redhat.com"
+            >
+              <li
+                className="pf-c-nav__item ins-c-navigation__additional-links"
+              >
+                <a
+                  aria-current={null}
+                  className="pf-c-nav__link ins-c-navigation__additional-links"
+                  href="https://marketplace.redhat.com"
+                  onClick={[Function]}
+                  ouiaId="extra-openshift-marketplace"
+                >
+                  Red Hat Marketplace
+                   
+                </a>
+              </li>
+            </NavItem>
+          </NavItemLink>
+          <NavItemLink
+            external={true}
+            id="extra-openshift-docs"
+            key="extra-openshift-docs"
+            title="Documentation"
+            url="https://docs.openshift.com/dedicated/4/"
+          >
+            <NavItem
+              className="ins-c-navigation__additional-links"
+              key="extra-openshift-docs"
+              ouiaId="extra-openshift-docs"
+              to="https://docs.openshift.com/dedicated/4/"
+            >
+              <li
+                className="pf-c-nav__item ins-c-navigation__additional-links"
+              >
+                <a
+                  aria-current={null}
+                  className="pf-c-nav__link ins-c-navigation__additional-links"
+                  href="https://docs.openshift.com/dedicated/4/"
+                  onClick={[Function]}
+                  ouiaId="extra-openshift-docs"
+                >
+                  Documentation
+                   
+                  <ExternalLinkAltIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
                   >
-                    <path
-                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                    />
-                  </svg>
-                </ExternalLinkAltIcon>
-              </a>
-            </li>
-          </NavItem>
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      />
+                    </svg>
+                  </ExternalLinkAltIcon>
+                </a>
+              </li>
+            </NavItem>
+          </NavItemLink>
         </ul>
       </NavList>
     </nav>
@@ -888,55 +901,31 @@ exports[`Navigation should render correctly 2 1`] = `
       onClick={[Function]}
       title="Remediations"
     />
-    <NavItem
-      className="ins-c-navigation__additional-links"
+    <NavItemLink
+      id="extra-openshift-support"
       key="extra-openshift-support"
-      ouiaId="extra-openshift-support"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="https://access.redhat.com/support/cases"
-    >
-      Support Cases
-       
-    </NavItem>
-    <NavItem
-      className="ins-c-navigation__additional-links"
+      link="https://access.redhat.com/support/cases"
+      title="Support Cases"
+    />
+    <NavItemLink
+      id="extra-openshift-cm"
       key="extra-openshift-cm"
-      ouiaId="extra-openshift-cm"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="mailto:ocm-feedback@redhat.com"
-    >
-      Cluster Manager Feedback
-       
-    </NavItem>
-    <NavItem
-      className="ins-c-navigation__additional-links"
+      link="mailto:ocm-feedback@redhat.com"
+      title="Cluster Manager Feedback"
+    />
+    <NavItemLink
+      id="extra-openshift-marketplace"
       key="extra-openshift-marketplace"
-      ouiaId="extra-openshift-marketplace"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="https://marketplace.redhat.com"
-    >
-      Red Hat Marketplace
-       
-    </NavItem>
-    <NavItem
-      className="ins-c-navigation__additional-links"
+      link="https://marketplace.redhat.com"
+      title="Red Hat Marketplace"
+    />
+    <NavItemLink
+      external={true}
+      id="extra-openshift-docs"
       key="extra-openshift-docs"
-      ouiaId="extra-openshift-docs"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="https://docs.openshift.com/dedicated/4/"
-    >
-      Documentation
-       
-      <ExternalLinkAltIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
-    </NavItem>
+      title="Documentation"
+      url="https://docs.openshift.com/dedicated/4/"
+    />
   </NavList>
 </Nav>
 `;


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ADVISOR-1510

tl;dr - swap documentation link for expandable nav, collapsed by default, the following links that open in new windows
1. original doc link
2. security link
3. api link

#### looks like
<img width="2048" alt="Screen Shot 2020-12-01 at 5 12 04 PM" src="https://user-images.githubusercontent.com/6640236/100803077-86b75580-33f8-11eb-808c-da76d2c77862.png">
<img width="320" alt="Screen Shot 2020-12-01 at 5 11 54 PM" src="https://user-images.githubusercontent.com/6640236/100803078-86b75580-33f8-11eb-9c99-45e9c5420921.png">
<img width="292" alt="Screen Shot 2020-12-01 at 5 11 48 PM" src="https://user-images.githubusercontent.com/6640236/100803079-874fec00-33f8-11eb-8378-81e9cd9aad20.png">
