### PR TITLE
Do not load edge in Prod appFilter

### DIFF
--- a/src/js/App/Header/AppFilter/useAppFilter.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.js
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { isBeta } from '../../../utils';
+import { isBeta, getEnv } from '../../../utils';
 import { evaluateVisibility } from '../../../utils/isNavItemVisible';
 
-export const requiredBundles = ['application-services', 'openshift', 'insights', 'edge', 'ansible', 'settings'];
+export const requiredBundles = ['application-services', 'openshift', 'insights', ...(getEnv() !== 'prod' ? ['edge'] : []), 'ansible', 'settings'];
 const bundlesOrder = ['application-services', 'openshift', 'rhel', 'edge', 'ansible', 'settings', 'cost-management', 'subscriptions'];
 
 function getBundleLink({ title, isExternal, href, routes, expandable, ...rest }) {


### PR DESCRIPTION
This is to fix an errors when opening app filter in prod. 
![image](https://user-images.githubusercontent.com/50696716/127183901-250393e1-a2aa-4c49-8b57-9e78f6a0924a.png)
