### PR TITLE
Enabel appId until we can remove it.

### DIFF
--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -187,5 +187,10 @@ export function changeActiveModuleReducer(state, { payload }) {
   return {
     ...state,
     activeModule: payload,
+    /**
+     * @deprecated
+     * App id is replaced by active module. It is still required until we completely remove usage of main.yml
+     */
+    appId: payload,
   };
 }


### PR DESCRIPTION
The global filter was disabled because the `appId` was undefined.