### PR TITLE
Revert "Include active group to active module check"

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -17,7 +17,7 @@ const LoadingComponent = () => (
   </Bullseye>
 );
 
-const isModule = (key, chrome) => key === (chrome?.activeSection?.id || chrome?.activeLocation) || key === chrome?.activeSection?.group;
+const isModule = (key, chrome) => key === (chrome?.activeSection?.id || chrome?.activeLocation);
 
 const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObjectId, globalFilterHidden }) => {
   const scalprum = useScalprum(config);


### PR DESCRIPTION
Reverts RedHatInsights/insights-chrome#1192

Causes incorrect module scope to be loaded