### PR TITLE
Add a temporary patch for approval fed modules.

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -99,6 +99,14 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
       !isLanding &&
       chrome?.modules?.reduce((app, curr) => {
         const [currKey] = Object.keys(curr);
+        /**
+         * hot fix for modules defined in sub apps
+         * Chrome can't handle it right now. We will come up with a propper solution this just needs to go in quickly
+         */
+        if (chrome?.activeApp === 'approval' && chrome?.activeSection?.id === 'catalog' && currKey === chrome?.activeApp) {
+          app = curr[currKey];
+        }
+
         if (isModule(currKey, chrome) || isModule(curr?.[currKey]?.module?.group, chrome)) {
           app = curr[currKey];
         }

--- a/src/js/nav/globalNav.js
+++ b/src/js/nav/globalNav.js
@@ -2,7 +2,7 @@ import { visibilityFunctions, isVisible } from '../consts';
 import { load } from 'js-yaml';
 import flatMap from 'lodash/flatMap';
 import { getUrl, isBeta } from '../utils';
-import flatten from 'lodash/flatten';
+import flattenDeep from 'lodash/flattenDeep';
 
 export let getNavFromConfig = async (masterConfig, active) => {
   return await Object.keys(masterConfig)
@@ -155,6 +155,6 @@ export async function loadNav(yamlConfig, cache) {
           globalNav,
           activeTechnology: 'Applications',
         }),
-    modules: flatten((activeBundle[active] || activeBundle.insights)?.modules || []),
+    modules: flattenDeep((activeBundle[active] || activeBundle.insights)?.modules || []),
   };
 }


### PR DESCRIPTION
We currently don't resolve sub-apps module definition. This blocks the approval UI and @lgalis from migration to chrome 2.

I will add a proper fix tomorrow morning but I want to unblock @lgalis so they can continue to work on their app. I have a suspicion there will be a similar error in the navigation when navigating to a from sub-apps that are not the same app. I will address that as well in a follow-UP pr with a propper long-term fix.