### PR TITLE
Add module ID exception rules for sub apps.

### DIFF
--- a/src/js/App/RootApp.js
+++ b/src/js/App/RootApp.js
@@ -14,6 +14,7 @@ import LandingNav from './Sidenav/LandingNav';
 import isEqual from 'lodash/isEqual';
 import { onToggle } from '../redux/actions';
 import LoadingFallback from '../utils/loading-fallback';
+import checkSubAppExceptionModule from '../utils/modulesExceptions';
 
 const isModule = (key, chrome) =>
   key === (chrome?.activeSection?.id || chrome?.activeLocation) ||
@@ -102,8 +103,9 @@ const RootApp = ({ activeApp, activeLocation, appId, config, pageAction, pageObj
         /**
          * hot fix for modules defined in sub apps
          * Chrome can't handle it right now. We will come up with a propper solution this just needs to go in quickly
+         * Use it as a first condition so it wont override already working module identifications
          */
-        if (chrome?.activeApp === 'approval' && chrome?.activeSection?.id === 'catalog' && currKey === chrome?.activeApp) {
+        if (checkSubAppExceptionModule(currKey, chrome)) {
           app = curr[currKey];
         }
 

--- a/src/js/utils/modulesExceptions.js
+++ b/src/js/utils/modulesExceptions.js
@@ -1,0 +1,26 @@
+const checkApproval = (moduleKey, chrome) =>
+  chrome?.activeApp === 'approval' && chrome?.activeSection?.id === 'catalog' && moduleKey === chrome?.activeApp;
+
+const checkSubsCentral = (_moduleKey, chrome) => chrome?.activeApp === 'rhel' && window.location.pathname.includes('/subscriptions/manifests');
+
+const moduleRules = {
+  approval: checkApproval,
+  'subscription-central': checkSubsCentral,
+};
+
+/**
+ * @deprecated
+ * This is a hotfix required before the nav system rework
+ * It fixes issues with sub apps being separate modules
+ * Unfortunately there is no common pattern and we can easily generalize the rules witout breaking normal remoe module identification.
+ * So we need special rule for each sub app
+ */
+function checkSubAppExceptionModule(moduleKey, chrome) {
+  const fn = moduleRules[moduleKey];
+  if (typeof fn === 'function') {
+    return fn(moduleKey, chrome);
+  }
+  return false;
+}
+
+export default checkSubAppExceptionModule;


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-13280

This is a dumb solution but won't break existing module identification... Nothing more we can do before the nav re-work.