### PR TITLE
Fix beta-switcher badge colors

### DIFF
--- a/src/js/App/Header/Tools.scss
+++ b/src/js/App/Header/Tools.scss
@@ -2,7 +2,12 @@
     display: flex;
 }
 
-.ins-c-toolbar__beta-badge {
-    background-color: var(--pf-global--primary-color--200);
-    margin-right: var(--pf-global--spacer--sm);
+header.pf-c-page__header {
+    button#SettingsMenu {
+        span.ins-c-toolbar__beta-badge {
+            background-color: var(--pf-global--palette--green-300);
+            color: var(--pf-global--Color--dark-100);
+            margin-right: var(--pf-global--spacer--sm);
+        }
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-13181

Changed beta-switcher color in the top navbar

![beta-switcher01](https://user-images.githubusercontent.com/50696716/113142658-6f179e80-922b-11eb-8fa4-839c1ee1293e.png)
![beta-switcher02](https://user-images.githubusercontent.com/50696716/113142660-6fb03500-922b-11eb-9786-b1b353fb75f4.png)
![beta-switcher03](https://user-images.githubusercontent.com/50696716/113142662-7048cb80-922b-11eb-90cb-63415b3ecb17.png)
![beta-switcher04](https://user-images.githubusercontent.com/50696716/113142663-7048cb80-922b-11eb-87a5-d3516df8345b.png)

@mmenestr
