### PR TITLE
Proper savings planner redirect

### DIFF
--- a/src/js/App/Sidenav/SectionNav.js
+++ b/src/js/App/Sidenav/SectionNav.js
@@ -7,7 +7,7 @@ import SecurityIcon from '@patternfly/react-icons/dist/js/icons/security-icon';
 import TrendUpIcon from '@patternfly/react-icons/dist/js/icons/trend-up-icon';
 import './SectionNav.scss';
 
-const anisbleHackIds = ['automation-calculator', 'organization-statistics', 'job-explorer', 'clusters', 'notifications'];
+const anisbleHackIds = ['savings-planner', 'automation-calculator', 'organization-statistics', 'job-explorer', 'clusters', 'notifications'];
 
 const sectionTitleMapper = (id) =>
   ({


### PR DESCRIPTION
Since ansible tower analytics routes lives under ansible/insights and new route has been added RedHatInsights/cloud-services-config#649 we have to update the list of routes in chrome as well, otherwise we'd still be redirected to ansbile/savings-planner instead of ansible/insights/savings-planner