### PR TITLE
Add SIDs filter to both global filter and tags modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4104,21 +4104,11 @@
       }
     },
     "@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.79",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.79.tgz",
-      "integrity": "sha512-codsJG4WTPywBumup/gD5J32NbSypz7IGOvzw7FIeVCHzpEjOHSbukLi9cNn6gUCnsfnDS/55aJda40gKE36lg==",
+      "version": "1.0.93",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.93.tgz",
+      "integrity": "sha512-m1zcckfKhs1hZTM8XyN5GoBgGLJdyEmQk063DPLRbNcmBmJQHIfIqc8WZEVD/kQ/dnQgC7CQyDvZWY8ZDrIT1g==",
       "requires": {
-        "axios": "^0.19.2"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        }
+        "axios": "^0.21.1"
       }
     },
     "@redhat-cloud-services/keycloak-js": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@redhat-cloud-services/frontend-components-notifications": "^2.2.4",
     "@redhat-cloud-services/frontend-components-remediations": "^2.3.9",
     "@redhat-cloud-services/frontend-components-utilities": "^2.2.8",
-    "@redhat-cloud-services/host-inventory-client": "^1.0.79",
+    "@redhat-cloud-services/host-inventory-client": "^1.0.93",
     "@redhat-cloud-services/keycloak-js": "0.0.3",
     "@redhat-cloud-services/rbac-client": "^1.0.75",
     "@sentry/browser": "^5.17.0",

--- a/src/js/App/GlobalFilter/TagsModal.js
+++ b/src/js/App/GlobalFilter/TagsModal.js
@@ -16,13 +16,14 @@ const TagsModal = ({ isOpen, filterTagsBy, onApplyTags, toggleModal, selectedTag
   const [tagsSelected, setTagsSelected] = useState([]);
   const [sidsSelected, setSidsSelected] = useState([]);
   const [filterBy, setFilterBy] = useState('');
+  const [filterSIDsBy, setFilterSIDsBy] = useState('');
   const dispatch = useDispatch();
   const [tagsLoaded, tagsCount, tagsPage, tagsPerPage] = useMetaSelector('tags');
   const [sidLoaded, sidCount, sidPage, sidPerPage] = useMetaSelector('sid');
   const tags = useSelector(({ globalFilter: { tags } }) => tags?.items || []);
   const sids = useSelector(({ globalFilter: { sid } }) => sid?.items || []);
   const filterScope = useSelector(({ globalFilter: { scope } }) => scope || undefined);
-  const debounceGeTags = useCallback(
+  const debounceGetTags = useCallback(
     debounce((search) => {
       dispatch(
         fetchAllTags(
@@ -31,7 +32,22 @@ const TagsModal = ({ isOpen, filterTagsBy, onApplyTags, toggleModal, selectedTag
             activeTags: selectedTags,
             search,
           },
-          { tagsPage, tagsPerPage }
+          { page: tagsPage, perPage: tagsPerPage }
+        )
+      );
+    }, 800),
+    []
+  );
+  const debounceGetSIDs = useCallback(
+    debounce((search) => {
+      dispatch(
+        fetchAllSIDs(
+          {
+            registeredWith: filterScope,
+            activeTags: selectedTags,
+            search,
+          },
+          { page: sidPage, perPage: sidPerPage }
         )
       );
     }, 800),
@@ -39,7 +55,9 @@ const TagsModal = ({ isOpen, filterTagsBy, onApplyTags, toggleModal, selectedTag
   );
   useEffect(() => {
     setFilterBy(filterTagsBy);
+    setFilterSIDsBy(filterTagsBy);
   }, [filterTagsBy]);
+
   return (
     <TagModal
       tabNames={['tags', 'SAP IDs (SID)']}
@@ -102,6 +120,7 @@ const TagsModal = ({ isOpen, filterTagsBy, onApplyTags, toggleModal, selectedTag
         setSidsSelected([]);
         setTagsSelected([]);
         setFilterBy('');
+        setFilterSIDsBy('');
         toggleModal(isSubmit);
       }}
       filters={[
@@ -114,7 +133,21 @@ const TagsModal = ({ isOpen, filterTagsBy, onApplyTags, toggleModal, selectedTag
               value: filterBy,
               onChange: (_e, value) => {
                 setFilterBy(() => value);
-                debounceGeTags(value);
+                debounceGetTags(value);
+              },
+            },
+          },
+        ],
+        [
+          {
+            label: 'SIDs filter',
+            placeholder: 'Filter SAP IDs',
+            value: 'sids-filter',
+            filterValues: {
+              value: filterSIDsBy,
+              onChange: (_e, value) => {
+                setFilterSIDsBy(() => value);
+                debounceGetSIDs(value);
               },
             },
           },
@@ -138,7 +171,7 @@ const TagsModal = ({ isOpen, filterTagsBy, onApplyTags, toggleModal, selectedTag
               {
                 registeredWith: filterScope,
                 activeTags: selectedTags,
-                search: filterBy,
+                search: filterSIDsBy,
               },
               pagination
             )

--- a/src/js/App/GlobalFilter/tagsApi.js
+++ b/src/js/App/GlobalFilter/tagsApi.js
@@ -31,10 +31,11 @@ export function getAllTags({ search, activeTags, registeredWith } = {}, paginati
   );
 }
 
-export function getAllSIDs({ activeTags, registeredWith } = {}, pagination = {}) {
+export function getAllSIDs({ search, activeTags, registeredWith } = {}, pagination = {}) {
   const [workloads, SID, selectedTags] = flatTags(activeTags, false, true);
 
   return sap.apiSystemProfileGetSapSids(
+    search,
     selectedTags, // tags
     (pagination && pagination.perPage) || 10,
     (pagination && pagination.page) || 1,


### PR DESCRIPTION
### Global filter support for SID filtration

API supports filtering of SIDs in a similiar manner to how tags are filtered, so let's adapt to it and use this updated API to properly filter SIDs.

This PR adds the filtering option to both global filter and tags selector modal.

![Screenshot from 2021-02-03 14-55-29](https://user-images.githubusercontent.com/3439771/106756766-e4059800-662f-11eb-9bbf-02c53b04ce8d.png)
![Screenshot from 2021-02-03 14-55-17](https://user-images.githubusercontent.com/3439771/106756775-e536c500-662f-11eb-9994-02afebf2f134.png)


Jira: https://issues.redhat.com/browse/RHCLOUD-10233