### PR TITLE
Fix: settings beta link

### DIFF
--- a/src/js/App/Header/ToolbarToggle.js
+++ b/src/js/App/Header/ToolbarToggle.js
@@ -37,7 +37,7 @@ class ToolbarToggle extends Component {
 
   render() {
     // Render the questionmark icon items
-    const dropdownItems = this.props.dropdownItems.map(({ url, title, onClick, isHidden }) =>
+    const dropdownItems = this.props.dropdownItems.map(({ url, title, onClick, isHidden, target = '_blank', rel = 'noopener noreferrer', ...rest }) =>
       !isHidden ? (
         <DropdownItem
           key={title}
@@ -48,8 +48,9 @@ class ToolbarToggle extends Component {
           {...(url
             ? {
                 href: url,
-                target: '_blank',
-                rel: 'noopener noreferrer',
+                target,
+                rel,
+                ...rest,
               }
             : { onClick: (ev) => this.onClick(ev, url, onClick) })}
         >

--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -13,11 +13,11 @@ import RedhatIcon from '@patternfly/react-icons/dist/js/icons/redhat-icon';
 import UserToggle from './UserToggle';
 import ToolbarToggle from './ToolbarToggle';
 import InsightsAbout from './InsightsAbout';
-import { Fragment } from 'react';
-import { Badge } from '@patternfly/react-core';
+import { Badge, Flex } from '@patternfly/react-core';
 import HeaderAlert from './HeaderAlert';
 import cookie from 'js-cookie';
 import './Tools.scss';
+import { isBeta } from '../../utils';
 
 export const switchRelease = (isBeta, pathname) => {
   cookie.set('cs_toggledRelease', 'true');
@@ -38,8 +38,8 @@ const Tools = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isInternal, setIsInternal] = useState(false);
   const [isDemoAcc, setIsDemoAcc] = useState(false);
-  const settingsPath = `${document.baseURI}${window.insights.chrome.isBeta() ? 'beta/' : ''}settings/my-user-access`;
-  const betaSwitcherTitle = `${window.insights.chrome.isBeta() ? 'Stop using' : 'Use'} the beta release`;
+  const settingsPath = `${document.baseURI}settings/my-user-access`;
+  const betaSwitcherTitle = `${isBeta() ? 'Stop using' : 'Use'} the beta release`;
 
   {
     /* Disable settings/cog icon when a user doesn't have an account number */
@@ -57,12 +57,13 @@ const Tools = () => {
   }
   const settingsMenuDropdownItems = [
     {
+      url: settingsPath,
       title: 'Settings',
-      onClick: () => (window.location = settingsPath),
+      target: '_self',
     },
     {
       title: betaSwitcherTitle,
-      onClick: () => (window.location = switchRelease(window.insights.chrome.isBeta(), window.location.pathname)),
+      onClick: () => (window.location = switchRelease(isBeta(), window.location.pathname)),
     },
   ];
 
@@ -73,10 +74,10 @@ const Tools = () => {
     <ToolbarToggle
       key="Settings menu"
       icon={() => (
-        <Fragment>
-          {window.insights.chrome.isBeta() ? <Badge className="ins-c-toolbar__beta-badge">beta</Badge> : null}
+        <Flex alignItems={{ default: 'alignItemsCenter' }}>
+          {isBeta() ? <Badge className="ins-c-toolbar__beta-badge">beta</Badge> : null}
           <CogIcon />
-        </Fragment>
+        </Flex>
       )}
       id="SettingsMenu"
       ouiaId="chrome-settings"
@@ -135,12 +136,13 @@ const Tools = () => {
   const mobileDropdownItems = [
     { title: 'separator' },
     {
+      url: settingsPath,
       title: 'Settings',
-      onClick: () => (window.location = settingsPath),
+      target: '_self',
     },
     {
       title: betaSwitcherTitle,
-      onClick: () => (window.location = switchRelease(window.insights.chrome.isBeta(), window.location.pathname)),
+      onClick: () => (window.location = switchRelease(isBeta(), window.location.pathname)),
     },
     { title: 'separator' },
     ...aboutMenuDropdownItems,
@@ -213,7 +215,7 @@ const Tools = () => {
 
       {cookie.get('cs_toggledRelease') === 'true' ? (
         <HeaderAlert
-          title={`You're ${window.insights.chrome.isBeta() ? 'now' : 'no longer'} using the beta release.`}
+          title={`You're ${isBeta() ? 'now' : 'no longer'} using the beta release.`}
           onDismiss={() => cookie.set('cs_toggledRelease', 'false')}
         />
       ) : null}


### PR DESCRIPTION
### Changes
- fix settings beta link, it was routing to `/beta/beta`
- Fix misaligned beta badge with the cog icon
- use links instead of a button for the settings link

### Before
![screenshot-ci cloud redhat com-2021 02 17-14_10_46](https://user-images.githubusercontent.com/22619452/108208945-f7cdf580-7129-11eb-8941-49090e1c442f.png)

### After
![screenshot-ci foo redhat com_1337-2021 02 17-14_10_54](https://user-images.githubusercontent.com/22619452/108208948-fac8e600-7129-11eb-88bb-9b450379f29c.png)
