### PR TITLE
Fix error component invalid children types.

### DIFF
--- a/src/js/App/ErrorComponent/ErrorComponent.js
+++ b/src/js/App/ErrorComponent/ErrorComponent.js
@@ -42,8 +42,11 @@ const ErrorComponent = (props) => {
             <FlexItem>
               <ExpandableSection toggleTextExpanded="Show less" toggleTextCollapsed="Show more">
                 <TextContent>
-                  <Text className="error-text">{props.error}</Text>
-                  {props.errorInfo?.componentStack && (
+                  {typeof props?.error === 'string' && <Text className="error-text">{props.error}</Text>}
+                  {typeof props?.error === 'object' && typeof props?.error?.message === 'string' && (
+                    <Text className="error-text">{props.error.message}</Text>
+                  )}
+                  {typeof props.errorInfo?.componentStack === 'string' && (
                     <Text className="error-text" component="code">
                       {props.errorInfo?.componentStack.split('\n').map((content, index) => (
                         <div className="error-line" key={index}>


### PR DESCRIPTION
Sometimes the error can be an error object instead of a string. We can now handle both.