### PR TITLE
Redirect subscription and cost-management when unentitled

### DIFF
--- a/src/js/jwt/insights/user.js
+++ b/src/js/jwt/insights/user.js
@@ -88,6 +88,9 @@ export default async (token) => {
   if (pathName[0] === 'beta') {
     pathName.shift();
   }
+  if (pathName?.[1] === 'subscriptions' || pathName?.[1] === 'cost-management') {
+    pathName.shift();
+  }
 
   if (user) {
     log(`Account Number: ${user.identity.account_number}`);


### PR DESCRIPTION
Subscriptions and cost-management are now part of `/openshift` or `/insight`
 
https://issues.redhat.com/browse/RHCLOUD-13435
