### PR TITLE
TEAMNADO-2098 Removing Subscription Central Nav Exception

### DIFF
--- a/src/js/utils/modulesExceptions.js
+++ b/src/js/utils/modulesExceptions.js
@@ -1,11 +1,10 @@
 const checkApproval = (moduleKey, chrome) =>
   chrome?.activeApp === 'approval' && chrome?.activeSection?.id === 'catalog' && moduleKey === chrome?.activeApp;
 
-const checkSubsCentral = (_moduleKey, chrome) => chrome?.activeApp === 'rhel' && window.location.pathname.includes('/subscriptions/manifests');
+
 
 const moduleRules = {
   approval: checkApproval,
-  'subscription-central': checkSubsCentral,
 };
 
 /**

--- a/src/js/utils/modulesExceptions.js
+++ b/src/js/utils/modulesExceptions.js
@@ -1,8 +1,6 @@
 const checkApproval = (moduleKey, chrome) =>
   chrome?.activeApp === 'approval' && chrome?.activeSection?.id === 'catalog' && moduleKey === chrome?.activeApp;
 
-
-
 const moduleRules = {
   approval: checkApproval,
 };


### PR DESCRIPTION
After conversation with @karelhala, we changed the app name to be `manifests` to match the route.  As a result, the hotfix mapping subscription-central to manifests can be removed, since the bundle is now also called manifests.

/cc @Hyperkid123 