### PR TITLE
Fix: rendering of non chrome 2 apps

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -29,7 +29,7 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
         app = curr[currKey];
       }
       return app;
-    }, {});
+    }, undefined);
     if (activeModule) {
       const appName = activeModule?.module?.appName || chrome?.activeSection?.id || chrome?.activeLocation;
       const [scope, module] = activeModule?.module?.split?.('#') || [];


### PR DESCRIPTION
We were assigning an empty object to the active module even though chrome was supposed to render the legacy app which caused the element with the app to be destroyed and the app disappeared.