### PR TITLE
Allow first level apps by checking active app Id and nav Id

### DIFF
--- a/src/js/App/Sidenav/Navigation/ChromeLink.js
+++ b/src/js/App/Sidenav/Navigation/ChromeLink.js
@@ -26,14 +26,15 @@ const useDynamicModule = (appId) => {
   return isDynamic;
 };
 
-const LinkWrapper = ({ href, isBeta, onLinkClick, className, children }) => {
+const LinkWrapper = ({ href, isBeta, onLinkClick, className, currAppId, appId, children }) => {
   let actionId = href.split('/').slice(2).join('/');
   if (actionId.includes('/')) {
     actionId = actionId.split('/').pop();
   }
-  if (href.split('/').length === 3) {
+  if (currAppId !== appId && href.split('/').length === 3) {
     actionId = '/';
   }
+
   /**
    * If the sub nav item points to application root
    * eg. /openshift/cost-management we don't want to send "/cost-management" but "/"
@@ -72,6 +73,8 @@ LinkWrapper.propTypes = {
   children: PropTypes.node.isRequired,
   isBeta: PropTypes.bool,
   onLinkClick: PropTypes.func.isRequired,
+  currAppId: PropTypes.string.isRequired,
+  appId: PropTypes.string.isRequired,
 };
 
 const basepath = document.baseURI;
@@ -116,7 +119,9 @@ RefreshLink.propTypes = {
 
 const ChromeLink = ({ appId, children, ...rest }) => {
   const { onLinkClick } = useContext(NavContext);
+  const currAppId = useSelector(({ chrome }) => chrome?.appId);
   const isDynamic = useDynamicModule(appId);
+  console.log(appId, 'this is appId!');
 
   if (!rest.isExternal && typeof isDynamic === 'undefined') {
     return null;
@@ -124,7 +129,7 @@ const ChromeLink = ({ appId, children, ...rest }) => {
 
   const LinkComponent = !rest.isExternal && isDynamic ? LinkWrapper : RefreshLink;
   return (
-    <LinkComponent onLinkClick={onLinkClick} appId={appId} {...rest}>
+    <LinkComponent onLinkClick={onLinkClick} appId={appId} currAppId={currAppId} {...rest}>
       {children}
     </LinkComponent>
   );

--- a/src/js/App/Sidenav/Navigation/ChromeLink.js
+++ b/src/js/App/Sidenav/Navigation/ChromeLink.js
@@ -121,7 +121,6 @@ const ChromeLink = ({ appId, children, ...rest }) => {
   const { onLinkClick } = useContext(NavContext);
   const currAppId = useSelector(({ chrome }) => chrome?.appId);
   const isDynamic = useDynamicModule(appId);
-  console.log(appId, 'this is appId!');
 
   if (!rest.isExternal && typeof isDynamic === 'undefined') {
     return null;


### PR DESCRIPTION
### Incorrect navId

When in app that lives on first level: 
- /edge/fleet-management
- /edge/manage-images
- /openshift/overview
- /openshift/releases
- /openshift/downloads

Clicking on any nav item will result in sending nav event with `navId: '/'`, this is incorrect as it should check for active appId in chrome, if it's the same as the one user clicked in navigation we shouldn't navigate user to root. This PR fixes such issue by checking if current navId is same as appId. And if so do not assume we want to navigate to root.