### PR TITLE
Make visibility apiRequest error human readable.

### DIFF
--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -69,15 +69,15 @@ export const visibilityFunctions = {
   isBeta: () => insights.chrome.isBeta(),
   loosePermissions: (permissions) => checkPermissions(permissions, 'some'),
   hasPermissions: checkPermissions,
-  apiRequest: async ({ url, method, accessor, matcher, ...options }) => {
+  apiRequest: async ({ url, method = 'GET', accessor, matcher, ...options }) => {
     return instance({
       url,
-      method: method || 'GET',
+      method,
       ...options,
     })
       .then((response) => matchValue(accessor ? get(response || {}, accessor) : response, matcher))
-      .catch((err) => {
-        console.log(err);
+      .catch(() => {
+        console.log('Unable to retrieve visibility result', { visibilityMethod: 'apiRequest', method, url });
         return false;
       });
   },


### PR DESCRIPTION
The mangled error messages are caused by one of our Axios instance interceptors. It expects an error object not an HTML document as an error response.

Instead of showing the error, we now show a generic message and some crucial metada. The error is still visible in the console and network tab so we know what has actually happened.

The message looks something like this:
```bash
Unable to retrieve visibility result {visibilityMethod: "apiRequest", method: "GET", url: "/api/image-builder/v1/version"}
```