### PR TITLE
Use adobe custom event instead of salite page bottom call.

### DIFF
--- a/src/js/chrome.js
+++ b/src/js/chrome.js
@@ -37,5 +37,5 @@ window.insights = createChromeInstance(libjwt, window.insights);
 
 if (typeof _satellite !== 'undefined' && typeof window._satellite.pageBottom === 'function') {
   window._satellite.pageBottom();
-  registerUrlObserver(window._satellite.pageBottom);
+  registerUrlObserver();
 }

--- a/src/js/url-observer.js
+++ b/src/js/url-observer.js
@@ -4,7 +4,7 @@
  * which are not using history go, push, pop functions that trigger popstate event.
  * @param {Function} observeCallback callback that will be triggered after URL change
  */
-const registerUrlObserver = (observeCallback) => {
+const registerUrlObserver = () => {
   /**
    * We ignore hash changes
    * Hashes only have frontend effect
@@ -16,9 +16,9 @@ const registerUrlObserver = (observeCallback) => {
     const observer = new MutationObserver(function (mutations) {
       mutations.forEach(function () {
         const newLocation = document.location.href.replace(/#.*$/, '');
-        if (oldHref !== newLocation) {
+        if (oldHref !== newLocation && window.sendCustomEvent) {
           oldHref = newLocation;
-          observeCallback();
+          window.sendCustomEvent('pageBottom');
         }
       });
     });


### PR DESCRIPTION
We have to use `sendCustomEvent('pageBottom')` to trigger the adobe analytics, not the `satellite.pageBottom` in the URL observer.
