### PR TITLE
only init sentry on actual prod

### DIFF
--- a/src/js/sentry.js
+++ b/src/js/sentry.js
@@ -97,7 +97,7 @@ function sentryTags(user) {
 /* eslint-enable camelcase */
 export default (user) => {
   // this should only be enabled for prod and prod beta
-  if (window.insights.chrome.getEnvironment() === 'prod') {
+  if (window.insights.chrome.isProd) {
     initSentry();
     sentryTags(user);
   }


### PR DESCRIPTION
getEnv was showing prod.foo as prod, so remove that in order to check for actual prod