### PR TITLE
Add navigation to ci-beta landing page.

### DIFF
--- a/src/js/App/Header/AppFilter.js
+++ b/src/js/App/Header/AppFilter.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { safeLoad } from 'js-yaml';
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
 import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 import { Dropdown } from '@patternfly/react-core/dist/js/components/Dropdown/Dropdown';
@@ -17,13 +16,12 @@ import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
 
 import ansible from '../../../../static/images/landing-page-icons/ansible.svg';
 import costManagement from '../../../../static/images/landing-page-icons/cost-management.svg';
-import { getNavFromConfig } from '../../nav/globalNav';
 import migrationsNamespace from '../../../../static/images/landing-page-icons/migrations.svg';
 import openshift from '../../../../static/images/landing-page-icons/ocm.svg';
 import settings from '../../../../static/images/landing-page-icons/fa-cog.svg';
-import sourceOfTruth from '../../nav/sourceOfTruth';
 
 import './AppFilter.scss';
+import useGlobalNav from '../../utils/useGlobalNav';
 
 const getIcon = (id) =>
   ({
@@ -37,22 +35,10 @@ const getIcon = (id) =>
     subscriptions: <img src={`${insights.chrome.isBeta() ? '/beta' : ''}/apps/landing/fonts/Subscriptions.svg`} alt="Subscriptions Logo" />,
   }[id]);
 
-const appIds = ['insights', 'openshift', 'cost-management', 'migrations', 'subscriptions', 'ansible', 'settings'];
-
 const AppFilter = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [filterValue, setFilterValue] = useState('');
-  const [apps, setApps] = useState([]);
-  const [filteredApps, setFilteredApps] = useState([]);
-
-  useEffect(() => {
-    (async () => {
-      const navigationYml = await sourceOfTruth();
-      const appData = await getNavFromConfig(safeLoad(navigationYml), undefined);
-      setApps(appIds.map((id) => appData[id]));
-      setFilteredApps(appIds.map((id) => appData[id]));
-    })();
-  }, []);
+  const { apps, filteredApps, setFilteredApps } = useGlobalNav();
 
   useEffect(() => {
     setFilteredApps(

--- a/src/js/App/Header/Header.js
+++ b/src/js/App/Header/Header.js
@@ -5,9 +5,7 @@ import UnAuthtedHeader from './UnAuthtedHeader';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import AppFilter from './AppFilter';
-
-const isFilterEnabled =
-  localStorage.getItem('chrome:experimental:app-filter') === 'true' || (insights.chrome.getEnvironment() === 'ci' && insights.chrome.isBeta());
+import { isFilterEnabled } from '../../utils/isAppNavEnabled';
 
 const Header = ({ user }) => {
   return user ? (

--- a/src/js/App/Sidenav/LandingNav.js
+++ b/src/js/App/Sidenav/LandingNav.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Nav, NavExpandable, NavItem, NavList } from '@patternfly/react-core';
+import useGlobalNav from '../../utils/useGlobalNav';
+import { isBeta } from '../../utils';
+import NavLoader from './Loader';
+import './LandingNav.scss';
+
+const LandingNav = () => {
+  const { apps } = useGlobalNav();
+  const isBetaEnv = isBeta();
+
+  return (
+    <Nav className="pf-m-dark pf-c-page__sidebar ins-c-landing-nav">
+      {apps.length === 0 ? (
+        <NavLoader />
+      ) : (
+        <NavList>
+          <NavItem preventDefault component="span">
+            <b>Red Hat Hybrid Cloud Console</b>
+          </NavItem>
+          {apps.map(({ id, title, routes }) => (
+            <NavExpandable className="ins-m-navigation-align" key={id} title={title}>
+              {routes.map(({ title, id: path }) => (
+                <NavItem className="ins-m-navigation-align" key={id} to={`/${isBetaEnv ? 'beta/' : ''}${id}/${path}`}>
+                  {title}
+                </NavItem>
+              ))}
+            </NavExpandable>
+          ))}
+        </NavList>
+      )}
+    </Nav>
+  );
+};
+
+export default LandingNav;

--- a/src/js/App/Sidenav/LandingNav.scss
+++ b/src/js/App/Sidenav/LandingNav.scss
@@ -1,0 +1,3 @@
+.ins-c-landing-nav {
+  height: 100%;
+}

--- a/src/js/App/Sidenav/index.js
+++ b/src/js/App/Sidenav/index.js
@@ -1,21 +1,38 @@
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, Fragment } from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-dom';
 import NavLoader from './Loader';
 import { spinUpStore } from '../../redux-config';
+import { isFilterEnabled } from '../../utils/isAppNavEnabled';
+import LandingNav from './LandingNav';
 
 const Sidenav = lazy(() => import(/* webpackChunkName: "Sidenav" */ './SideNav'));
 
 export const navLoader = () => {
   const { store } = spinUpStore();
-  if (document.querySelector('aside')) {
+  if (document.querySelector('aside#ins-c-sidebar')) {
     render(
       <Provider store={store}>
         <Suspense fallback={<NavLoader />}>
           <Sidenav />
         </Suspense>
       </Provider>,
-      document.querySelector('aside')
+      document.querySelector('aside#ins-c-sidebar')
+    );
+  } else if (isFilterEnabled && document.querySelector('aside#ins-c-landing-nav')) {
+    const elem = document.querySelector('aside#ins-c-landing-nav');
+    /**
+     * Nav classes have to be added at runtime only when the nav should be rendered
+     * to prevent navigation background to be displayed in non ci-beta envs.
+     */
+    elem.classList.add('pf-c-page__sidebar', 'pf-l-page__sidebar');
+    render(
+      <Provider store={store}>
+        <Suspense fallback={<Fragment />}>
+          <LandingNav />
+        </Suspense>
+      </Provider>,
+      elem
     );
   }
 };

--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -13,7 +13,7 @@ import debugFunctions from '../debugFunctions';
 import { visibilityFunctions } from '../consts';
 import Cookies from 'js-cookie';
 import logger from '../jwt/logger';
-import { getUrl, getEnv } from '../utils';
+import { getUrl, getEnv, isBeta } from '../utils';
 import { createSupportCase } from '../createCase';
 import get from 'lodash/get';
 import { flatTags } from '../App/GlobalFilter/constants';
@@ -109,7 +109,7 @@ export function bootstrap(libjwt, initFunc, getUser) {
         login: () => libjwt.jwt.login(),
       },
       isProd: window.location.host === 'cloud.redhat.com',
-      isBeta: () => (window.location.pathname.split('/')[1] === 'beta' ? true : false),
+      isBeta,
       isPenTest: () => (Cookies.get('x-rh-insights-pentest') ? true : false),
       getBundle: () => getUrl('bundle'),
       getApp: () => getUrl('app'),

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -80,7 +80,10 @@ export function clearActive(state) {
 
 export function navToggleReducer(state) {
   const mq = window.matchMedia && window.matchMedia('(min-width: 1200px)');
-  let page = document.getElementById('ins-c-sidebar');
+  let page = document.getElementById('ins-c-sidebar') || document.getElementById('ins-c-landing-nav');
+  if (!page) {
+    return state;
+  }
 
   if (mq && mq.matches) {
     page.classList.remove('pf-m-expanded');

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -132,3 +132,7 @@ export function getUrl(type) {
 export function getEnv() {
   return Object.entries(DEFAULT_ROUTES).find(([, { url }]) => url.includes(location.hostname))?.[0] || 'qa';
 }
+
+export function isBeta() {
+  return window.location.pathname.split('/')[1] === 'beta' ? true : false;
+}

--- a/src/js/utils/isAppNavEnabled.js
+++ b/src/js/utils/isAppNavEnabled.js
@@ -1,0 +1,3 @@
+import { getEnv, isBeta } from '../utils';
+
+export const isFilterEnabled = localStorage.getItem('chrome:experimental:app-filter') === 'true' || (getEnv() === 'ci' && isBeta());

--- a/src/js/utils/useGlobalNav.js
+++ b/src/js/utils/useGlobalNav.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { safeLoad } from 'js-yaml';
+import { getNavFromConfig } from '../nav/globalNav';
+import sourceOfTruth from '../nav/sourceOfTruth';
+
+const appIds = ['insights', 'openshift', 'cost-management', 'migrations', 'subscriptions', 'ansible', 'settings'];
+
+const useGlobalNav = () => {
+  const [state, setState] = useState({
+    apps: [],
+    filteredApps: [],
+    isLoaded: false,
+  });
+  const setFilteredApps = (filteredApps) => setState((prev) => ({ ...prev, filteredApps }));
+  useEffect(() => {
+    (async () => {
+      const navigationYml = await sourceOfTruth();
+      const appData = await getNavFromConfig(safeLoad(navigationYml), undefined);
+      setState({ apps: appIds.map((id) => appData[id]), filteredApps: appIds.map((id) => appData[id]), isLoaded: true });
+    })();
+  }, []);
+
+  return { ...state, setFilteredApps };
+};
+
+export default useGlobalNav;

--- a/src/pug/landing-nav.pug
+++ b/src/pug/landing-nav.pug
@@ -1,0 +1,8 @@
+.pf-c-page.pf-m-redhat-font#page
+    include landing-header.pug
+    aside#ins-c-landing-nav
+    main.pf-c-page__main.pf-l-page__main#root(role='main', data-ouia-safe='false')
+        section.pf-c-page__main-section.pf-l-page__main-section
+            .ins-c-spinner.ins-m-center(role='status')
+                span(class="pf-u-screen-reader") Loading...
+include after.pug


### PR DESCRIPTION
The landing page nav was moved to chrome to re-use the same data as app filter does. We can also use show/hide logic for the menu which is nice.

jira: https://issues.redhat.com/browse/RHCLOUD-11968

### Changes
- create hook from app filter data loading
  - hook can now be re-used for the landing nav
  - data is cached so we should only make one request
- move `isBeta` declaration to helper functions
- create `isFilterEnabled` constant feature flag until all these changes hits prod
- added nav to landing page
- creates new pug template for the landing page with nav

![screenshot-ci foo redhat com_1337-2021 02 02-11_34_29](https://user-images.githubusercontent.com/22619452/106588645-53558c00-654b-11eb-8149-e65067eeb732.png)
