### PR TITLE
Menu restyling: take 4

### DIFF
--- a/src/js/App/Sidenav/SectionNav.scss
+++ b/src/js/App/Sidenav/SectionNav.scss
@@ -40,6 +40,10 @@
             .pf-c-nav__item {
               .pf-c-nav__link{
                 padding-left: var(--pf-global--spacer--sm);
+                svg {
+                  width: 12px;
+                  height: 12px;
+                }
               }
             }
           }
@@ -55,6 +59,10 @@
       --pf-c-nav__link--hover--after--BorderColor:  var(--pf-global--primary-color--light-100);
       a {
         padding-left: var(--pf-global--spacer--sm)
+      }
+      svg {
+        width: 12px;
+        height: 12px;
       }
     }
   }


### PR DESCRIPTION
Change external links icons to 12px

![Screen Shot 2021-03-29 at 9 54 31 AM](https://user-images.githubusercontent.com/1287144/112847202-d5a68c00-9074-11eb-899f-8806d6a6a10d.png)
