### PR TITLE
Add temporary chrome2 flag on window.

### DIFF
--- a/src/pug/templates/head-block.pug
+++ b/src/pug/templates/head-block.pug
@@ -5,3 +5,5 @@ link(rel="icon"  type="image/png" href="https://access.redhat.com/webassets/aval
 link(rel='stylesheet', href=`./apps/chrome/${ chromeCSS }`)
 //- Add sentry here so other apps can use it
 script(src="https://browser.sentry-cdn.com/5.15.0/bundle.min.js", crossorigin="anonymous")
+//- temporary flag to identify chrome 2. This us used by the application to prevent ReactDOM.render in migrated apps.
+<script type="text/javascript"> window.insights = {chrome: { isChrome2: true }} </script>


### PR DESCRIPTION
This flag is necessary for migrated applications to stop rendering the App via `ReactDOM.render`. It works with https://github.com/RedHatInsights/frontend-components/pull/813/commits/84b1d8fb41d10e7da4b4682a7ae2d18cd8824557 and gates the render call only for non-chrome2 shell.

This flag can be removed once chrome 2.0 is deployed in all envs.