### PR TITLE
Fix: missing chrome 2 flag.

### DIFF
--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -99,6 +99,7 @@ export function bootstrap(libjwt, initFunc, getUser) {
       createCase: (fields) => insights.chrome.auth.getUser().then((user) => createSupportCase(user.identity, fields)),
       visibilityFunctions,
       init: initFunc,
+      isChrome2: true,
     },
     experimental: {},
   };


### PR DESCRIPTION
Fixes double app rendering.

The chrome 2 flag was overridden and missing causing the application to be rendered by chrome and also by `ReactDom.render`. That can lead to infinite loops sometimes. 