### PR TITLE
Load sections from main.yaml

### DIFF
--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -190,9 +190,9 @@ export const Navigation = () => {
   };
 
   const settingsWithSections = settings.reduce((acc, item) => {
-    const section = acc.find((i) => i.section === item.section) || { items: [], section: item.section };
+    const section = acc.find(({ section }) => section === item.section) || { items: [], section: item.section };
     return [
-      ...acc.filter((i) => i.section === undefined || i.section !== item.section),
+      ...acc.filter(({ section }) => section === undefined || section !== item.section),
       item.section ? { ...section, items: [...section.items, item] } : item,
     ];
   }, []);

--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -189,10 +189,18 @@ export const Navigation = () => {
     }
   };
 
+  const settingsWithSections = settings.reduce((acc, item) => {
+    const section = acc.find((i) => i.section === item.section) || { items: [], section: item.section };
+    return [
+      ...acc.filter((i) => i.section === undefined || i.section !== item.section),
+      item.section ? { ...section, items: [...section.items, item] } : item,
+    ];
+  }, []);
+
   return (
     <Nav aria-label="Insights Global Navigation" data-ouia-safe="true">
       <NavList>
-        {settings?.map((item, key) => (
+        {settingsWithSections?.map((item, key) => (
           <SectionNav activeLocation={activeLocation} activeApp={activeApp} key={item.id || key} {...item} onClick={onClick} />
         ))}
         {extraLinks[activeLocation]?.map?.((item) =>

--- a/src/js/App/Sidenav/SectionNav.js
+++ b/src/js/App/Sidenav/SectionNav.js
@@ -4,10 +4,13 @@ import { NavGroup } from '@patternfly/react-core/dist/js/components/Nav/NavGroup
 import ExpandableNav from './ExpandableNav';
 import './SectionNav.scss';
 
-const SectionNav = ({ items, title, id, onClick, ...props }) => {
+const sectionTitleMapper = (id) =>
+  ({ operations: 'Operations Insights', security: 'Security Insights', business: 'Business Insight', insights: 'Insights' }[id] || '');
+
+const SectionNav = ({ items, section, onClick, ...props }) => {
   if (items?.length > 0) {
     return (
-      <NavGroup className="ins-c-section-nav" id={id} title={title.toUpperCase()}>
+      <NavGroup className="ins-c-section-nav" id={section} title={sectionTitleMapper(section)}>
         {items.map((item, key) => (
           <ExpandableNav
             key={item.id || key}
@@ -19,12 +22,11 @@ const SectionNav = ({ items, title, id, onClick, ...props }) => {
       </NavGroup>
     );
   }
-  const item = { id, title, ...props };
   return (
     <ExpandableNav
-      title={title}
-      id={id}
-      onClick={(event, subItem) => (item.subItems ? onClick(event, subItem, item) : onClick(event, item))}
+      title={props.title}
+      id={props.id}
+      onClick={(event, subItem) => (props.subItems ? onClick(event, subItem, props) : onClick(event, props))}
       {...props}
     />
   );
@@ -33,8 +35,9 @@ const SectionNav = ({ items, title, id, onClick, ...props }) => {
 SectionNav.propTypes = {
   items: PropTypes.array,
   subItems: PropTypes.array,
-  title: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
+  section: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  title: PropTypes.string,
   activeLocation: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
 };

--- a/src/js/App/Sidenav/SectionNav.test.js
+++ b/src/js/App/Sidenav/SectionNav.test.js
@@ -9,14 +9,13 @@ describe('SectionNav', () => {
     expect(container).toMatchSnapshot();
   });
   it('should render group with app', () => {
-    const props = { id: 'id', title: 'title', activeLocation: 'loc', onClick: jest.fn(), items: [{ id: 'app', title: 'title' }] };
+    const props = { section: 'section1', activeLocation: 'loc', onClick: jest.fn(), items: [{ id: 'app', title: 'title' }] };
     const { container } = render(<SectionNav {...props} />);
     expect(container).toMatchSnapshot();
   });
   it('should render group with app and sub app', () => {
     const props = {
-      id: 'id',
-      title: 'title',
+      section: 'section1',
       activeLocation: 'loc',
       onClick: jest.fn(),
       items: [{ id: 'app', title: 'title', subItems: [{ id: 'subapp', title: 'title2' }] }],

--- a/src/js/App/Sidenav/__snapshots__/SectionNav.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/SectionNav.test.js.snap
@@ -110,9 +110,7 @@ exports[`SectionNav should render group with app 1`] = `
     <h2
       class="pf-c-nav__section-title"
       id="section1"
-    >
-      SECTION1
-    </h2>
+    />
     <ul>
       <li
         class="pf-c-nav__item"
@@ -141,9 +139,7 @@ exports[`SectionNav should render group with app and sub app 1`] = `
     <h2
       class="pf-c-nav__section-title"
       id="section1"
-    >
-      SECTION1
-    </h2>
+    />
     <ul>
       <li
         class="pf-c-nav__item pf-m-expandable ins-m-navigation-align"

--- a/src/js/App/Sidenav/__snapshots__/SectionNav.test.js.snap
+++ b/src/js/App/Sidenav/__snapshots__/SectionNav.test.js.snap
@@ -104,14 +104,14 @@ exports[`SectionNav should render corectly 1`] = `
 exports[`SectionNav should render group with app 1`] = `
 <div>
   <section
-    aria-labelledby="id"
+    aria-labelledby="section1"
     class="pf-c-nav__section ins-c-section-nav"
   >
     <h2
       class="pf-c-nav__section-title"
-      id="id"
+      id="section1"
     >
-      TITLE
+      SECTION1
     </h2>
     <ul>
       <li
@@ -135,14 +135,14 @@ exports[`SectionNav should render group with app 1`] = `
 exports[`SectionNav should render group with app and sub app 1`] = `
 <div>
   <section
-    aria-labelledby="id"
+    aria-labelledby="section1"
     class="pf-c-nav__section ins-c-section-nav"
   >
     <h2
       class="pf-c-nav__section-title"
-      id="id"
+      id="section1"
     >
-      TITLE
+      SECTION1
     </h2>
     <ul>
       <li

--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -60,6 +60,7 @@ async function getRoutesForApp(app, masterConfig) {
                 ...(subItem.default && { default: subItem.default }),
                 ...(subItem.group && { group: subItem.group }),
                 ...(subItem.reload && { reload: subItem.reload }),
+                ...(subItem.section && { reload: subItem.section }),
               },
               modules,
             ];
@@ -107,6 +108,7 @@ async function getAppData(appId, propName, masterConfig) {
         ...(!app.frontend.suppress_id && { id: appId }),
         ...(app.frontend.reload && { reload: app.frontend.reload }),
         ...(routes?.length > 0 && { [propName]: routes }),
+        ...(app.frontend.section && { section: app.frontend.section }),
       },
       [
         ...(modules || []),
@@ -135,6 +137,7 @@ export async function loadNav(yamlConfig, cache) {
   }
 
   const globalNav = (activeBundle[active] || activeBundle.insights)?.routes;
+
   return {
     ...(activeBundle[active]
       ? {


### PR DESCRIPTION
Should be merged after #1201

This PR adds the ability to parse sections from `CSC. It groups together apps with same section set. But without changes to CSC this should not result in any visual changes.

Example:
```
sources:
  title: Discovered Inventory
  api:
    versions:
      - v1
  channel: '#insights_topology_svc'
  deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy
  frontend:
    title: Sources
    section: test
    paths:
      - /settings/sources
  source_repo: https://github.com/RedHatInsights/sources-ui
```