### PR TITLE
Allow client side routing trough app filter.

### DIFF
--- a/src/js/App/Header/AppFilter/AppFilter.js
+++ b/src/js/App/Header/AppFilter/AppFilter.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -28,6 +28,7 @@ import {
 import './AppFilter.scss';
 import useAppFilter from './useAppFilter';
 import ChromeLink from '../../Sidenav/Navigation/ChromeLink';
+import { useLocation } from 'react-router-dom';
 
 const App = ({ id, title, links = [] }) =>
   links.length > 0 ? (
@@ -39,7 +40,7 @@ const App = ({ id, title, links = [] }) =>
             {links.map(({ href, title, isHidden, ...rest }) =>
               isHidden ? null : (
                 <Text component="p" key={`${id}-${href}`}>
-                  <ChromeLink {...rest} appId="static" title={title} href={href}>
+                  <ChromeLink {...rest} title={title} href={href}>
                     {title}
                   </ChromeLink>
                 </Text>
@@ -59,10 +60,17 @@ App.propTypes = {
 
 const AppFilterDropdown = ({ isLoaded, setIsOpen, isOpen, filterValue, setFilterValue, filteredApps }) => {
   const dropdownRef = useRef(null);
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    if (isLoaded) {
+      setIsOpen(false);
+    }
+  }, [pathname]);
+
   return (
     <Dropdown
       className="ins-c-page__app-filter-dropdown-toggle"
-      onSelect={() => setIsOpen(true)}
       toggle={
         <DropdownToggle
           id="toggle-id"

--- a/src/js/App/Header/AppFilter/useAppFilter.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.js
@@ -11,6 +11,7 @@ function getBundleLink({ title, isExternal, href, routes, expandable, ...rest })
   const costLinks = [];
   const subscriptionsLinks = [];
   let url = href;
+  let appId = rest.appId;
   if (expandable) {
     routes.forEach(({ href, title, ...rest }) => {
       if (href.includes('/openshift/cost-management') && rest.filterable !== false) {
@@ -27,12 +28,14 @@ function getBundleLink({ title, isExternal, href, routes, expandable, ...rest })
 
       if (!url && href.match(/^\//)) {
         url = isExternal ? href : href.split('/').slice(0, 3).join('/');
+        appId = rest.appId ? rest.appId : appId;
       }
     });
   }
 
   return {
     ...rest,
+    appId,
     isExternal,
     title,
     href: url,

--- a/src/js/App/Header/AppFilter/useAppFilter.test.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.test.js
@@ -297,6 +297,7 @@ describe('useAppFilter', () => {
     });
     expect(result.current.data[TEST_ID].links).toEqual([
       {
+        appId: 'foo',
         href: '/foo/bar',
         isHidden: false,
         title: 'title',

--- a/src/js/App/Header/HeaderTests/Header.test.js
+++ b/src/js/App/Header/HeaderTests/Header.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 import { Header } from '../Header';
 import UnauthedHeader from '../UnAuthtedHeader';
 
@@ -23,9 +24,11 @@ describe('Header', () => {
   it('should render correctly', () => {
     const store = mockStore(initialState);
     const { container } = render(
-      <Provider store={store}>
-        <Header />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={store}>
+          <Header />
+        </Provider>
+      </MemoryRouter>
     );
     expect(container).toMatchSnapshot();
   });
@@ -48,9 +51,11 @@ describe('unauthed', () => {
   it('should render correctly', () => {
     const store = mockStore(initialState);
     const { container } = render(
-      <Provider store={store}>
-        <UnauthedHeader />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={store}>
+          <UnauthedHeader />
+        </Provider>
+      </MemoryRouter>
     );
     expect(container.querySelector('div')).toMatchSnapshot();
   });


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-15542

### Changes
- allow client-side routing when using appfilter

App filter is now using the same logic as the left nav. By adding the `appId` to `ChromeLink` components, we can now use client-side routing, even when switching between bundles. This will greatly increase navigation speed when using the app filter.

Applications not migrated to chrome 2 will still use `RefreshLink`.

![app-filter-transition](https://user-images.githubusercontent.com/22619452/127316756-b4b2547c-55fd-452e-a4a9-e52947e18605.gif)
