### PR TITLE
Fix: landing page global nav undefined.

### DIFF
--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -37,10 +37,12 @@ export function navUpdateReducer(state, { payload: { activeSection, globalNav, .
     ...state,
     ...payload,
     activeSection,
-    globalNav: globalNav.map((app) => ({
-      ...app,
-      active: activeSection && (app.title === activeSection.title || app.id === activeSection.id),
-    })),
+    globalNav: globalNav
+      ? globalNav.map((app) => ({
+          ...app,
+          active: activeSection && (app.title === activeSection.title || app.id === activeSection.id),
+        }))
+      : state.globalNav,
   };
 }
 


### PR DESCRIPTION
Add a fallback for global nav if no data exists. It can prevent the landing page from rendering.