### PR TITLE
Raise permissions pagination limit

### DIFF
--- a/src/js/rbac/fetchPermissions.js
+++ b/src/js/rbac/fetchPermissions.js
@@ -3,7 +3,7 @@ import logger from '../jwt/logger';
 
 const log = logger('fetchPermissions.js');
 
-const perPage = 100;
+const perPage = 1000;
 
 const fetchPermissions = (userToken, app = '') => {
   const rbacApi = createRbacAPI(userToken);


### PR DESCRIPTION
This should "fix" the issue with the access endpoint response total count causing only first 100 permissions to be fetched at any time.

Platform infra is working on the pagination issues so hopefully it will be fixed before anyone hits the limit.