### PR TITLE
Enable landing page navigation

### DIFF
--- a/src/js/App/Header/Brand.js
+++ b/src/js/App/Header/Brand.js
@@ -32,4 +32,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(({ chrome: { navHidden } }) => ({ navHidden }), mapDispatchToProps)(Brand);
+export default connect(({ chrome: { navHidden, user } }) => ({ navHidden: !user ? true : navHidden }), mapDispatchToProps)(Brand);

--- a/src/js/App/Header/HeaderTests/__snapshots__/Brand.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/Brand.test.js.snap
@@ -181,6 +181,7 @@ exports[`Brand should render correctly with state navHidden: false 1`] = `
 >
   <div
     class="pf-c-page__header-brand-toggle"
+    hidden=""
   >
     <button
       aria-disabled="false"

--- a/src/js/App/Header/HeaderTests/__snapshots__/Header.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/Header.test.js.snap
@@ -6,6 +6,7 @@ exports[`Header should render correctly 1`] = `
 >
   <div
     class="pf-c-page__header-brand-toggle"
+    hidden=""
   >
     <button
       aria-disabled="false"
@@ -49,6 +50,7 @@ exports[`unauthed should render correctly 1`] = `
 >
   <div
     class="pf-c-page__header-brand-toggle"
+    hidden=""
   >
     <button
       aria-disabled="false"

--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -8,7 +8,8 @@ import { BrowserRouter } from 'react-router-dom';
 import SideNav from './Sidenav/SideNav';
 import Header from './Header/Header';
 import ErrorBoundary from './ErrorBoundary';
-import { isBeta } from '../utils';
+import { getEnv, isBeta } from '../utils';
+import LandingNav from './Sidenav/LandingNav';
 
 const LoadingComponent = () => (
   <Bullseye className="pf-u-p-xl">
@@ -20,6 +21,7 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
   const isGlobalFilterEnabled =
     (!globalFilterHidden && activeLocation === 'insights') || Boolean(localStorage.getItem('chrome:experimental:global-filter'));
   const scalprum = useScalprum(config);
+  const hideNav = useSelector(({ chrome: { user } }) => !user);
   const remoteModule = useSelector(({ chrome }) => {
     if (chrome?.activeSection?.module) {
       const appName = chrome?.activeSection?.module?.appName || chrome?.activeSection?.id;
@@ -51,8 +53,9 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
       }
     }
   }, [remoteModule]);
+  const useLandingNav = isBeta() && getEnv() === 'ci';
   return (
-    <BrowserRouter basename={isBeta ? '/beta' : '/'}>
+    <BrowserRouter basename={isBeta() ? '/beta' : '/'}>
       <div
         className="pf-c-drawer__content"
         data-ouia-subnav={activeApp}
@@ -62,7 +65,10 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
         {...(pageAction && { 'data-ouia-page-type': pageAction })}
         {...(pageObjectId && { 'data-ouia-page-object-id': pageObjectId })}
       >
-        <Page header={<PageHeader headerTools={<Header />} />} sidebar={<PageSidebar id="ins-c-sidebar" nav={<SideNav />} isNavOpen />}>
+        <Page
+          header={<PageHeader headerTools={<Header />} />}
+          sidebar={hideNav ? undefined : <PageSidebar id="ins-c-sidebar" nav={useLandingNav ? <LandingNav /> : <SideNav />} isNavOpen />}
+        >
           <div ref={insightsContentRef} className={isGlobalFilterEnabled ? '' : 'ins-m-full--height'}>
             {isGlobalFilterEnabled && <GlobalFilter />}
             {remoteModule && (

--- a/src/js/App/Sidenav/LandingNav.js
+++ b/src/js/App/Sidenav/LandingNav.js
@@ -11,12 +11,6 @@ const LandingNav = () => {
   const showNav = useSelector(({ chrome: { user } }) => !!user);
   useEffect(() => {
     if (showNav) {
-      const elem = document.querySelector('aside#ins-c-landing-nav');
-      /**
-       * Nav classes have to be added at runtime only when the nav should be rendered
-       * to prevent navigation background to be displayed in non ci-beta envs.
-       */
-      elem.classList.add('pf-m-dark', 'pf-c-page__sidebar');
       setElementReady(true);
     }
   }, [showNav]);
@@ -26,6 +20,7 @@ const LandingNav = () => {
   /**
    * render navigation only if the user is logged in
    */
+  console.log({ showNav, elementReady });
   if (!showNav || !elementReady) {
     return null;
   }

--- a/src/js/App/__snapshots__/RootApp.test.js.snap
+++ b/src/js/App/__snapshots__/RootApp.test.js.snap
@@ -16,6 +16,7 @@ exports[`RootApp should render correctly - no data 1`] = `
       >
         <div
           class="pf-c-page__header-brand-toggle"
+          hidden=""
         >
           <button
             aria-disabled="false"
@@ -68,101 +69,6 @@ exports[`RootApp should render correctly - no data 1`] = `
         </button>
       </div>
     </header>
-    <div
-      aria-hidden="false"
-      class="pf-c-page__sidebar pf-m-expanded"
-      id="ins-c-sidebar"
-    >
-      <div
-        class="pf-c-page__sidebar-body"
-      >
-        <section
-          class="ins-c-app-switcher--loading"
-        >
-          <div
-            class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-          >
-             
-          </div>
-        </section>
-        <nav
-          aria-label="Insights Global Navigation"
-          class="pf-c-nav"
-          data-ouia-component-id="OUIA-Generated-Nav-1"
-          data-ouia-component-type="PF4/Nav"
-          data-ouia-safe="false"
-        >
-          <ul
-            class="pf-c-nav__list"
-          >
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-1"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-2"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-3"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-4"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
     <main
       class="pf-c-page__main"
       tabindex="-1"
@@ -199,6 +105,7 @@ exports[`RootApp should render correctly 1`] = `
       >
         <div
           class="pf-c-page__header-brand-toggle"
+          hidden=""
         >
           <button
             aria-disabled="false"
@@ -251,101 +158,6 @@ exports[`RootApp should render correctly 1`] = `
         </button>
       </div>
     </header>
-    <div
-      aria-hidden="false"
-      class="pf-c-page__sidebar pf-m-expanded"
-      id="ins-c-sidebar"
-    >
-      <div
-        class="pf-c-page__sidebar-body"
-      >
-        <section
-          class="ins-c-app-switcher--loading"
-        >
-          <div
-            class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-          >
-             
-          </div>
-        </section>
-        <nav
-          aria-label="Insights Global Navigation"
-          class="pf-c-nav"
-          data-ouia-component-id="OUIA-Generated-Nav-2"
-          data-ouia-component-type="PF4/Nav"
-          data-ouia-safe="false"
-        >
-          <ul
-            class="pf-c-nav__list"
-          >
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-5"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-6"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-7"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-8"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
     <main
       class="pf-c-page__main"
       tabindex="-1"
@@ -383,6 +195,7 @@ exports[`RootApp should render correctly with pageAction 1`] = `
       >
         <div
           class="pf-c-page__header-brand-toggle"
+          hidden=""
         >
           <button
             aria-disabled="false"
@@ -435,101 +248,6 @@ exports[`RootApp should render correctly with pageAction 1`] = `
         </button>
       </div>
     </header>
-    <div
-      aria-hidden="false"
-      class="pf-c-page__sidebar pf-m-expanded"
-      id="ins-c-sidebar"
-    >
-      <div
-        class="pf-c-page__sidebar-body"
-      >
-        <section
-          class="ins-c-app-switcher--loading"
-        >
-          <div
-            class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-          >
-             
-          </div>
-        </section>
-        <nav
-          aria-label="Insights Global Navigation"
-          class="pf-c-nav"
-          data-ouia-component-id="OUIA-Generated-Nav-3"
-          data-ouia-component-type="PF4/Nav"
-          data-ouia-safe="false"
-        >
-          <ul
-            class="pf-c-nav__list"
-          >
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-9"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-10"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-11"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-12"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
     <main
       class="pf-c-page__main"
       tabindex="-1"
@@ -567,6 +285,7 @@ exports[`RootApp should render correctly with pageObjectId 1`] = `
       >
         <div
           class="pf-c-page__header-brand-toggle"
+          hidden=""
         >
           <button
             aria-disabled="false"
@@ -619,101 +338,6 @@ exports[`RootApp should render correctly with pageObjectId 1`] = `
         </button>
       </div>
     </header>
-    <div
-      aria-hidden="false"
-      class="pf-c-page__sidebar pf-m-expanded"
-      id="ins-c-sidebar"
-    >
-      <div
-        class="pf-c-page__sidebar-body"
-      >
-        <section
-          class="ins-c-app-switcher--loading"
-        >
-          <div
-            class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-          >
-             
-          </div>
-        </section>
-        <nav
-          aria-label="Insights Global Navigation"
-          class="pf-c-nav"
-          data-ouia-component-id="OUIA-Generated-Nav-4"
-          data-ouia-component-type="PF4/Nav"
-          data-ouia-safe="false"
-        >
-          <ul
-            class="pf-c-nav__list"
-          >
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-13"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-14"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-15"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-16"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
     <main
       class="pf-c-page__main"
       tabindex="-1"
@@ -752,6 +376,7 @@ exports[`RootApp should render correctly with pageObjectId and pageAction 1`] = 
       >
         <div
           class="pf-c-page__header-brand-toggle"
+          hidden=""
         >
           <button
             aria-disabled="false"
@@ -804,101 +429,6 @@ exports[`RootApp should render correctly with pageObjectId and pageAction 1`] = 
         </button>
       </div>
     </header>
-    <div
-      aria-hidden="false"
-      class="pf-c-page__sidebar pf-m-expanded"
-      id="ins-c-sidebar"
-    >
-      <div
-        class="pf-c-page__sidebar-body"
-      >
-        <section
-          class="ins-c-app-switcher--loading"
-        >
-          <div
-            class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-          >
-             
-          </div>
-        </section>
-        <nav
-          aria-label="Insights Global Navigation"
-          class="pf-c-nav"
-          data-ouia-component-id="OUIA-Generated-Nav-5"
-          data-ouia-component-type="PF4/Nav"
-          data-ouia-safe="false"
-        >
-          <ul
-            class="pf-c-nav__list"
-          >
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-17"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-18"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-19"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-            <li
-              class="pf-c-nav__item"
-              data-ouia-component-id="OUIA-Generated-NavItem-20"
-              data-ouia-component-type="PF4/NavItem"
-              data-ouia-safe="true"
-            >
-              <a
-                class="pf-c-nav__link ins-c-skeleton__link"
-              >
-                <div
-                  class="ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
-                >
-                   
-                </div>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
     <main
       class="pf-c-page__main"
       tabindex="-1"

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -89,7 +89,7 @@ aside {
 }
 
 // Page layout styles
-.pf-c-drawer__content, #root.pf-c-page__main, #temp.pf-c-page__main, #no-access.pf-c-page__main {
+.pf-c-drawer__content, #root.pf-c-page__main, #temp.pf-c-page__main {
     height: 100%;
 }
 


### PR DESCRIPTION
Enables landing page nav in chrome 2.0

nav is part of the chrome react app.

Merge with: https://github.com/RedHatInsights/landing-page-frontend/pull/189

@epwinchell styling looks a bit strange to me. Could look at it once its merged and fix it? There are probably some global styles somewhere.