### PR TITLE
add release note script

### DIFF
--- a/generate_notes.js
+++ b/generate_notes.js
@@ -1,0 +1,142 @@
+const { execSync } = require('child_process');
+const { repository } = require('./package.json');
+const { Octokit } = require("@octokit/rest");
+
+const refs = process.argv[2];
+if (!refs) {
+  console.error('must pass refs (ie v1.15.2...v1.16-rc2)');
+  process.exit(1);
+}
+if (!process.env.GH_TOKEN) {
+  console.error('Must set GH_TOKEN or ratelimit will be hit');
+  process.exit(1);
+}
+
+const octokit = new Octokit({
+  auth: process.env.GH_TOKEN
+});
+
+function getCommitType(subject) {
+  if (subject.match(/ dep/i) || subject.match(/$depend/i)) {
+    return 'dependencies';
+  }
+  else if (subject.match(/doc/i) || subject.match(/readme/i)) {
+    return 'docs';
+  }
+  else if (subject.match(/fix/i)) {
+    return 'fix';
+  }
+  else if (subject.match(/feature/i) || subject.match(/add/i)) {
+    return 'feature';
+  }
+  return 'general';
+}
+
+const split = repository.url
+  .replace('git+', '')
+  .replace('https://github.com/', '')
+  .replace(/.git$/, '')
+  .split('/');
+const owner = split[0];
+const repo = split[1];
+async function getCommitTypeGithub(prnum) {
+  const res = await octokit.pulls.get({
+    owner,
+    repo,
+    pull_number: prnum
+  });
+  if (res.data) {
+    if (res.data.labels && res.data.labels.length > 0) {
+      if (res.data.labels.includes(label => label.name === 'bug')) {
+        return 'fix';
+      }
+      else if (res.data.labels.includes(label => ['dependencies', 'depfu'].includes(label.name))) {
+        return 'dependencies';
+      }
+      else if (res.data.labels.includes(label => label.name === 'enhancement')) {
+        return 'feature';
+      }
+    }
+    const titleType = getCommitType(res.data.title);
+    if (titleType !== 'general') {
+      return titleType;
+    }
+    if (res.data.body) {
+      return getCommitType(res.data.body);
+    }
+  }
+
+  return 'general';
+}
+
+function getCommits() {
+  const subjects = execSync(`git log ${refs} --format="%s"`).toString().split('\n').filter(Boolean);
+  const authors  = execSync(`git log ${refs} --format="%an"`).toString().split('\n').filter(Boolean);
+  const shas     = execSync(`git log ${refs} --format="%h"`).toString().split('\n').filter(Boolean);
+
+  return subjects.map((subject, i) => {
+    const match = subject.match(/#(\d+)/);
+
+    return {
+      subject,
+      author: authors[i],
+      sha: shas[i],
+      type: getCommitType(subject),
+      prnum: match && match[1]
+    };
+  });
+}
+
+function getGroupedCommits(commits) {
+  return commits.reduce((acc, cur) => {
+    acc[cur.type] = acc[cur.type] || [];
+    acc[cur.type].push(cur);
+
+    return acc;
+  }, {});
+}
+
+const typeOrder = {
+  'dependencies': 1,
+  'features': 2,
+  'fix': 3
+};
+const defaultOrder = 99;
+const sortTypes = (t1, t2) => {
+  const t1Index = typeOrder[t1] || defaultOrder;
+  const t2Index = typeOrder[t2] || defaultOrder;
+  if (t1Index === defaultOrder && t2Index === defaultOrder) {
+    return t1.localeCompare(t2);
+  }
+
+  return t1Index > t2Index ? 1 : -1;
+}
+function capitalize(input) {
+  return input[0].toUpperCase() + input.substring(1);
+}
+
+async function addCommitTypes(commits) {
+  for (const commit of commits) {
+    if (commit.type === 'general' && commit.prnum) {
+      commit.type = await getCommitTypeGithub(commit.prnum);
+    }
+  }
+}
+
+async function printReleaseNotes() {
+  const commits = getCommits();
+  await addCommitTypes(commits);
+  
+  const groupedCommits = getGroupedCommits(commits);
+
+  Object.keys(groupedCommits).sort(sortTypes).forEach(type => {
+    console.log('\n#', capitalize(type));
+    groupedCommits[type].forEach(commit => {
+      console.log(`- ${commit.subject}`);
+    });
+  });
+}
+
+printReleaseNotes();
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3090,6 +3090,147 @@
         }
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.5.tgz",
+      "integrity": "sha512-+DCtPykGnvXKWWQI0E1XD+CCeWSBhB6kwItXqfFmNBlIlhczuDPbg+P6BtLnVBaRJDAjv+1mrUJuRsFSjktopg==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.0.tgz",
+      "integrity": "sha512-CJ6n7izLFXLvPZaWzCQDjU/RP+vHiZmWdOunaCS87v+2jxMsW9FB5ktfIxybRBxZjxuJGRnxk7xJecWTVxFUYQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.0.tgz",
+      "integrity": "sha512-o4Q9VPYaIdzxskfVuWk7Dcb6Ldq2xbd1QKmPCRx29nFdFxm+2Py74QLfbB3CgankZerHnNJ9wgINOkwa/O2qRg==",
+      "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.9.1.tgz",
+      "integrity": "sha512-8wnuWGjwDIEobbBet2xAjZwgiMVTgIer5wBsnGXzV3lJ4yqphLU2FEMpkhSrDx7y+WkZDfZ+V+1cFMZ1mAaFag==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.8.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
+      "dev": true
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.10.1.tgz",
+      "integrity": "sha512-YGMiEidTORzgUmYZu0eH4q2k8kgQSHQMuBOBYiKxUYs/nXea4q/Ze6tDzjcRAPmHNJYXrENs1bEMlcdGKT+8ug==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.8.2",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.14.tgz",
+      "integrity": "sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.1.0.tgz",
+      "integrity": "sha512-YQfpTzWV3jdzDPyXQVO54f5I2t1zxk/S53Vbe+Aa5vQj6MdTx6sNEWzmUzUO8lSVowbGOnjcQHzW1A8ATr+/7g==",
+      "dev": true,
+      "requires": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "4.10.1"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
+      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^4.0.0",
+        "@types/node": ">= 8"
+      }
+    },
     "@patternfly/patternfly": {
       "version": "4.42.2",
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.42.2.tgz",
@@ -7527,6 +7668,12 @@
         }
       }
     },
+    "before-after-hook": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.1.tgz",
+      "integrity": "sha512-5ekuQOvO04MDj7kYZJaMab2S8SPjGJbotVNyv7QYFCOAwrGZs/YnoDNlh1U+m5hl7H2D/+n0taaAV/tfyd3KMA==",
+      "dev": true
+    },
     "bfj": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
@@ -10133,6 +10280,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.1",
@@ -30606,6 +30759,12 @@
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
       }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
     },
     "universalify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@babel/plugin-transform-runtime": "^7.10.1",
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.10.1",
+    "@octokit/rest": "^18.1.0",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "0.0.0",
     "@types/node": "^14.0.13",
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
It's not perfect, but I think it's a step in the right direction for @karelhala . Sample output for `node generate_notes.js v1.15.2...v1.16-rc2`:

```
# Dependencies
- Update remediations dependency. (#1117)
- Update axios to version 0.21.1 (#1106)
- Remove jwt-redhat dependency, it's no longer used (#1069)
- Merge pull request #1051 from karelhala/update-inv-20-10-30
- Update inventory dep to newest version
- Merge pull request #1050 from karelhala/update-deps-20-10-27
- Update all FEC deps on 20-10-27

# Fix
- Merge pull request #1146 from PanSpagetka/fix-filter-app-filter
- Merge branch 'master' into fix-filter-app-filter
- Fix App filter
- Merge pull request #1134 from Hyperkid123/rbac-url-fragment
- fix(header): removed extra character from settings link
- Merge pull request #1132 from RedHatInsights/fixes/app-filter-prod
- Merge branch 'master' into fixes/app-filter-prod
- Update inventory to fix loading issues (#1131)
- Merge pull request #1130 from Hyperkid123/support-options
- Fix unauthed console errors (#1129)
- fix(header): change get support title to support options
- Merge pull request #1123 from RedHatInsights/fixes/user-toggle
- fix user menu again
- fix alignment of app switcher and user dropdown (#1116)
- Merge pull request #1113 from Hyperkid123/fix-incorrect-image-src
- Merge pull request #1095 from Hyperkid123/fix-env-cache-switch
- fix user id and org_id
- Fix multiple key selection by increasing version of FEC and using correct tag keys (#1071)
- fix-settings-href (#1074)
- Merge pull request #1063 from RedHatInsights/fixes/sso-urls
- fix logs
- Fix cog url on prod stable (#1060)
- Merge pull request #1058 from RedHatInsights/fixes/internal-beta-flag
- Merge pull request #1053 from karelhala/fix-sid-pagination
- Merge branch 'master' into fix-sid-pagination
- Fix get all SIDs by using correct function
- Fix unauth for trust (#1045)
- Merge pull request #1044 from RedHatInsights/fixes/mua-dropdown
- fix mua on prod stable (#1037)

# Docs
- Add link to docs (#1147)
- Updates documentation lnav as per bu request 🦹🥳 (#1138)
- Merge pull request #1089 from AllenBW/enhancement/ADVISOR-1510
- Reconfigures insights documentation link as per bu request 🙇🏽💋🦾
- Reformat docs and README (#1065)
- Update docs (#1052)
- Enable dynamic navigation items. (#1029)

# Feature
- Add app filter experimental enable function (#1144)
- App filter cleanup 1 (#1140)
- remove all the temp nav styling (#1136)
- Merge pull request #1119 from karelhala/global-filter-updates
- Add leading slash to beta image icons.
- Merge pull request #1101 from PanSpagetka/add-app-filter
- Merge branch 'master' into add-app-filter
- Add isbeta check for static assets
- Add app filter
- Add Adobes MarketingCloudVisitorID to Pendo data
- Add data-ouia-safe on chrome init. (#1098)
- Add debounce when using global filter filter by text (#1097)
- adding dup user_id
- Allow tags bookmarking trough hash value of location (#1070)
- Merge pull request #1072 from RedHatInsights/enhancements/create-case-hash
- add ability to get hash info for current app when suport case is opened
- Add routes (#1066)
- Add loosePermissions method. (#1061)
- add ability to get current environment (#1057)
- add flag to remove internal from prod
- Merge pull request #1055 from Hyperkid123/api-request-matcher
- Add apiRequests matchers.

# General
- Proper global filter store for disabled state (#1149)
- Wrap store filter so it doesn't trigger when disabled (#1148)
- Update Inventory to allow hide filters (#1145)
- Use full width for global filter (#1137)
- Update remediations to iunclude new validate check (#1141)
- Change where subs watch is pointing (#1139)
- Merge pull request #1135 from karelhala/update-inv-21-01-22
- Update inventory to use new custom fetcher
- Instead of hiding, disable global filter (#1133)
- lint
- do not show app filter on prod-beta
- Merge branch 'master' into support-options
- Update inventory to use actions dropdown instead of kebab (#1128)
- Merge pull request #1121 from Hyperkid123/stop-loading-nav-no-user
- Merge branch 'master' into stop-loading-nav-no-user
- Merge pull request #1122 from PanSpagetka/pendo-track-ad-blocking
- Merge branch 'master' into stop-loading-nav-no-user
- Merge branch 'master' into pendo-track-ad-blocking
- update pendo on prod-stable (#1125)
- Merge branch 'master' into pendo-track-ad-blocking
- Merge pull request #1105 from PanSpagetka/remove-context-switcher
- Merge branch 'master' into pendo-track-ad-blocking
- Use error callback
- Merge branch 'master' into stop-loading-nav-no-user
- Merge branch 'master' into remove-context-switcher
- track Pendo ad blocking
- Merge branch 'master' into global-filter-updates
- Merge branch 'master' into stop-loading-nav-no-user
- Merge branch 'master' into remove-context-switcher
- Update styling
- Do not load nav config for unauthed user.
- Update inventory to latest (#1120)
- update cog in mua (#1114)
- Merge branch 'master' into global-filter-updates
- Update global filter with new UX requests
- Hide App switcher in Beta
- Merge pull request #1112 from PanSpagetka/update-app-filter
- Merge branch 'master' into update-app-filter
- Use precise imports
- Merge branch 'master' into update-app-filter
- simplify classes and styling
- icon styling and media query update
- New mocks changes
- styling update
- More changes
- Make layout to be more column like
- Update App filter
- Merge branch 'master' into update-app-filter
- simplify classes and styling
- icon styling and media query update
- Merge pull request #1115 from RedHatInsights/enhancements/mua-point
- update path to use mua always
- New mocks changes
- styling update
- Merge branch 'update-app-filter' of https://github.com/PanSpagetka/insights-chrome into update-app-filter
- More changes
- Merge branch 'master' into update-app-filter
- Make layout to be more column like
- Update App filter
- Remove redhat from app switcher (#1102)
- Cleanup
- Get app data from CSC
- Use static assets from landing page
- Do not release to qa
- Update urijs to version 1.19.5
- Merge pull request #1099 from RedHatInsights/adobe_visitor_id_in_pendo
- Merge branch 'master' into adobe_visitor_id_in_pendo
- Update version of FEC to newest version on 20-12-11 (#1100)
- lint
- comma not semicolon, I swear I used to code
- use new fields for case creation (#1096)
- Clear chrome cache when switching beta/non-bete env.
- Merge pull request #1093 from Hyperkid123/use-correct-page-bottom
- Use adobe custom event instead of salite page bottom call.
- Merge pull request #1091 from RedHatInsights/pendo_tmp
- Merge branch 'master' into pendo_tmp
- initial
- Merge pull request #1088 from fhlavac/remediations-wizard
- Enable new DDF remediations wizard in debug
- send the hash to the env instead (#1075)
- Merge branch 'master' into enhancements/create-case-hash
- Merge branch 'master' into enhancements/create-case-hash
- remove training link (#1073)
- comments
- lint
- update url.js
- lint
- Clear chrome-store from local storage on logout. (#1056)
- Merge pull request #1054 from rvsia/updateGenInfo
- Merge branch 'master' into updateGenInfo
- Update general info to latest
- [Prod Stable] Unauth Trust Page (#1049)
- use cname for pendo (#1047)
- Merge pull request #1039 from karelhala/calculate-groupped-nav
- Update tests to respect only active section
- Calculate only currently observed nav
- mua on beta only
```