### PR TITLE
Menu styling fix

### DIFF
--- a/src/js/App/Sidenav/Navigation/Navigation.scss
+++ b/src/js/App/Sidenav/Navigation/Navigation.scss
@@ -28,6 +28,7 @@
     }
     ul
       > li.pf-c-nav__item {
+        border-top: 0;
         --pf-c-nav__item--MarginTop: 0;
         --pf-c-nav__item--before--BorderWidth: 0;
         &:last-child {


### PR DESCRIPTION
Remove horizontal line between menu groups
Jira: https://issues.redhat.com/browse/RHCLOUD-15162
Relates to: https://github.com/RedHatInsights/insights-chrome/pull/1424

<img width="530" alt="Screen Shot 2021-07-12 at 2 43 50 PM" src="https://user-images.githubusercontent.com/1287144/125339773-a49a5080-e31f-11eb-8263-fd5a69df3d44.png">
<img width="545" alt="Screen Shot 2021-07-12 at 2 44 00 PM" src="https://user-images.githubusercontent.com/1287144/125339778-a49a5080-e31f-11eb-8b94-ca2107c0116f.png">
