### PR TITLE
Update OCM documentation link

### DIFF
--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -75,7 +75,7 @@ const extraLinks = {
     },
     {
       id: 'extra-openshift-docs',
-      url: 'https://docs.openshift.com/dedicated/4/',
+      url: 'https://access.redhat.com/documentation/en-us/openshift_cluster_manager/',
       title: 'Documentation',
       external: true,
     },


### PR DESCRIPTION
Update the OCM documentation links, changing it from OpenShift Dedicated docs to the specific docs for OpenShift Cluster Manager

cc: @karelhala 
