### PR TITLE
Fix 'hasPendingAjax' checking fetchResults

### DIFF
--- a/src/js/chrome/iqeEnablement.js
+++ b/src/js/chrome/iqeEnablement.js
@@ -73,7 +73,7 @@ export default {
     xhrResults.map((e) => console.log(`[iqe] xhr incomplete: ${e._url}`)); // eslint-disable-line no-console
     Object.values(fetchResults).map((e) => console.log(`[iqe] fetch incomplete: ${e}`)); // eslint-disable-line no-console
 
-    return xhrResults.length > 0 || fetchResults.hasOwnProperty('length') ? fetchResults.length : Object.values(fetchResults).length > 0; // eslint-disable-line no-prototype-builtins
+    return xhrResults.length > 0 || Object.values(fetchResults).length > 0;
   },
   isPageSafe: () => !document.querySelectorAll('[data-ouia-safe=false]').length !== 0,
   xhrResults: () => {

--- a/src/js/chrome/iqeEnablement.js
+++ b/src/js/chrome/iqeEnablement.js
@@ -73,7 +73,7 @@ export default {
     xhrResults.map((e) => console.log(`[iqe] xhr incomplete: ${e._url}`)); // eslint-disable-line no-console
     Object.values(fetchResults).map((e) => console.log(`[iqe] fetch incomplete: ${e}`)); // eslint-disable-line no-console
 
-    return xhrResults.length > 0 || fetchResults.length > 0;
+    return xhrResults.length > 0 || fetchResults.hasOwnProperty('length') ? fetchResults.length : Object.values(fetchResults).length > 0; // eslint-disable-line no-prototype-builtins
   },
   isPageSafe: () => !document.querySelectorAll('[data-ouia-safe=false]').length !== 0,
   xhrResults: () => {


### PR DESCRIPTION
We use this in iqe-core to check when a page is ready for selenium interaction. I noticed that it was returning `False` when XHR requests were still pending. 