### PR TITLE
Fix: duplicate chrome entry files

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -7,7 +7,7 @@ const commonConfig = ({ publicPath, noHash }) => ({
   entry: path.resolve(__dirname, '../src/js/chrome.js'),
   output: {
     path: path.resolve(__dirname, '../build/js'),
-    filename: `chrome${noHash ? '' : '.[chunkhash]'}.js`,
+    filename: `chrome-root${noHash ? '' : '.[chunkhash]'}.js`,
     publicPath,
     chunkFilename: `[name]${noHash ? '' : '.[chunkhash]'}.js`,
   },

--- a/scripts/build-pug.js
+++ b/scripts/build-pug.js
@@ -5,7 +5,7 @@ const path = require('path');
 const release = process.argv[2]; //"insights or insightsbeta"
 
 async function getAssetPath(extension, noHash) {
-    const files = glob.sync(`build/**/chrome${noHash ? '' : '.*'}.${extension}`);
+    const files = glob.sync(`build/**/chrome${extension === 'js' ? '-root': ''}${noHash ? '' : '.*'}.${extension}`);
     return path.relative('build/', files[0]);
 }
 


### PR DESCRIPTION
The federated module name and chrome entry point name were the same. `chrome.[hash].js` That causes an issue when generating the HTML template because sometimes the federated module was chosen instead of the chrome root.

Causing chrome not to render and initialize.

Chrome root filename is now `chrome-root.[hash].js`