### PR TITLE
Trigger nav render on "active" attribute change.

### DIFF
--- a/src/js/utils/comparators.js
+++ b/src/js/utils/comparators.js
@@ -2,8 +2,8 @@ import isEqual from 'lodash/isEqual';
 
 export const globalNavComparator = (a, b) =>
   isEqual(
-    a?.map(({ id }) => id),
-    b?.map(({ id }) => id)
+    a?.map(({ id, active }) => ({ id, active })),
+    b?.map(({ id, active }) => ({ id, active }))
   );
 
 export const activeSectionComparator = (a, b) => a?.id === b?.id;


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-14472

The navigation renders optimizations were not taking into account the nav item `active` flag and it was blocking rendering.

Fixed by adding the `active` to the list of selector triggers.