### PR TITLE
Wrap store filter so it doesn't trigger when disabled

### DIFF
--- a/src/js/App/GlobalFilter/GlobalFilter.js
+++ b/src/js/App/GlobalFilter/GlobalFilter.js
@@ -35,7 +35,9 @@ const GlobalFilter = () => {
   const userLoaded = useSelector(({ chrome: { user } }) => Boolean(user));
   const filterScope = useSelector(({ globalFilter: { scope } }) => scope || undefined);
   const loadTags = (selectedTags, filterScope, filterTagsBy, token) => {
-    storeFilter(selectedTags, token);
+    if (isAllowed() && !isDisabled && userLoaded) {
+      storeFilter(selectedTags, token);
+    }
     batch(() => {
       dispatch(
         fetchAllTags({


### PR DESCRIPTION
### Global filter populates hash when disabled

When global filter is disabled it will mutate the hash partial of URL. We still want to preserve the localstorage save as users could have been navigated to this page trough direct link and navigating away can break the restoration of this filter from localStorage upon navigation change.