### PR TITLE
Fix switching back to stable release

### DIFF
--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -22,7 +22,7 @@ import { isBeta } from '../../utils';
 export const switchRelease = (isBeta, pathname) => {
   cookie.set('cs_toggledRelease', 'true');
   if (isBeta) {
-    return `${document.baseURI}${pathname.replace(/\/*beta\/*/, '')}`;
+    return `${document.baseURI.replace(/\/*beta/, '')}${pathname.replace(/\/*beta\/*/, '')}`;
   } else {
     let path = pathname.split('/');
     path[0] = 'beta';


### PR DESCRIPTION
### Switching to stable not working

There is a bug, that when switching back to stable release the page stays on beta. This PR fixes such issue by removing `beta` from `baseURI` and from `pathname` as well.