### PR TITLE
Do not load nav config for unauthed user.

### DIFF
--- a/src/js/chrome/create-chrome.js
+++ b/src/js/chrome/create-chrome.js
@@ -26,9 +26,21 @@ const createChromeInstance = (jwt, insights) => {
    * Load navigation after login
    */
   const navResolver = jwtResolver.then(async () => {
+    const user = await libjwt.jwt.getUserInfo();
+    if (!user) {
+      /**
+       * Stop navigation loading and caching if there is no user logged in
+       */
+      return;
+    }
     const navigationYml = await sourceOfTruth(libjwt.jwt.getEncodedToken());
     const navigationData = await loadNav(navigationYml, chromeInstance.cache);
-    chromeNavUpdate(navigationData);
+    /**
+     * Prevent navigation caching if no cache exists
+     */
+    if (chromeInstance.cache) {
+      chromeNavUpdate(navigationData);
+    }
   });
 
   const init = () => {


### PR DESCRIPTION
@ryelo I got a question. Is this going to break openshift nav? Should we make an exception for that namepsace? I recall that even unauthed users can access the OCM.

jira: https://issues.redhat.com/browse/RHCLOUD-11627