### PR TITLE
Add app filter experimental enable function

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -2,9 +2,9 @@
 set -e
 set -x
 
-# for now in chrome... push everywhere when master updates
+# push to ci and qa when master merges
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
-    for env in ci #qa
+    for env in ci qa
     do
         echo
         echo

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Available function:
 - `remediationsDebug` - to enable debug buttons in remediations app
 - `shortSession` - to enable short session in order to test automatic logouts
 - `forcePendo` - to force Pendo initializtion
+- `appFilter` - to enable new application filter in any environment
 
 ## Futher reading
 

--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -21,6 +21,7 @@ global.window.insights = {
         isBeta: () => {
             return null;
         },
+        getEnvironment: () => 'test',
         isPenTest: () => false,
         isProd: false,
         auth: {

--- a/src/js/App/Header/Header.js
+++ b/src/js/App/Header/Header.js
@@ -6,11 +6,14 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import AppFilter from './AppFilter';
 
+const isFilterEnabled =
+  localStorage.getItem('chrome:experimental:app-filter') === 'true' || (insights.chrome.getEnvironment() === 'ci' && insights.chrome.isBeta());
+
 const Header = ({ user }) => {
   return user ? (
     <Fragment>
       <Brand />
-      {!window.insights.chrome.isProd && <AppFilter />}
+      {isFilterEnabled && <AppFilter />}
       <Tools />
     </Fragment>
   ) : (

--- a/src/js/debugFunctions.js
+++ b/src/js/debugFunctions.js
@@ -14,4 +14,5 @@ export default {
   allDetails: () => functionBuilder('chrome:inventory:experimental_detail', true),
   inventoryDrawer: () => functionBuilder('chrome:inventory:experimental_drawer', true),
   globalFilter: () => functionBuilder('chrome:experimental:global-filter', true),
+  appFilter: () => functionBuilder('chrome:experimental:app-filter', true),
 };


### PR DESCRIPTION
### App filter enablement

We don't want to change how we promote envs and cherry pick commits not related to appFilter, instead let's push appFilter code to any environment and just hide it behind feature flag. If you want to enable the appFilter for local development new enable function `insights.chrome.enable.appFilter` has been added.