### PR TITLE
Populate entitlements on landing page as well

### DIFF
--- a/src/js/jwt/insights/user.js
+++ b/src/js/jwt/insights/user.js
@@ -71,7 +71,7 @@ function tryBounceIfUnentitled(data, section) {
   }
 
   if (section && section !== '') {
-    if (data[service] && data[service].is_entitled) {
+    if (data?.[service]?.is_entitled) {
       log(`Entitled to: ${service}`);
     } else {
       log(`Not entitled to: ${service}`);
@@ -80,7 +80,7 @@ function tryBounceIfUnentitled(data, section) {
   }
 }
 
-export default (token) => {
+export default async (token) => {
   let user = buildUser(token);
 
   const pathName = getWindow().location.pathname.split('/');
@@ -91,21 +91,25 @@ export default (token) => {
 
   if (user) {
     log(`Account Number: ${user.identity.account_number}`);
+    let data;
+    try {
+      data = await servicesApi(token.jti).servicesGet();
+    } catch {
+      // let's swallow error from services API
+    }
 
     // NOTE: Openshift supports Users with Account Number of -1
     // thus we need to bypass here
-    // dont call entitlements on / /beta /openshift or /beta/openshift
+    // call entitlements on / /beta /openshift or /beta/openshift,
+    // but swallow error
     //
     // Landing Page *does* support accounts with -1
     // it has to
     if (pageAllowsUnentitled()) {
-      return new Promise((resolve) => {
-        user.identity = {
-          ...user.identity,
-          entitlements: {},
-        };
-        resolve(user);
-      });
+      return {
+        ...user,
+        entitlements: data || {}, // if the services returned error, use empty object
+      };
     }
 
     // Important this has to come after the above -1 allow checks
@@ -121,18 +125,13 @@ export default (token) => {
       return;
     }
 
-    return servicesApi(token.jti)
-      .servicesGet()
-      .then((data) => {
-        tryBounceIfUnentitled(data, pathName[0]);
-        return {
-          ...user,
-          entitlements: data,
-        };
-      });
+    tryBounceIfUnentitled(data, pathName[0]);
+
+    return {
+      ...user,
+      entitlements: data,
+    };
   } else {
     log('User not ready');
   }
-
-  return new Promise((res) => res());
 };

--- a/src/js/jwt/insights/user.unit.test.js
+++ b/src/js/jwt/insights/user.unit.test.js
@@ -66,8 +66,8 @@ describe('User', () => {
   /* eslint-enable camelcase */
 
   describe('default', () => {
-    test('appends the entitlements data onto the user object', () => {
-      const o = user.default(token);
+    test('appends the entitlements data onto the user object', async () => {
+      const o = await user.default(token);
       expect(o).toHaveProperty('entitlements', { foo: 'bar' });
       expect(o).toHaveProperty('identity');
     });


### PR DESCRIPTION
### No entitlements on landing page

Since we want to check if user has entitlements on landing page as well, call entitlements API on any page, if the page does not support entitlements continue as before. If the page supports entitlements and user has -1, show this information. If user has no entitlements for specific place bounce them to landing page.