### PR TITLE
Ugly fix for cost management active nav

### DIFF
--- a/src/js/App/Sidenav/ExpandableNav.js
+++ b/src/js/App/Sidenav/ExpandableNav.js
@@ -32,7 +32,8 @@ const ExpandableNav = ({ subItems, onClick, title, id, active, ignoreCase, activ
       ouiaId={id}
       title={title}
       parent={activeLocation}
-      isActive={active || id === activeApp}
+      // TODO: Fix me! Please! This is ugly!
+      isActive={!window.location.pathname.includes('openshift/cost-management/') && (active || id === activeApp)}
       onClick={onClick}
       navigate={navigate}
       isBeta={isBeta}


### PR DESCRIPTION
### Two nav items active

When cost-management is activated it also shows as active openshift application. This PR is quick and dirty solution, I don't thing we can make it more pretty on such short notice. It will ignore the first nav item and render active just the nested nav.

##### Before

![Screenshot from 2021-04-09 15-50-08](https://user-images.githubusercontent.com/3439771/114190263-691c6e80-994b-11eb-831a-a691c0c5e017.png)

##### After
![Screenshot from 2021-04-09 15-50-47](https://user-images.githubusercontent.com/3439771/114190282-6faae600-994b-11eb-83a3-fd335d07b722.png)
