### PR TITLE
Enable "filterable" attribute for app filter.

### DIFF
--- a/src/js/App/Header/AppFilter/useAppFilter.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.js
@@ -13,11 +13,11 @@ function getBundleLink({ title, isExternal, href, routes, expandable, ...rest })
   let url = href;
   if (expandable) {
     routes.forEach(({ href, title, ...rest }) => {
-      if (href.includes('/openshift/cost-management')) {
+      if (href.includes('/openshift/cost-management') && rest.filterable !== false) {
         costLinks.push({ ...rest, href, title });
       }
 
-      if (href.includes('/insights/subscriptions') || href.includes('/openshift/subscriptions')) {
+      if (rest.filterable !== false && (href.includes('/insights/subscriptions') || href.includes('/openshift/subscriptions'))) {
         subscriptionsLinks.push({
           ...rest,
           href,
@@ -72,7 +72,8 @@ const useAppFilter = () => {
         return [...acc, curr];
       }, [])
       .flat()
-      .map(getBundleLink);
+      .map(getBundleLink)
+      .filter(({ filterable }) => filterable !== false);
     const bundleLinks = [];
     const extraLinks = {
       cost: [],


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-13888

requires: https://github.com/RedHatInsights/cloud-services-config/pull/749

Hides links from app filter with `filterable: false` attribute.