### PR TITLE
replace fileMapper with `${name}-navigation.json`

### DIFF
--- a/src/js/App/Header/AppFilter/useAppFilter.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.js
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isBeta } from '../../../utils';
 import { evaluateVisibility } from '../../../utils/isNavItemVisible';
-import { navigationFileMapper } from '../../../utils/useNavigation';
 
 export const requiredBundles = ['application-services', 'openshift', 'insights', 'edge', 'ansible', 'settings'];
 const bundlesOrder = ['application-services', 'openshift', 'rhel', 'edge', 'ansible', 'settings', 'cost-management', 'subscriptions'];
@@ -127,7 +126,7 @@ const useAppFilter = () => {
         ...prev,
         isLoading: true,
       }));
-      let bundles = requiredBundles.filter((app) => !existingSchemas.includes(app)).map((app) => navigationFileMapper[app]);
+      let bundles = requiredBundles.filter((app) => !existingSchemas.includes(app));
       bundles.map((fragment) =>
         axios
           .get(`${isBetaEnv ? '/beta' : ''}/config/chrome/${fragment}`)

--- a/src/js/App/Header/AppFilter/useAppFilter.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.js
@@ -129,7 +129,7 @@ const useAppFilter = () => {
       let bundles = requiredBundles.filter((app) => !existingSchemas.includes(app));
       bundles.map((fragment) =>
         axios
-          .get(`${isBetaEnv ? '/beta' : ''}/config/chrome/${fragment}`)
+          .get(`${isBetaEnv ? '/beta' : ''}/config/chrome/${fragment}-navigation.json`)
           .then(handleBundleData)
           .catch((err) => {
             console.error('Unable to load appfilter bundle', err);

--- a/src/js/App/Header/AppFilter/useAppFilter.test.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.test.js
@@ -7,7 +7,6 @@ import configureStore from 'redux-mock-store';
 import * as axios from 'axios';
 
 import useAppFilter, { requiredBundles } from './useAppFilter';
-import { navigationFileMapper } from '../../../utils/useNavigation';
 
 jest.mock('axios', () => {
   const axios = jest.requireActual('axios');
@@ -97,7 +96,7 @@ describe('useAppFilter', () => {
     });
     expect(axiosGetSpy).toHaveBeenCalledTimes(6);
     for (let index = 0; index < 6; index++) {
-      expect(axiosGetSpy.mock.calls[index]).toEqual([`/config/chrome/${navigationFileMapper[requiredBundles[index]]}`]);
+      expect(axiosGetSpy.mock.calls[index]).toEqual([`/config/chrome/${requiredBundles[index]}`]);
     }
     axiosGetSpy.mockReset();
   });

--- a/src/js/App/Header/AppFilter/useAppFilter.test.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.test.js
@@ -96,7 +96,7 @@ describe('useAppFilter', () => {
     });
     expect(axiosGetSpy).toHaveBeenCalledTimes(6);
     for (let index = 0; index < 6; index++) {
-      expect(axiosGetSpy.mock.calls[index]).toEqual([`/config/chrome/${requiredBundles[index]}`]);
+      expect(axiosGetSpy.mock.calls[index]).toEqual([`/config/chrome/${requiredBundles[index]}-navigation.json`]);
     }
     axiosGetSpy.mockReset();
   });

--- a/src/js/utils/useNavigation.js
+++ b/src/js/utils/useNavigation.js
@@ -28,17 +28,6 @@ function cleanNavItemsHref(navItem) {
   return result;
 }
 
-export const navigationFileMapper = {
-  insights: 'rhel-navigation.json',
-  ansible: 'ansible-navigation.json',
-  settings: 'settings-navigation.json',
-  'user-preferences': 'user-preferences-navigation.json',
-  openshift: 'openshift-navigation.json',
-  'application-services': 'application-services-navigation.json',
-  edge: 'edge-navigation.json',
-  docs: 'docs-navigation.json',
-};
-
 function levelArray(navItems) {
   return flatMap(navItems, ({ href, routes, navItems }) => {
     if (!href && navItems) {
@@ -154,26 +143,24 @@ const useNavigation = () => {
   useEffect(() => {
     let observer;
     if (currentNamespace) {
-      axios
-        .get(`${window.location.origin}${isBetaEnv ? '/beta' : ''}/config/chrome/${navigationFileMapper[currentNamespace]}`)
-        .then(async (response) => {
-          if (observer && typeof observer.disconnect === 'function') {
-            observer.disconnect();
-          }
+      axios.get(`${window.location.origin}${isBetaEnv ? '/beta' : ''}/config/chrome/${currentNamespace}-navigation.json`).then(async (response) => {
+        if (observer && typeof observer.disconnect === 'function') {
+          observer.disconnect();
+        }
 
-          const data = response.data;
-          const navItems = await Promise.all(data.navItems.map(cleanNavItemsHref).map(evaluateVisibility));
-          const schema = {
-            ...data,
-            navItems,
-            sortedLinks: levelArray(data.navItems).sort((a, b) => (a.length < b.length ? 1 : -1)),
-          };
-          observer = registerLocationObserver(pathname, schema);
-          observer.observe(document.querySelector('body'), {
-            childList: true,
-            subtree: true,
-          });
+        const data = response.data;
+        const navItems = await Promise.all(data.navItems.map(cleanNavItemsHref).map(evaluateVisibility));
+        const schema = {
+          ...data,
+          navItems,
+          sortedLinks: levelArray(data.navItems).sort((a, b) => (a.length < b.length ? 1 : -1)),
+        };
+        observer = registerLocationObserver(pathname, schema);
+        observer.observe(document.querySelector('body'), {
+          childList: true,
+          subtree: true,
         });
+      });
     }
     return () => {
       if (observer && typeof observer.disconnect === 'function') {


### PR DESCRIPTION
When adding a nav item in https://github.com/RedHatInsights/cloud-services-config I find it unreasonable to also have to update insight-chrome's `src/js/utils/useNavigation.js`.

It looks like the only name not in accordance is `insights` -> `rhel` so I've moved the file in https://github.com/RedHatInsights/cloud-services-config/pull/735.

If a mapper is really necessary, I believe it should come from cloud-services-config and I can update https://github.com/RedHatInsights/cloud-services-config/pull/735.