### PR TITLE
Add back nav_toggle event

### DIFF
--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -21,6 +21,15 @@ const PUBLIC_EVENTS = {
       },
     }),
   ],
+  NAVIGATION_TOGGLE: [
+    (callback) => {
+      console.warn('NAVIGATION_TOGGLE event is deprecated and will be removed in future versions of chrome.');
+      return {
+        on: 'NAVIGATION_TOGGLE',
+        callback,
+      };
+    },
+  ],
   GLOBAL_FILTER_UPDATE: [
     (callback) => ({
       on: actionTypes.GLOBAL_FILTER_UPDATE,

--- a/src/js/redux/actions.js
+++ b/src/js/redux/actions.js
@@ -121,3 +121,10 @@ export function registerModule(module, manifest) {
     },
   };
 }
+
+/**
+ * @deprecated
+ */
+export const onToggle = () => ({
+  type: 'NAVIGATION_TOGGLE',
+});


### PR DESCRIPTION
Some apps have to use this event to **resize their PF charts**. We will re-introduce the event only until the PF components are fixed. This is something that components should do internally and not rely on some external events.

I would suggest using ResizeObserver (https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) but it's a fairly new API.