### PR TITLE
Global location

### DIFF
--- a/src/js/App/GlobalFilter/constants.js
+++ b/src/js/App/GlobalFilter/constants.js
@@ -69,7 +69,8 @@ export const storeFilter = (tags, token, isEnabled, history) => {
     searchParams.append('tags', mappedTags);
 
     history.push({
-      ...history.location,
+      pathname: location.pathname,
+      search: location.search,
       hash: searchParams.toString(),
     });
   }


### PR DESCRIPTION
## Hotfix for incorrect history.location

When in SPA app and user hard refreshes on one page, navigates to another and changes something in global filter the react's history location contains the one user hard refreshed on and not current one. This means that the URL will change to something unstable.

#### Steps to reproduce
Example:
* Navigate to https://cloud.redhat.com/insights/advisor/systems (paste this URL directly to incognito mode)
* Click on `recommendations`
* Select something in global filter

The URL should be https://cloud.redhat.com/insights/advisor/recommendations?impacting=true&rule_status=enabled&sort=-total_risk&limit=20&offset=0#workloads=SAP&SIDs=CX1&tags= but it is https://cloud.redhat.com/insights/advisor/systems?sort=-last_seen&offset=0&limit=20&hits=all#workloads=SAP&SIDs=CX1&tags=

#### Resoning
This PR fixes such issue, by using window location instead of React's history. New navigation treats the history in different way so this issue is not replicable on ci/qa-stable envs.

JIRA: https://issues.redhat.com/browse/RHCLOUD-14672