### PR TITLE
Check refresh token before adding it to jwt options.

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -48,14 +48,15 @@ export default () => {
 
   wipePostbackParamsThatAreNotForUs();
   const token = cookie.get(options.cookieName);
+  const refreshToken = cookie.get('cs_jwt_refresh');
 
   // If we find an existing token, use it
   // so that we dont auth even when a valid token is present
   // otherwise its quick, but we bounce around and get a new token
   // on every page load
-  if (token && token.length > 10) {
+  if (token && token.length > 10 && refreshToken && refreshToken.length > 10) {
+    options.refreshToken = refreshToken;
     options.token = token;
-    options.refreshToken = cookie.get('cs_jwt_refresh');
   }
 
   const promise = jwt.init(options).then(bouncer);

--- a/src/js/jwt/modules/useChromeAuth.js
+++ b/src/js/jwt/modules/useChromeAuth.js
@@ -40,14 +40,15 @@ export const initChromeAuth = () => {
 
   wipePostbackParamsThatAreNotForUs();
   const token = cookie.get(options.cookieName);
+  const refreshToken = cookie.get('cs_jwt_refresh');
 
   // If we find an existing token, use it
   // so that we dont auth even when a valid token is present
   // otherwise its quick, but we bounce around and get a new token
   // on every page load
-  if (token && token.length > 10) {
+  if (token && token.length > 10 && refreshToken && refreshToken.length > 10) {
+    options.refreshToken = refreshToken;
     options.token = token;
-    options.refreshToken = cookie.get('cs_jwt_refresh');
   }
 
   const promise = jwt.init(options).then(bouncer);


### PR DESCRIPTION
possible fix for: https://issues.redhat.com/browse/RHCLOUD-15240

The refresh token seems to have the value `"undefined"` (yes string with) so the check if refresh token is existing fails, and the chrome tries to decode invalid token. Seems like we were checking it for the normal token but it was unexpected for the refresh token. Commit is in ci/qa-beta but not in stable yet. I think we might want to propagate this all the way to prod stable if it fixes the problem.