### PR TITLE
Include parent for better navigation in appFilter

### DIFF
--- a/src/js/App/Header/AppFilter.js
+++ b/src/js/App/Header/AppFilter.js
@@ -44,20 +44,23 @@ const getIcon = (id) =>
     subscriptions: <IconSubscriptions alt="Subscriptions Logo" />,
   }[id]);
 
-const App = ({ id, title, routes }) => (
+const App = ({ id, title, routes, parent }) => (
   <div className="galleryItem">
     <Split>
       <SplitItem className="left">{getIcon(id)}</SplitItem>
       <SplitItem className="right">
         <TextContent>
           <Text component="h4">{title}</Text>
-          {routes.map((subApp) => (
-            <Text component="p" key={`${id}/${subApp.id}`}>
-              <Text component="a" href={`${id}/${subApp.id}`}>
-                {subApp.title}
+          {routes.map((subApp) => {
+            const redirectUrl = subApp.reload || `${parent ? `${parent.id}/` : ''}${id}/${subApp.id}`;
+            return (
+              <Text component="p" key={`${id}/${subApp.id}`}>
+                <Text component="a" href={redirectUrl}>
+                  {subApp.title}
+                </Text>
               </Text>
-            </Text>
-          ))}
+            );
+          })}
         </TextContent>
       </SplitItem>
     </Split>
@@ -68,6 +71,9 @@ App.propTypes = {
   id: PropTypes.string,
   title: PropTypes.node,
   routes: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string.isRequired })),
+  parent: PropTypes.shape({
+    id: PropTypes.string,
+  }),
 };
 
 const AppFilterDropdown = ({ isLoaded, setIsOpen, isOpen, filterValue, setFilterValue, filteredApps }) => (

--- a/src/js/utils/useGlobalNav.js
+++ b/src/js/utils/useGlobalNav.js
@@ -30,12 +30,18 @@ const useGlobalNav = () => {
       (async () => {
         const navigationYml = await sourceOfTruth();
         const appData = await getNavFromConfig(load(navigationYml), undefined);
-        setState((prev) => ({
-          ...prev,
-          apps: appIds.map((id) => appData[id]).filter((app) => !!app),
-          filteredApps: appIds.map((id) => appData[id]),
-          isLoaded: true,
-        }));
+        setState((prev) => {
+          const apps = appIds.map((id) => appData[id]).filter((app) => !!app);
+          return {
+            ...prev,
+            apps: apps,
+            filteredApps: appIds.map((id) => ({
+              ...appData[id],
+              parent: apps?.find(({ routes }) => routes?.find(({ id: appId }) => appId === id)),
+            })),
+            isLoaded: true,
+          };
+        });
       })();
     }
   }, [state.isOpen]);


### PR DESCRIPTION
### Adjust nested app filter navigation

Since we want to surface some apps that are nested in bundles in appFilter (cost-management and subscriptions) we have to include the app ID for better navigation. This PR also allows using `reload` when navigating to each app in appFilter.