### PR TITLE
Fix invalid app filter links for expandable items.

### DIFF
--- a/src/js/App/Header/AppFilter/useAppFilter.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.js
@@ -25,7 +25,9 @@ function getBundleLink({ title, isExternal, href, routes, expandable, ...rest })
         });
       }
 
-      url = isExternal ? href : href.split('/').slice(0, 3).join('/');
+      if (!url && href.match(/^\//)) {
+        url = isExternal ? href : href.split('/').slice(0, 3).join('/');
+      }
     });
   }
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-15232

Do not use nested external links for expandable categories.