### PR TITLE
Use just the new remediations wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5317,13 +5317,40 @@
       }
     },
     "@redhat-cloud-services/frontend-components-remediations": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-3.0.0.tgz",
-      "integrity": "sha512-0rvLLB+61CL6uWd8JXzfhvFCF4KlIMf9LvWGGzRG8hwD/mhuzuYk2odVltyUojirSsJPrIeYfk23MuFVNRUeQQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-3.1.1.tgz",
+      "integrity": "sha512-LLk4AgnQmitAH08oWGnIA608rbyelvxmA5F5KPmV2xlpdkwmO/f+DJyZA/DtvDEeXfp1bAXtms8wuFTHYOoh9g==",
       "requires": {
+        "@data-driven-forms/pf4-component-mapper": "^2.23.3",
+        "@data-driven-forms/react-form-renderer": "^2.23.3",
         "@redhat-cloud-services/frontend-components": ">=3.0.0",
         "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
         "urijs": "^1.19.4"
+      },
+      "dependencies": {
+        "@data-driven-forms/pf4-component-mapper": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-2.24.0.tgz",
+          "integrity": "sha512-GRReWOSGcDdLgypmbRLFSt+XJQjUcIUylMbjb8Oc2qUbOL/EqlkspKD8aRx5ViLuq9lT9CdQO+f2SBuJ8eJdrw==",
+          "requires": {
+            "downshift": "^5.4.3",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@data-driven-forms/react-form-renderer": {
+          "version": "2.24.1",
+          "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-2.24.1.tgz",
+          "integrity": "sha512-0UeHFFNPCc2XiYMHwnlW+N4Wrag9eygZD+mkPwKu6MAFweH1eWn4D4N3LUkE4O6FJw16mPMzfI3iizXN8T9uQA==",
+          "requires": {
+            "final-form": "^4.20.0",
+            "final-form-arrays": "^3.0.2",
+            "final-form-focus": "^1.1.2",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.7.2",
+            "react-final-form": "^6.5.0",
+            "react-final-form-arrays": "^3.1.1"
+          }
+        }
       }
     },
     "@redhat-cloud-services/frontend-components-translations": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@redhat-cloud-services/frontend-components-inventory-patchman": "^1.11.1",
     "@redhat-cloud-services/frontend-components-inventory-vulnerabilities": "^1.63.1",
     "@redhat-cloud-services/frontend-components-notifications": "^3.0.4",
-    "@redhat-cloud-services/frontend-components-remediations": "^3.0.0",
+    "@redhat-cloud-services/frontend-components-remediations": "^3.1.1",
     "@redhat-cloud-services/frontend-components-utilities": "^3.0.3",
     "@redhat-cloud-services/host-inventory-client": "^1.0.93",
     "@redhat-cloud-services/keycloak-js": "0.0.3",

--- a/src/js/remediations/index.js
+++ b/src/js/remediations/index.js
@@ -16,10 +16,7 @@ export default async function loadRemediation(dependencies) {
     },
     // eslint-disable-next-line react/display-name
     RemediationWizard: () => (
-      <RenderWrapper.default
-        cmp={localStorage.getItem('remediations:debug') === 'true' ? remediationsData.NewRemediationWizard : remediationsData.RemediationWizard}
-        onAppRender={(wizardRef) => deferred.resolve(wizardRef)}
-      />
+      <RenderWrapper.default cmp={remediationsData.RemediationWizard} onAppRender={(wizardRef) => deferred.resolve(wizardRef)} />
     ),
   };
 }


### PR DESCRIPTION
### Use just the new remediations wizard

Since we have the new remediations wizard up and running and no longer upport old one, we should flip the logic of using just the new remediations wizard.

### **Merge after**
* [ ] https://github.com/RedHatInsights/frontend-components/pull/1031