### PR TITLE
Check reload attribute for nav highlight before fallback.

### DIFF
--- a/src/js/App/Sidenav/SideNav.js
+++ b/src/js/App/Sidenav/SideNav.js
@@ -20,6 +20,9 @@ export const SideNav = () => {
       const { subItems } = globalNav?.find?.(({ active }) => active) || {};
       const defaultActive =
         subItems?.find?.(({ id }) => location.pathname.split('/').find((item) => item === id)) ||
+        subItems?.find?.(
+          ({ reload }) => reload && reload.split('/').find((fragment) => location.pathname.split('/').find((item) => item === fragment))
+        ) ||
         subItems?.find?.(({ default: isDefault }) => isDefault) ||
         subItems?.[0];
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-13931

navigation sub-items that have a different `id` than a partial in browser `location.pathname` will not initialize the nav highlight correctly. Because the nav is unable to find the correct nav item, it will use a fallback item instead.

We can do an additional check of the `reload` attribute before using fallbacks.

It works for OCM but we may find other apps with the same issue. A long-term fix will have to be introduced in the nav re-write.

@john-dupuy can you please run some tests against this PR? This may affect other applications. If the testing fails we will introduce an exception for this bug until mentioned re-write.