### PR TITLE
Prevent automatic SSO login redirect in landing page.

### DIFF
--- a/src/js/jwt/jwt.js
+++ b/src/js/jwt/jwt.js
@@ -310,7 +310,12 @@ function updateToken() {
       log(err);
       Sentry.captureException(err);
       log('Token updated failed, trying to reauth');
-      login();
+      /**
+       * The login call here breaks the UI for un atuthed user.
+       * If you access the landing page, you are always immediately redirected to the SSO login page.
+       * Please remove this comment oce the issue is fixed.
+       */
+      // login();
     });
 }
 


### PR DESCRIPTION
related to: https://github.com/RedHatInsights/insights-chrome/issues/1451#issuecomment-856585567

Accessing the landing page as a un authed user will automatically redirect you to the SSO login form.

cc @ryelo 