### PR TITLE
Memoize page root

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React, { memo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { connect, useSelector } from 'react-redux';
+import { connect, shallowEqual, useSelector } from 'react-redux';
 import GlobalFilter from './GlobalFilter/GlobalFilter';
 import { useScalprum, ScalprumComponent } from '@scalprum/react-core';
 import { Bullseye, Page, PageHeader, PageSidebar, Spinner } from '@patternfly/react-core';
@@ -10,6 +10,7 @@ import { Header, HeaderTools } from './Header/Header';
 import ErrorBoundary from './ErrorBoundary';
 import { getEnv, isBeta } from '../utils';
 import LandingNav from './Sidenav/LandingNav';
+import isEqual from 'lodash/isEqual';
 
 const LoadingComponent = () => (
   <Bullseye className="pf-u-p-xl">
@@ -18,6 +19,55 @@ const LoadingComponent = () => (
 );
 
 const isModule = (key, chrome) => key === (chrome?.activeSection?.id || chrome?.activeLocation);
+
+const ShieldedRoot = memo(
+  ({ useLandingNav, hideNav, insightsContentRef, isGlobalFilterEnabled, initialized, remoteModule, appId }) => (
+    <Page
+      isManagedSidebar={!hideNav}
+      header={<PageHeader logoProps={{ href: './' }} logo={<Header />} showNavToggle={!hideNav} headerTools={<HeaderTools />} />}
+      sidebar={hideNav ? undefined : <PageSidebar id="ins-c-sidebar" nav={useLandingNav ? <LandingNav /> : <SideNav />} />}
+    >
+      <div ref={insightsContentRef} className={isGlobalFilterEnabled ? '' : 'ins-m-full--height'}>
+        {isGlobalFilterEnabled && <GlobalFilter />}
+        {remoteModule && (
+          <main role="main" className={appId}>
+            {typeof remoteModule !== 'undefined' && initialized ? (
+              <ErrorBoundary>
+                {/* Slcaprum component does not react on config changes. Hack it with key to force new instance until that is enabled. */}
+                <ScalprumComponent fallback={<LoadingComponent />} LoadingComponent={LoadingComponent} key={remoteModule.appName} {...remoteModule} />
+              </ErrorBoundary>
+            ) : (
+              <Bullseye className="pf-u-p-xl">
+                <Spinner size="xl" />
+              </Bullseye>
+            )}
+          </main>
+        )}
+        <main className="pf-c-page__main" id="no-access"></main>
+      </div>
+    </Page>
+  ),
+  (prevProps, nextProps) => isEqual(prevProps, nextProps)
+);
+
+ShieldedRoot.propTypes = {
+  useLandingNav: PropTypes.bool,
+  hideNav: PropTypes.bool,
+  insightsContentRef: PropTypes.object.isRequired,
+  isGlobalFilterEnabled: PropTypes.bool.isRequired,
+  initialized: PropTypes.bool,
+  remoteModule: PropTypes.shape({
+    appName: PropTypes.string.isRequired,
+  }),
+  appId: PropTypes.string,
+};
+ShieldedRoot.defaultProps = {
+  useLandingNav: false,
+  hideNav: false,
+  isGlobalFilterEnabled: false,
+  initialized: false,
+};
+ShieldedRoot.displayName = 'ShieldedRoot';
 
 const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObjectId, globalFilterHidden }) => {
   const scalprum = useScalprum(config);
@@ -39,7 +89,7 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
         appName,
       };
     }
-  });
+  }, shallowEqual);
   const isLanding = useSelector(({ chrome }) => chrome?.appId === 'landing');
   const isGlobalFilterEnabled =
     !isLanding && ((!globalFilterHidden && activeLocation === 'insights') || Boolean(localStorage.getItem('chrome:experimental:global-filter')));
@@ -75,35 +125,15 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
         {...(pageAction && { 'data-ouia-page-type': pageAction })}
         {...(pageObjectId && { 'data-ouia-page-object-id': pageObjectId })}
       >
-        <Page
-          isManagedSidebar={!hideNav}
-          header={<PageHeader logoProps={{ href: './' }} logo={<Header />} showNavToggle={!hideNav} headerTools={<HeaderTools />} />}
-          sidebar={hideNav ? undefined : <PageSidebar id="ins-c-sidebar" nav={useLandingNav ? <LandingNav /> : <SideNav />} />}
-        >
-          <div ref={insightsContentRef} className={isGlobalFilterEnabled ? '' : 'ins-m-full--height'}>
-            {isGlobalFilterEnabled && <GlobalFilter />}
-            {remoteModule && (
-              <main role="main" className={appId}>
-                {typeof remoteModule !== 'undefined' && scalprum.initialized ? (
-                  <ErrorBoundary>
-                    {/* Slcaprum component does not react on config changes. Hack it with key to force new instance until that is enabled. */}
-                    <ScalprumComponent
-                      fallback={<LoadingComponent />}
-                      LoadingComponent={LoadingComponent}
-                      key={remoteModule.appName}
-                      {...remoteModule}
-                    />
-                  </ErrorBoundary>
-                ) : (
-                  <Bullseye className="pf-u-p-xl">
-                    <Spinner size="xl" />
-                  </Bullseye>
-                )}
-              </main>
-            )}
-            <main className="pf-c-page__main" id="no-access"></main>
-          </div>
-        </Page>
+        <ShieldedRoot
+          isGlobalFilterEnabled={isGlobalFilterEnabled}
+          hideNav={hideNav}
+          insightsContentRef={insightsContentRef}
+          useLandingNav={useLandingNav}
+          initialized={scalprum.initialized}
+          remoteModule={remoteModule}
+          appId={appId}
+        />
       </div>
     </BrowserRouter>
   );


### PR DESCRIPTION
Prevents unnecessary re-renders of page root.

This fixes an issue with infinite loops in drift frontend. Each chrome store change triggered from within applications also triggered the page root re-render and causes ScalprumComponent to be re-rendered multiple times. Preventing extra rendering improves performance and fixes spontaneous infinite loops.