### PR TITLE
Fix sub apps module loading.

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -17,7 +17,8 @@ import LoadingFallback from '../utils/loading-fallback';
 
 const isModule = (key, chrome) =>
   key === (chrome?.activeSection?.id || chrome?.activeLocation) ||
-  (key !== undefined && chrome?.activeSection?.group !== undefined && key === chrome?.activeSection?.group);
+  (key !== undefined && chrome?.activeSection?.group !== undefined && key === chrome?.activeSection?.group) ||
+  key === chrome?.activeApp;
 
 const ShieldedRoot = memo(
   ({ useLandingNav, hideNav, insightsContentRef, isGlobalFilterEnabled, initialized, remoteModule, appId }) => {
@@ -99,14 +100,6 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
       !isLanding &&
       chrome?.modules?.reduce((app, curr) => {
         const [currKey] = Object.keys(curr);
-        /**
-         * hot fix for modules defined in sub apps
-         * Chrome can't handle it right now. We will come up with a propper solution this just needs to go in quickly
-         */
-        if (chrome?.activeApp === 'approval' && chrome?.activeSection?.id === 'catalog' && currKey === chrome?.activeApp) {
-          app = curr[currKey];
-        }
-
         if (isModule(currKey, chrome) || isModule(curr?.[currKey]?.module?.group, chrome)) {
           app = curr[currKey];
         }

--- a/src/js/App/Sidenav/SideNav.js
+++ b/src/js/App/Sidenav/SideNav.js
@@ -22,6 +22,7 @@ export const SideNav = () => {
       const { subItems } = globalNav?.find?.(({ active }) => active) || {};
       const defaultActive =
         subItems?.find?.(({ id }) => location.pathname.split('/').find((item) => item === id)) ||
+        subItems?.find?.(({ reload }) => reload && window.location.pathname.includes(reload)) ||
         subItems?.find?.(({ default: isDefault }) => isDefault) ||
         subItems?.[0];
 


### PR DESCRIPTION
This fixes 2 issues.
1. when a sub-app of an app is a standalone build and we need to load it as a remote module
2. When app id does not match the URL, we will use the reload string to match it with current location