### PR TITLE
Fix incorrect getUser call

### DIFF
--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -71,7 +71,7 @@ export const visibilityFunctions = {
   isBeta: () => insights.chrome.isBeta(),
   isHidden: () => true,
   withEmail: async (toHave) => {
-    const data = await insights.chrome.getUser();
+    const data = await insights.chrome.auth.getUser();
     const {
       identity: { user },
     } = data || {};


### PR DESCRIPTION
Causes runtime crash when opening the app filter.