### PR TITLE
Replace beta in pathname so it is not repeated

### DIFF
--- a/src/js/App/GlobalFilter/constants.js
+++ b/src/js/App/GlobalFilter/constants.js
@@ -69,7 +69,8 @@ export const storeFilter = (tags, token, isEnabled, history) => {
     searchParams.append('tags', mappedTags);
 
     history.push({
-      pathname: location.pathname,
+      // we have to replace beta otherwise it's repeated
+      pathname: location.pathname.replace('/beta', ''),
       search: location.search,
       hash: searchParams.toString(),
     });


### PR DESCRIPTION
### Do not repeat beta

If user selects global filter the URL gets malformed and `beta/` is repeated multiple times. This is caused by mixture of basename and changing the pathname. It's not replicable on ci-beta where we treat the history slightly differently.