### PR TITLE
Use full width for global filter

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -171,6 +171,7 @@ section.ins-c-app-switcher--loading {
         .pf-l-split__item:first-of-type { min-width: 150px;}
 
         .ins-c-tagfilter {
+        width: 100%;
         &.pf-m-expanded { width: 450px; }
         .pf-c-select__menu {
             max-height: 400px;


### PR DESCRIPTION
### UX required changes

We have to keep consistency between applications and the size of global filter, UX identified that the full width of global filter will be better for users.