### PR TITLE
[prod-stable] Wait for jwt initPromise to be completed before retrieving the token

### DIFF
--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -96,7 +96,7 @@ export function bootstrap(libjwt, initFunc, getUser) {
       auth: {
         getOfflineToken: () => libjwt.getOfflineToken(),
         doOffline: () => libjwt.jwt.doOffline(consts.noAuthParam, consts.offlineToken),
-        getToken: () => libjwt.jwt.getUserInfo().then(() => libjwt.jwt.getEncodedToken()),
+        getToken: () => libjwt.initPromise.then(() => libjwt.jwt.getUserInfo().then(() => libjwt.jwt.getEncodedToken())),
         getUser,
         qe: qe,
         logout: (bounce) => libjwt.jwt.logoutAllTabs(bounce),


### PR DESCRIPTION
part of https://github.com/RedHatInsights/insights-chrome/issues/1531 for prod stable