### PR TITLE
Add edge to app filter

### DIFF
--- a/src/js/utils/useGlobalNav.js
+++ b/src/js/utils/useGlobalNav.js
@@ -3,7 +3,7 @@ import { load } from 'js-yaml';
 import { getNavFromConfig } from '../nav/globalNav';
 import sourceOfTruth from '../nav/sourceOfTruth';
 
-const appIds = ['application-services', 'openshift', 'insights', 'ansible', 'settings'];
+const appIds = ['application-services', 'openshift', 'insights', 'edge', 'ansible', 'settings'];
 const useGlobalNav = () => {
   const [state, setState] = useState({
     isOpen: false,
@@ -25,10 +25,12 @@ const useGlobalNav = () => {
           return {
             ...prev,
             apps: apps,
-            filteredApps: appIds.map((id) => ({
-              ...appData[id],
-              parent: apps?.find(({ routes }) => routes?.find(({ id: appId }) => appId === id)),
-            })),
+            filteredApps: appIds
+              .map((id) => ({
+                ...appData[id],
+                parent: apps?.find(({ routes }) => routes?.find(({ id: appId }) => appId === id)),
+              }))
+              .filter((app) => app?.routes?.length > 0),
             isLoaded: true,
           };
         });


### PR DESCRIPTION
### When no routes given empty space is shown

If some app that should be in app filter is missing we are showing empty space in the app filter. This PR fixes such issue by filtering away apps without routes.

![Screenshot from 2021-05-03 13-31-15](https://user-images.githubusercontent.com/3439771/116872542-57f71280-ac16-11eb-843d-e83add9918ae.png)
