### PR TITLE
Add data-ouia-safe on chrome init.

### DIFF
--- a/src/js/chrome/create-chrome.js
+++ b/src/js/chrome/create-chrome.js
@@ -32,6 +32,14 @@ const createChromeInstance = (jwt, insights) => {
   });
 
   const init = () => {
+    /**
+     * Mutate the root element to enable QA during app init.
+     * Previously was done from applications after react-dom render.
+     */
+    const rootEl = document.getElementById('root');
+    if (rootEl) {
+      rootEl.setAttribute('data-ouia-safe', true);
+    }
     window.insights.chrome = {
       ...window.insights.chrome,
       ...chromeInit(navResolver),


### PR DESCRIPTION
Chrome 2 compatible applications should not mutate any chrome "owned" elements. We are removing the code that does this while migrating apps.

The ouia safe attribute will be set for now inside the chrome init function, which every app has to call. In chrome 2.0 we can do this via react component lifecycle.