### PR TITLE
Use window location to store global filter hash

### DIFF
--- a/src/js/App/GlobalFilter/constants.js
+++ b/src/js/App/GlobalFilter/constants.js
@@ -69,7 +69,8 @@ export const storeFilter = (tags, token, isEnabled, history) => {
     searchParams.append('tags', mappedTags);
 
     history.push({
-      ...history.location,
+      pathname: location.pathname,
+      search: location.search,
       hash: searchParams.toString(),
     });
   }

--- a/src/js/App/GlobalFilter/constants.test.js
+++ b/src/js/App/GlobalFilter/constants.test.js
@@ -147,7 +147,11 @@ describe('storeFilter', () => {
         true,
         history
       );
-      expect(push).toHaveBeenCalledWith({ hash: 'workloads=something&SIDs=&tags=' });
+      expect(push).toHaveBeenCalledWith({
+        hash: 'workloads=something&SIDs=&tags=',
+        pathname: '/',
+        search: '',
+      });
     });
 
     it('should add SIDs', () => {
@@ -167,7 +171,11 @@ describe('storeFilter', () => {
         true,
         history
       );
-      expect(push).toHaveBeenCalledWith({ hash: 'SIDs=something&tags=' });
+      expect(push).toHaveBeenCalledWith({
+        hash: 'SIDs=something&tags=',
+        pathname: '/',
+        search: '',
+      });
     });
 
     it('should add tags', () => {
@@ -198,7 +206,11 @@ describe('storeFilter', () => {
         true,
         history
       );
-      expect(push).toHaveBeenCalledWith({ hash: 'SIDs=&tags=bridges%2Fporter%3Dsam%2Cfragile%2Ftag%3Dsam%2Cfragile%2Ftag2%3Dsam' });
+      expect(push).toHaveBeenCalledWith({
+        hash: 'SIDs=&tags=bridges%2Fporter%3Dsam%2Cfragile%2Ftag%3Dsam%2Cfragile%2Ftag2%3Dsam',
+        pathname: '/',
+        search: '',
+      });
     });
 
     it('should build complex hash', () => {
@@ -241,6 +253,8 @@ describe('storeFilter', () => {
       );
       expect(push).toHaveBeenCalledWith({
         hash: 'workloads=something&SIDs=something&tags=bridges%2Fporter%3Dsam%2Cfragile%2Ftag%3Dsam%2Cfragile%2Ftag2%3Dsam',
+        pathname: '/',
+        search: '',
       });
     });
   });


### PR DESCRIPTION
## Hotfix for incorrect history.location

When in SPA app and user hard refreshes on one page, navigates to another and changes something in global filter the react's history location contains the one user hard refreshed on and not current one. This means that the URL will change to something unstable.

#### Steps to reproduce
Example:
* Navigate to https://cloud.redhat.com/insights/advisor/systems (paste this URL directly to incognito mode)
* Click on `recommendations`
* Select something in global filter

The URL should be https://cloud.redhat.com/insights/advisor/recommendations?impacting=true&rule_status=enabled&sort=-total_risk&limit=20&offset=0#workloads=SAP&SIDs=CX1&tags= but it is https://cloud.redhat.com/insights/advisor/systems?sort=-last_seen&offset=0&limit=20&hits=all#workloads=SAP&SIDs=CX1&tags=

#### Resoning
This PR fixes such issue, by using window location instead of React's history. New navigation treats the history in different way so this issue is not replicable on ci/qa-~~stable~~beta envs.

JIRA: https://issues.redhat.com/browse/RHCLOUD-14672