### PR TITLE
Block app filter loading before first open

### DIFF
--- a/src/js/App/Header/AppFilter.js
+++ b/src/js/App/Header/AppFilter.js
@@ -54,9 +54,8 @@ const extraApps = [
 ];
 
 const AppFilter = () => {
-  const [isOpen, setIsOpen] = useState(false);
   const [filterValue, setFilterValue] = useState('');
-  const { apps, filteredApps, setFilteredApps, isLoaded } = useGlobalNav(isOpen);
+  const { apps, filteredApps, setFilteredApps, isLoaded, isOpen, setIsOpen } = useGlobalNav();
 
   useEffect(() => {
     setFilteredApps(

--- a/src/js/App/Header/AppFilter.js
+++ b/src/js/App/Header/AppFilter.js
@@ -56,7 +56,7 @@ const extraApps = [
 const AppFilter = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [filterValue, setFilterValue] = useState('');
-  const { apps, filteredApps, setFilteredApps, isLoaded } = useGlobalNav();
+  const { apps, filteredApps, setFilteredApps, isLoaded } = useGlobalNav(isOpen);
 
   useEffect(() => {
     setFilteredApps(

--- a/src/js/App/Sidenav/LandingNav.js
+++ b/src/js/App/Sidenav/LandingNav.js
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Nav, NavItem, NavList } from '@patternfly/react-core';
-import useGlobalNav from '../../utils/useGlobalNav';
 import { isBeta } from '../../utils';
-import NavLoader from './Loader';
 import './LandingNav.scss';
 import { useSelector } from 'react-redux';
 
@@ -21,7 +19,6 @@ const LandingNav = () => {
       setElementReady(true);
     }
   }, [showNav]);
-  const { isLoaded } = useGlobalNav();
   const isBetaEnv = isBeta();
 
   /**
@@ -32,20 +29,16 @@ const LandingNav = () => {
   }
   return (
     <Nav className="ins-c-landing-nav">
-      {!isLoaded ? (
-        <NavLoader />
-      ) : (
-        <NavList>
-          <div className="ins-c-app-title">
-            <b>Red Hat Hybrid Cloud Console</b>
-          </div>
-          {routes.map(({ title, id, route }) => (
-            <NavItem className="ins-m-navigation-align" key={id} to={`/${isBetaEnv ? 'beta/' : ''}${route}`}>
-              {title}
-            </NavItem>
-          ))}
-        </NavList>
-      )}
+      <NavList>
+        <div className="ins-c-app-title">
+          <b>Red Hat Hybrid Cloud Console</b>
+        </div>
+        {routes.map(({ title, id, route }) => (
+          <NavItem className="ins-m-navigation-align" key={id} to={`/${isBetaEnv ? 'beta/' : ''}${route}`}>
+            {title}
+          </NavItem>
+        ))}
+      </NavList>
     </Nav>
   );
 };

--- a/src/js/utils/useGlobalNav.js
+++ b/src/js/utils/useGlobalNav.js
@@ -5,7 +5,7 @@ import sourceOfTruth from '../nav/sourceOfTruth';
 
 const appIds = ['insights', 'openshift', 'cost-management', 'migrations', 'subscriptions', 'ansible', 'settings'];
 
-const useGlobalNav = () => {
+const useGlobalNav = (isOpen) => {
   const [state, setState] = useState({
     apps: [],
     filteredApps: [],
@@ -13,12 +13,15 @@ const useGlobalNav = () => {
   });
   const setFilteredApps = (filteredApps) => setState((prev) => ({ ...prev, filteredApps }));
   useEffect(() => {
-    (async () => {
-      const navigationYml = await sourceOfTruth();
-      const appData = await getNavFromConfig(load(navigationYml), undefined);
-      setState({ apps: appIds.map((id) => appData[id]).filter((app) => !!app), filteredApps: appIds.map((id) => appData[id]), isLoaded: true });
-    })();
-  }, []);
+    if (isOpen === true && state.isLoaded === false) {
+      setState({ ...state, isLoaded: null });
+      (async () => {
+        const navigationYml = await sourceOfTruth();
+        const appData = await getNavFromConfig(load(navigationYml), undefined);
+        setState({ apps: appIds.map((id) => appData[id]).filter((app) => !!app), filteredApps: appIds.map((id) => appData[id]), isLoaded: true });
+      })();
+    }
+  }, [isOpen]);
 
   return { ...state, setFilteredApps };
 };

--- a/src/js/utils/useGlobalNav.js
+++ b/src/js/utils/useGlobalNav.js
@@ -5,25 +5,32 @@ import sourceOfTruth from '../nav/sourceOfTruth';
 
 const appIds = ['insights', 'openshift', 'cost-management', 'migrations', 'subscriptions', 'ansible', 'settings'];
 
-const useGlobalNav = (isOpen) => {
+const useGlobalNav = () => {
   const [state, setState] = useState({
+    isOpen: false,
     apps: [],
     filteredApps: [],
     isLoaded: false,
   });
   const setFilteredApps = (filteredApps) => setState((prev) => ({ ...prev, filteredApps }));
+  const setIsOpen = (isOpen) => setState((prev) => ({ ...prev, isOpen }));
   useEffect(() => {
-    if (isOpen === true && state.isLoaded === false) {
+    if (state.isOpen === true && state.isLoaded === false) {
       setState({ ...state, isLoaded: null });
       (async () => {
         const navigationYml = await sourceOfTruth();
         const appData = await getNavFromConfig(load(navigationYml), undefined);
-        setState({ apps: appIds.map((id) => appData[id]).filter((app) => !!app), filteredApps: appIds.map((id) => appData[id]), isLoaded: true });
+        setState(({ isOpen }) => ({
+          apps: appIds.map((id) => appData[id]).filter((app) => !!app),
+          filteredApps: appIds.map((id) => appData[id]),
+          isLoaded: true,
+          isOpen,
+        }));
       })();
     }
-  }, [isOpen]);
+  }, [state.isOpen]);
 
-  return { ...state, setFilteredApps };
+  return { ...state, setFilteredApps, setIsOpen };
 };
 
 export default useGlobalNav;


### PR DESCRIPTION
### Do not fire nav filter calls

If app filter is not opened do not fire requests to filter the full navigation. This PR does that by setting `isLoaded` for global nav to 3rd state `null` in which the nav is being loaded this state is set once the filter is opened and nav has not been loaded yet. Once the nav is loaded no more requests are fired, you can open and close the app filter multipletimes while it is being processed and only one calculation will be fired.

![animation](https://user-images.githubusercontent.com/3439771/110930495-75e87b00-8329-11eb-89db-cc58662edd94.gif)


### Do not use global nav on landing nav

Since landing nav uses static list of nav items we don't have to use the globalNav there.