### PR TITLE
Turn off source maps everywhere.

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -2,28 +2,22 @@ const webpack = require('webpack');
 const resolve = require('path').resolve;
 const WriteFileWebpackPlugin = require('write-file-webpack-plugin');
 const { ModuleFederationPlugin } = require('webpack').container;
-const gitRevisionPlugin = new (require('git-revision-webpack-plugin'))({
-  branch: true,
-});
 
 const deps = require('../package.json').dependencies;
 const ChunkMapper = new (require('@redhat-cloud-services/frontend-components-config/chunk-mapper'))({
   modules: 'chrome',
 });
 
-const gitBranch = process.env.TRAVIS_BRANCH || process.env.BRANCH || gitRevisionPlugin.branch();
-const akamaiBranches = ['prod-stable', 'prod-beta'];
-
 const plugins = [
   new WriteFileWebpackPlugin(),
-  ...(akamaiBranches.includes(gitBranch)
-    ? []
-    : [
+  ...(process.env.SOURCEMAPS === 'true'
+    ? [
         new webpack.SourceMapDevToolPlugin({
           test: /\.js/i,
           filename: `sourcemaps/[name].js.map`,
         }),
-      ]),
+      ]
+    : []),
   new ModuleFederationPlugin({
     name: 'chrome',
     filename: 'chrome.[hash].js',

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Chroming for Insights",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=development npm run watch",
-    "start:beta": "NODE_ENV=development npm run build:js:beta -- --env noHash=true && npm run build:sass && npm run build:pug:beta -- nohash && npm-run-all --parallel watch:beta:*",
+    "start": "NODE_ENV=development SOURCEMAPS=true npm run watch",
+    "start:beta": "NODE_ENV=development SOURCEMAPS=true npm run build:js:beta -- --env noHash=true && npm run build:sass && npm run build:pug:beta -- nohash && npm-run-all --parallel watch:beta:*",
     "analyze:js": "NODE_ENV=production webpack --config config/webpack.config.js --env analyze=true --env publicPath=/apps/chrome/js/ --mode=production",
     "build": "NODE_ENV=production npm run build:js -- --mode=production && npm-run-all build:images-chrome  build:sass    clean:chrome    hash:chrome   build:pug   build:fonts build:Fafonts",
     "build:beta": "NODE_ENV=production npm run build:js:beta -- --mode=production && npm-run-all build:images-chrome build:sass clean:chrome hash:chrome build:pug:beta build:fonts build:Fafonts",


### PR DESCRIPTION
### Why

We are having more and more reports that developers are facing an issue with chunk loading in chromium-based browsers while the debugger is opened. I was doing some debugging and turns out, the main culprit in those chunk loading errors is source maps. If we turn off source maps generators (or use a different browser or disable source maps in the browser) the issues go away.

I would like to experiment further with source maps and different strategies, but I believe we should "unblock" developers first. Just a note, it's happening both with insights proxy and the webpack proxy. Although it differs per-app basis. 