### PR TITLE
Optimize rendering in left navigation components

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -41,7 +41,7 @@ const ShieldedRoot = memo(
             headerTools={<HeaderTools />}
           />
         }
-        sidebar={hideNav ? undefined : <PageSidebar id="ins-c-sidebar" nav={useLandingNav ? <LandingNav /> : <SideNav />} />}
+        sidebar={hideNav ? undefined : <PageSidebar id="ins-c-sidebar" nav={useLandingNav ? <LandingNav /> : <SideNav key="side-nav" />} />}
       >
         <div ref={insightsContentRef} className={classnames('ins-c-render', { 'ins-m-full--height': !isGlobalFilterEnabled })}>
           {isGlobalFilterEnabled && <GlobalFilter />}

--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -102,16 +102,16 @@ NavItemLink.propTypes = {
 
 export const Navigation = () => {
   const { activeApp, activeLocation, activeGroup, appId } = useSelector(
-    ({ chrome: { activeApp, activeLocation, activeGroup, appId } }) => ({
-      activeApp,
-      activeLocation,
-      activeGroup,
-      appId,
+    ({ chrome }) => ({
+      activeApp: chrome?.activeApp,
+      activeLocation: chrome?.activeLocation,
+      activeGroup: chrome?.activeGroup,
+      appId: chrome?.appId,
     }),
     shallowEqual
   );
-  const activeSection = useSelector(({ chrome: { activeSection } }) => activeSection, activeSectionComparator);
-  const settings = useSelector(({ chrome: { globalNav } }) => globalNav, globalNavComparator);
+  const activeSection = useSelector(({ chrome }) => chrome?.activeSection, activeSectionComparator);
+  const settings = useSelector(({ chrome }) => chrome?.globalNav, globalNavComparator);
   const dispatch = useDispatch();
   const history = useHistory();
   const prevLocation = useRef(window.location.pathname);

--- a/src/js/App/Sidenav/Navigation.js
+++ b/src/js/App/Sidenav/Navigation.js
@@ -12,6 +12,7 @@ import './Navigation.scss';
 import SectionNav from './SectionNav';
 import { useHistory } from 'react-router-dom';
 import { isBeta } from '../../utils';
+import { activeSectionComparator, globalNavComparator } from '../../utils/comparators';
 
 const basepath = document.baseURI;
 
@@ -100,17 +101,17 @@ NavItemLink.propTypes = {
 };
 
 export const Navigation = () => {
-  const { settings, activeApp, activeLocation, activeSection, activeGroup, appId } = useSelector(
-    ({ chrome: { globalNav, activeApp, activeLocation, activeSection, activeGroup, appId } }) => ({
-      settings: globalNav,
+  const { activeApp, activeLocation, activeGroup, appId } = useSelector(
+    ({ chrome: { activeApp, activeLocation, activeGroup, appId } }) => ({
       activeApp,
       activeLocation,
-      activeSection,
       activeGroup,
       appId,
     }),
     shallowEqual
   );
+  const activeSection = useSelector(({ chrome: { activeSection } }) => activeSection, activeSectionComparator);
+  const settings = useSelector(({ chrome: { globalNav } }) => globalNav, globalNavComparator);
   const dispatch = useDispatch();
   const history = useHistory();
   const prevLocation = useRef(window.location.pathname);

--- a/src/js/App/Sidenav/SideNav.js
+++ b/src/js/App/Sidenav/SideNav.js
@@ -12,9 +12,9 @@ import { globalNavComparator } from '../../utils/comparators';
 export const SideNav = () => {
   const dispatch = useDispatch();
 
-  const activeTechnology = useSelector(({ chrome: { activeTechnology } }) => activeTechnology);
-  const appId = useSelector(({ chrome: { appId } }) => appId);
-  const globalNav = useSelector(({ chrome: { globalNav } }) => globalNav, globalNavComparator);
+  const activeTechnology = useSelector(({ chrome }) => chrome?.activeTechnology);
+  const appId = useSelector(({ chrome }) => chrome?.appId);
+  const globalNav = useSelector(({ chrome }) => chrome?.globalNav, globalNavComparator);
   const isFirst = useRef(true);
 
   useEffect(() => {

--- a/src/js/App/Sidenav/SideNav.js
+++ b/src/js/App/Sidenav/SideNav.js
@@ -1,5 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
+import React, { Fragment, useEffect, useRef } from 'react';
 import Navigation from './Navigation';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -8,13 +7,18 @@ import { appNavClick } from '../../redux/actions';
 import NavLoader from './Loader';
 import './SideNav.scss';
 import { isFilterEnabled } from '../../utils/isAppNavEnabled';
+import { globalNavComparator } from '../../utils/comparators';
 
 export const SideNav = () => {
   const dispatch = useDispatch();
-  const { activeTechnology, globalNav, appId } = useSelector(({ chrome }) => chrome);
-  const [isFirst, setIsFirst] = useState(true);
+
+  const activeTechnology = useSelector(({ chrome: { activeTechnology } }) => activeTechnology);
+  const appId = useSelector(({ chrome: { appId } }) => appId);
+  const globalNav = useSelector(({ chrome: { globalNav } }) => globalNav, globalNavComparator);
+  const isFirst = useRef(true);
+
   useEffect(() => {
-    if (globalNav && isFirst) {
+    if (globalNav && isFirst.current) {
       const { subItems } = globalNav?.find?.(({ active }) => active) || {};
       const defaultActive =
         subItems?.find?.(({ id }) => location.pathname.split('/').find((item) => item === id)) ||
@@ -22,7 +26,7 @@ export const SideNav = () => {
         subItems?.[0];
 
       dispatch(appNavClick(defaultActive || {}));
-      setIsFirst(() => false);
+      isFirst.current = false;
     }
   }, [globalNav]);
 
@@ -34,16 +38,6 @@ export const SideNav = () => {
   ) : (
     <NavLoader />
   );
-};
-
-SideNav.propTypes = {
-  activeTechnology: PropTypes.string,
-  globalNav: PropTypes.arrayOf(PropTypes.object),
-};
-
-SideNav.defaultProps = {
-  activeTechnology: '',
-  activeLocation: '',
 };
 
 export default SideNav;

--- a/src/js/utils/comparators.js
+++ b/src/js/utils/comparators.js
@@ -1,0 +1,9 @@
+import isEqual from 'lodash/isEqual';
+
+export const globalNavComparator = (a, b) =>
+  isEqual(
+    a?.map(({ id }) => id),
+    b?.map(({ id }) => id)
+  );
+
+export const activeSectionComparator = (a, b) => a.id === b.id;

--- a/src/js/utils/comparators.js
+++ b/src/js/utils/comparators.js
@@ -6,4 +6,4 @@ export const globalNavComparator = (a, b) =>
     b?.map(({ id }) => id)
   );
 
-export const activeSectionComparator = (a, b) => a.id === b.id;
+export const activeSectionComparator = (a, b) => a?.id === b?.id;

--- a/src/js/utils/comparators.test.js
+++ b/src/js/utils/comparators.test.js
@@ -1,0 +1,43 @@
+import { activeSectionComparator, globalNavComparator } from './comparators';
+
+describe('comparators', () => {
+  describe('globalNav', () => {
+    const globalNav1 = [
+      { title: 'Sources', module: 'sources#./RootApp', id: 'sources', active: false },
+      {
+        title: 'Integrations',
+        module: { appName: 'integrations', scope: 'notifications', module: './RootApp', manifest: '/apps/notifications/fed-mods.json' },
+        id: 'integrations',
+        active: false,
+      },
+    ];
+    const globalNav2 = [
+      {
+        title: 'My User Access',
+        module: { appName: 'my-user-access', scope: 'rbac', module: './RootApp', manifest: '/apps/rbac/fed-mods.json' },
+        id: 'my-user-access',
+        default: true,
+        active: false,
+      },
+      { title: 'Sources', module: 'sources#./RootApp', id: 'sources', active: false },
+    ];
+
+    it('same', () => {
+      expect(globalNavComparator(globalNav1, globalNav1)).toEqual(true);
+    });
+
+    it('different', () => {
+      expect(globalNavComparator(globalNav1, globalNav2)).toEqual(false);
+    });
+  });
+
+  describe('activeSectionComparator', () => {
+    it('same', () => {
+      expect(activeSectionComparator({ id: 'sources' }, { id: 'sources' })).toEqual(true);
+    });
+
+    it('different', () => {
+      expect(activeSectionComparator({ id: 'sources' }, { id: 'integrations' })).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
- better comparators for checking complex items
- useState replaced with useRef to not trigger additional render

**Known issue**

When you switch applications in the side nav, the navigation is rendered 2x - first when the click is done, second when identifyApp is triggered from the app. You can see it on the nav itself - when you switch you can see it took a while to 'select' the app:

![Kapture 2021-03-15 at 12 41 11](https://user-images.githubusercontent.com/32869456/111150658-a7ae4b80-858e-11eb-8540-d290252996fb.gif)

@Hyperkid123 
