### PR TITLE
Masthead mobile fix

### DIFF
--- a/src/js/App/Header/AppFilter.scss
+++ b/src/js/App/Header/AppFilter.scss
@@ -1,4 +1,5 @@
-@media screen and (max-width:768px) {
+@import '~@patternfly/patternfly/sass-utilities/_all';
+@media screen and (max-width: $pf-global--breakpoint--md) {
   .pf-c-page__header {
     &-tools-group {
       margin-left: 0 !important;
@@ -28,9 +29,9 @@
       --pf-c-dropdown__toggle--before--BorderLeftColor: var(--pf-global--disabled-color--100);
     }
   }
-  @media screen and (max-width:768px) { 
+  @media screen and (max-width: $pf-global--breakpoint--md) { 
       .pf-c-dropdown__toggle {
-        margin-left: 10px;
+        margin-left: var(--pf-global--spacer--md);
       }
   }
   .pf-c-dropdown__menu::before {
@@ -94,7 +95,7 @@
       }
     }
   }
-  @media screen and (max-width:768px) { 
+  @media screen and (max-width: $pf-global--breakpoint--md) { 
     .pf-c-dropdown__menu {
       bottom:0; // allows scrolling
       div.gallery {

--- a/src/js/App/Header/ContextSwitcher.scss
+++ b/src/js/App/Header/ContextSwitcher.scss
@@ -1,3 +1,4 @@
+@import '~@patternfly/patternfly/sass-utilities/_all';
 .ins-c-page__context-switcher-dropdown {
   .pf-c-dropdown__toggle {
     display: inline-block;
@@ -62,5 +63,13 @@
 .context-switcher-banner {
   margin-bottom: 18px;
   transition: margin-bottom .3s;
+}
+
+@media screen and (max-width: $pf-global--breakpoint--xl) {
+  .ins-c-page__context-switcher-dropdown {
+    .pf-c-dropdown__toggle {
+      display: none;
+    }
+  }
 }
 


### PR DESCRIPTION
This PR hides the context switcher at the same breakpoint as the menu to prevent the mobile masthead from breaking

![Screen Shot 2021-04-19 at 2 26 11 PM](https://user-images.githubusercontent.com/1287144/115288420-6a098900-a11f-11eb-91ad-8540a3d8f10e.png)
![Screen Shot 2021-04-19 at 2 26 23 PM](https://user-images.githubusercontent.com/1287144/115288422-6aa21f80-a11f-11eb-8cd7-c98d9829f2b6.png)
![Screen Shot 2021-04-19 at 2 26 46 PM](https://user-images.githubusercontent.com/1287144/115288421-6aa21f80-a11f-11eb-8f89-a669fbd5c424.png)

