### PR TITLE
Load tags only if global filter not disabled

### DIFF
--- a/src/js/App/GlobalFilter/GlobalFilter.js
+++ b/src/js/App/GlobalFilter/GlobalFilter.js
@@ -209,10 +209,10 @@ const GlobalFilter = () => {
         setValue(() => data);
         setToken(() => currToken);
       })();
-    } else if (userLoaded && token && isAllowed()) {
+    } else if (userLoaded && token && isAllowed() && !isDisabled) {
       loadTags(selectedTags, filterScope, filterTagsBy, token);
     }
-  }, [selectedTags, filterScope, userLoaded, isAllowed()]);
+  }, [selectedTags, filterScope, userLoaded, isAllowed(), isDisabled]);
 
   useEffect(() => {
     if (userLoaded && isAllowed()) {


### PR DESCRIPTION
### Do not fire tags when app disables it

With the chrome 2 enabled chrome renders before an app and if app wants to disable the global filter requests for fetching tags and sap info are fired before the app calls chrome to disable global filter. This PR fixes such issue by not fetching global filter values if global filter is diabled.