### PR TITLE
Add cost to global scalprum registry

### DIFF
--- a/src/js/chrome/render-chrome.js
+++ b/src/js/chrome/render-chrome.js
@@ -28,6 +28,11 @@ const App = () => {
         name: 'chrome',
         manifestLocation: `${window.location.origin}${isBeta() ? '/beta' : ''}/apps/chrome/js/fed-mods.json`,
       },
+      'cost-management': {
+        name: 'cost-management',
+        scope: 'costManagement',
+        manifestLocation: `${window.location.origin}${isBeta() ? '/beta' : ''}/apps/cost-management/fed-mods.json`,
+      },
     }
   );
 


### PR DESCRIPTION
Cost needs to share modules across different bundles so we have to make it global.

Once we start working on the new nav structure, I think we should also decouple the module definition so we can have it defined in one place. Currently it "fails" because we only evaluate apps from the current bundle. We can have a separate section for modules and register them all at once.