### PR TITLE
Fix feedback summary string.

### DIFF
--- a/src/js/App/Feedback.js
+++ b/src/js/App/Feedback.js
@@ -26,7 +26,7 @@ const Feedback = ({ user }) => {
         },
         body: JSON.stringify({
           description: `Feedback: ${textAreaValue}, Username: ${user.identity.user.username}, Account ID: ${user.identity.account_number}, Email: ${user.identity.user.email}, URL: ${window.location.href}`, //eslint-disable-line
-          summary: `${!window.insights.chrome.isProd && '[PRE-PROD]'} Insights Feedback`,
+          summary: `${window.insights.chrome.isProd ? '[PROD]' : '[PRE-PROD]'} Insights Feedback`,
           labels: [app, bundle],
         }),
       }).then((response) => response.json());


### PR DESCRIPTION
If the `!window.insights.chrome.isProd` condition was false, it will output that `false` result into the template string.

~~@ryelo is it supposed to show the `[PROD]` string in the summary or do we want the flag only for pre-prod environments?~~

OK, the `[PROD]` prefix should exist.