### PR TITLE
TEAMNADO-2098 Adding Manifest Exception Rule

### DIFF
--- a/src/js/utils/modulesExceptions.js
+++ b/src/js/utils/modulesExceptions.js
@@ -1,8 +1,11 @@
 const checkApproval = (moduleKey, chrome) =>
   chrome?.activeApp === 'approval' && chrome?.activeSection?.id === 'catalog' && moduleKey === chrome?.activeApp;
 
+const checkManifests = (_moduleKey, chrome) => chrome?.activeApp === 'rhel' && window.location.pathname.includes('/subscriptions/manifests');
+
 const moduleRules = {
   approval: checkApproval,
+  manifests: checkManifests,
 };
 
 /**


### PR DESCRIPTION
Adds an exception for the /subscriptions/manifests to point to the newly named manifests bundle.

cc @Hyperkid123 @karelhala 