### PR TITLE
Fix: use div as nav logo root element

### DIFF
--- a/src/js/App/Header/AppFilter.js
+++ b/src/js/App/Header/AppFilter.js
@@ -73,51 +73,41 @@ const AppFilter = () => {
   );
 
   return (
-    <div
-      onClick={(event) => {
-        /**
-         * We have to stop the venet when clicking on the app filter.
-         * If the event bubbles up the DOM it will trigger a loho link click which we don't want to
-         */
-        event.preventDefault();
-      }}
+    <Dropdown
+      className="ins-c-page__app-filter-dropdown"
+      isPlain
+      onSelect={() => setIsOpen(true)}
+      toggle={
+        <DropdownToggle id="toggle-id" onToggle={() => setIsOpen(!isOpen)} toggleIndicator={CaretDownIcon}>
+          Applications and services
+        </DropdownToggle>
+      }
+      isOpen={isOpen}
+      ouiaId="App Filter"
     >
-      <Dropdown
-        className="ins-c-page__app-filter-dropdown"
-        isPlain
-        onSelect={() => setIsOpen(true)}
-        toggle={
-          <DropdownToggle id="toggle-id" onToggle={() => setIsOpen(!isOpen)} toggleIndicator={CaretDownIcon}>
-            Applications and services
-          </DropdownToggle>
-        }
-        isOpen={isOpen}
-        ouiaId="App Filter"
-      >
-        <div className="content">
-          <SearchInput
-            placeholder="Find application or service"
-            value={filterValue}
-            onChange={(val) => setFilterValue(val)}
-            onClear={() => setFilterValue('')}
-          />
-          {filteredApps?.length > 0 ? (
-            <div className="gallery">{filteredApps.map((app) => renderApp(app))}</div>
-          ) : (
-            <EmptyState className="pf-u-mt-xl" variant={EmptyStateVariant.full}>
-              <EmptyStateIcon className="pf-u-mb-xl" icon={FilterIcon} />
-              <Title headingLevel="h4">No matching applications or services found.</Title>
-              <EmptyStateBody className="pf-u-mb-xl">
-                This filter criteria matches no applications or services. Try changing your input filter.
-              </EmptyStateBody>
-              <Button className="pf-u-mt-lg" variant="link" onClick={() => setFilterValue('')}>
-                Clear all filters
-              </Button>
-            </EmptyState>
-          )}
-        </div>
-      </Dropdown>
-    </div>
+      <div className="content">
+        <SearchInput
+          placeholder="Find application or service"
+          value={filterValue}
+          onChange={(val) => setFilterValue(val)}
+          onClear={() => setFilterValue('')}
+        />
+        {filteredApps?.length > 0 ? (
+          <div className="gallery">{filteredApps.map((app) => renderApp(app))}</div>
+        ) : (
+          <EmptyState className="pf-u-mt-xl" variant={EmptyStateVariant.full}>
+            <EmptyStateIcon className="pf-u-mb-xl" icon={FilterIcon} />
+            <Title headingLevel="h4">No matching applications or services found.</Title>
+            <EmptyStateBody className="pf-u-mb-xl">
+              This filter criteria matches no applications or services. Try changing your input filter.
+            </EmptyStateBody>
+            <Button className="pf-u-mt-lg" variant="link" onClick={() => setFilterValue('')}>
+              Clear all filters
+            </Button>
+          </EmptyState>
+        )}
+      </div>
+    </Dropdown>
   );
 };
 

--- a/src/js/App/Header/Header.js
+++ b/src/js/App/Header/Header.js
@@ -10,7 +10,9 @@ export const Header = () => {
   const user = useSelector(({ chrome }) => chrome?.user);
   return (
     <Fragment>
-      <Logo />
+      <a href="./" className="ins-c-header-link">
+        <Logo />
+      </a>
       {user && isFilterEnabled && <AppFilter />}
     </Fragment>
   );

--- a/src/js/App/Header/HeaderTests/__snapshots__/Header.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/Header.test.js.snap
@@ -2,10 +2,15 @@
 
 exports[`Header should render correctly 1`] = `
 <div>
-  <img
-    alt="Red Hat Logo"
-    src="test-file-stub"
-  />
+  <a
+    class="ins-c-header-link"
+    href="./"
+  >
+    <img
+      alt="Red Hat Logo"
+      src="test-file-stub"
+    />
+  </a>
 </div>
 `;
 

--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -26,7 +26,7 @@ const ShieldedRoot = memo(
   ({ useLandingNav, hideNav, insightsContentRef, isGlobalFilterEnabled, initialized, remoteModule, appId }) => (
     <Page
       isManagedSidebar={!hideNav}
-      header={<PageHeader logoProps={{ href: './' }} logo={<Header />} showNavToggle={!hideNav} headerTools={<HeaderTools />} />}
+      header={<PageHeader logoComponent="div" logo={<Header />} showNavToggle={!hideNav} headerTools={<HeaderTools />} />}
       sidebar={hideNav ? undefined : <PageSidebar id="ins-c-sidebar" nav={useLandingNav ? <LandingNav /> : <SideNav />} />}
     >
       <div ref={insightsContentRef} className={isGlobalFilterEnabled ? '' : 'ins-m-full--height'}>

--- a/src/js/App/__snapshots__/RootApp.test.js.snap
+++ b/src/js/App/__snapshots__/RootApp.test.js.snap
@@ -14,15 +14,19 @@ exports[`RootApp should render correctly - no data 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <div
           class="pf-c-page__header-brand-link"
-          href="./"
         >
-          <img
-            alt="Red Hat Logo"
-            src="test-file-stub"
-          />
-        </a>
+          <a
+            class="ins-c-header-link"
+            href="./"
+          >
+            <img
+              alt="Red Hat Logo"
+              src="test-file-stub"
+            />
+          </a>
+        </div>
       </div>
       <div
         class="pf-c-page__header-tools"
@@ -75,15 +79,19 @@ exports[`RootApp should render correctly 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <div
           class="pf-c-page__header-brand-link"
-          href="./"
         >
-          <img
-            alt="Red Hat Logo"
-            src="test-file-stub"
-          />
-        </a>
+          <a
+            class="ins-c-header-link"
+            href="./"
+          >
+            <img
+              alt="Red Hat Logo"
+              src="test-file-stub"
+            />
+          </a>
+        </div>
       </div>
       <div
         class="pf-c-page__header-tools"
@@ -137,15 +145,19 @@ exports[`RootApp should render correctly with pageAction 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <div
           class="pf-c-page__header-brand-link"
-          href="./"
         >
-          <img
-            alt="Red Hat Logo"
-            src="test-file-stub"
-          />
-        </a>
+          <a
+            class="ins-c-header-link"
+            href="./"
+          >
+            <img
+              alt="Red Hat Logo"
+              src="test-file-stub"
+            />
+          </a>
+        </div>
       </div>
       <div
         class="pf-c-page__header-tools"
@@ -199,15 +211,19 @@ exports[`RootApp should render correctly with pageObjectId 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <div
           class="pf-c-page__header-brand-link"
-          href="./"
         >
-          <img
-            alt="Red Hat Logo"
-            src="test-file-stub"
-          />
-        </a>
+          <a
+            class="ins-c-header-link"
+            href="./"
+          >
+            <img
+              alt="Red Hat Logo"
+              src="test-file-stub"
+            />
+          </a>
+        </div>
       </div>
       <div
         class="pf-c-page__header-tools"
@@ -262,15 +278,19 @@ exports[`RootApp should render correctly with pageObjectId and pageAction 1`] = 
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <div
           class="pf-c-page__header-brand-link"
-          href="./"
         >
-          <img
-            alt="Red Hat Logo"
-            src="test-file-stub"
-          />
-        </a>
+          <a
+            class="ins-c-header-link"
+            href="./"
+          >
+            <img
+              alt="Red Hat Logo"
+              src="test-file-stub"
+            />
+          </a>
+        </div>
       </div>
       <div
         class="pf-c-page__header-tools"

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -44,6 +44,10 @@ aside {
     overflow: auto !important;
 }
 
+.ins-c-header-link {
+    display: flex;
+}
+
 .pf-c-about-modal-box__logo {
     display: none;
 }


### PR DESCRIPTION
Before the root element was `a` which caused redirecting and visual issues when clicking on the app filter and anything else except the logo image.

Only the image is now wrapped in a link.