### PR TITLE
Fix nav loader styling

### DIFF
--- a/src/js/App/Sidenav/Loader.js
+++ b/src/js/App/Sidenav/Loader.js
@@ -1,7 +1,6 @@
 import React, { Fragment } from 'react';
-import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/components/cjs/Skeleton';
-import { Nav } from '@patternfly/react-core/dist/js/components/Nav/Nav';
-import { NavList } from '@patternfly/react-core/dist/js/components/Nav/NavList';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+import { Nav, NavList } from '@patternfly/react-core';
 import NavigationItem from './NavigationItem';
 
 const NavLoader = () => (

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -178,6 +178,10 @@ section.ins-c-app-switcher--loading {
     .pf-c-dropdown__toggle-icon { height: 1em; }
 }
 
+.ins-c-skeleton__link {
+    width: 100%;
+}
+
 // Pen testing
 .ins-c-pen-test {
     border-top: 3px solid #A18FFF;


### PR DESCRIPTION
The loader links were not full width

![nav-loader](https://user-images.githubusercontent.com/22619452/111126919-855b0480-8573-11eb-92cf-8996fd5a4010.gif)
