### PR TITLE
Fix: catch click event on app filter click

### DIFF
--- a/src/js/App/Header/AppFilter.js
+++ b/src/js/App/Header/AppFilter.js
@@ -73,41 +73,51 @@ const AppFilter = () => {
   );
 
   return (
-    <Dropdown
-      className="ins-c-page__app-filter-dropdown"
-      isPlain
-      onSelect={() => setIsOpen(true)}
-      toggle={
-        <DropdownToggle id="toggle-id" onToggle={() => setIsOpen(!isOpen)} toggleIndicator={CaretDownIcon}>
-          Applications and services
-        </DropdownToggle>
-      }
-      isOpen={isOpen}
-      ouiaId="App Filter"
+    <div
+      onClick={(event) => {
+        /**
+         * We have to stop the venet when clicking on the app filter.
+         * If the event bubbles up the DOM it will trigger a loho link click which we don't want to
+         */
+        event.preventDefault();
+      }}
     >
-      <div className="content">
-        <SearchInput
-          placeholder="Find application or service"
-          value={filterValue}
-          onChange={(val) => setFilterValue(val)}
-          onClear={() => setFilterValue('')}
-        />
-        {filteredApps?.length > 0 ? (
-          <div className="gallery">{filteredApps.map((app) => renderApp(app))}</div>
-        ) : (
-          <EmptyState className="pf-u-mt-xl" variant={EmptyStateVariant.full}>
-            <EmptyStateIcon className="pf-u-mb-xl" icon={FilterIcon} />
-            <Title headingLevel="h4">No matching applications or services found.</Title>
-            <EmptyStateBody className="pf-u-mb-xl">
-              This filter criteria matches no applications or services. Try changing your input filter.
-            </EmptyStateBody>
-            <Button className="pf-u-mt-lg" variant="link" onClick={() => setFilterValue('')}>
-              Clear all filters
-            </Button>
-          </EmptyState>
-        )}
-      </div>
-    </Dropdown>
+      <Dropdown
+        className="ins-c-page__app-filter-dropdown"
+        isPlain
+        onSelect={() => setIsOpen(true)}
+        toggle={
+          <DropdownToggle id="toggle-id" onToggle={() => setIsOpen(!isOpen)} toggleIndicator={CaretDownIcon}>
+            Applications and services
+          </DropdownToggle>
+        }
+        isOpen={isOpen}
+        ouiaId="App Filter"
+      >
+        <div className="content">
+          <SearchInput
+            placeholder="Find application or service"
+            value={filterValue}
+            onChange={(val) => setFilterValue(val)}
+            onClear={() => setFilterValue('')}
+          />
+          {filteredApps?.length > 0 ? (
+            <div className="gallery">{filteredApps.map((app) => renderApp(app))}</div>
+          ) : (
+            <EmptyState className="pf-u-mt-xl" variant={EmptyStateVariant.full}>
+              <EmptyStateIcon className="pf-u-mb-xl" icon={FilterIcon} />
+              <Title headingLevel="h4">No matching applications or services found.</Title>
+              <EmptyStateBody className="pf-u-mb-xl">
+                This filter criteria matches no applications or services. Try changing your input filter.
+              </EmptyStateBody>
+              <Button className="pf-u-mt-lg" variant="link" onClick={() => setFilterValue('')}>
+                Clear all filters
+              </Button>
+            </EmptyState>
+          )}
+        </div>
+      </Dropdown>
+    </div>
   );
 };
 


### PR DESCRIPTION
Caused by PF page layout.

The whole logo is wrapped in a link element. Click on the app filter was triggering the navigation. This adds a wrapper element around it and catches the event. Using the keyboard works as expected.