### PR TITLE
Make the read count in tags selector lighter

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -178,6 +178,9 @@ section.ins-c-app-switcher--loading {
             overflow: auto;
         }
 
+        .pf-c-select__menu li button:hover label .pf-c-badge.pf-m-read {
+            background: var(--pf-global--Color--light-100);
+        }
         .ins-c-tagfilter__option-value { max-width: 360px; }
         }
     }


### PR DESCRIPTION
### Make the read count tags more visible

Because the hover is same as background color of read tag we want to make it more readable by making is lighter.

![Screenshot from 2021-02-02 15-48-10](https://user-images.githubusercontent.com/3439771/106616875-52822180-656e-11eb-833d-2ac019b6a874.png)
