### PR TITLE
Fix: wait with module search after user is initialized.

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -93,6 +93,7 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
   const remoteModule = useSelector(({ chrome }) => {
     const activeModule =
       !isLanding &&
+      !hideNav &&
       chrome?.modules?.reduce((app, curr) => {
         const [currKey] = Object.keys(curr);
         if (isModule(currKey, chrome) || isModule(curr?.[currKey]?.module?.group, chrome)) {


### PR DESCRIPTION
fixes: #1218 

The issue is caused by fetching an incorrect module before the user is initialized. The chrome ties to fetch insights dashboard from the incorrect path and because of that it removes the landing page dom element from the DOM thus the page is not rendering. This is a hotfix and we will need a better way of finding root-level apps.

We will not look for modules until a user is logged in. Landing page is not using federated modules for rendering just yet.