### PR TITLE
Introduce custom global filter menu component.

### DIFF
--- a/src/js/App/GlobalFilter/GlobalFilter.js
+++ b/src/js/App/GlobalFilter/GlobalFilter.js
@@ -1,7 +1,6 @@
 import React, { useEffect, Fragment, useState, useCallback, memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch, batch, shallowEqual } from 'react-redux';
-import { GroupFilter } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { useTagsFilter } from '@redhat-cloud-services/frontend-components/FilterHooks';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
 import { fetchAllSIDs, fetchAllTags, fetchAllWorkloads, globalFilterChange } from '../../redux/actions';
@@ -10,6 +9,7 @@ import TagsModal from './TagsModal';
 import { workloads, updateSelected, storeFilter, generateFilter } from './constants';
 import debounce from 'lodash/debounce';
 import { useHistory } from 'react-router-dom';
+import GlobalFilterMenu from './GlobalFilterMenu';
 
 const GlobalFilterDropdown = ({
   isAllowed,
@@ -43,7 +43,7 @@ const GlobalFilterDropdown = ({
                 position: 'right',
               })}
             >
-              <GroupFilter {...filter} isDisabled={!allowed || isDisabled} placeholder="Filter results" />
+              <GlobalFilterMenu {...filter} selectedTags={selectedTags} isDisabled={!allowed || isDisabled} placeholder="Filter results" />
             </GroupFilterWrapper>
           ) : (
             <Skeleton size={SkeletonSize.xl} />
@@ -124,7 +124,7 @@ GlobalFilterDropdown.propTypes = {
     })
   ),
   setValue: PropTypes.func.isRequired,
-  selectedTags: PropTypes.array,
+  selectedTags: PropTypes.object,
   isOpen: PropTypes.bool,
   filterTagsBy: PropTypes.string,
   filterScope: PropTypes.string,

--- a/src/js/App/GlobalFilter/GlobalFilterMenu.js
+++ b/src/js/App/GlobalFilter/GlobalFilterMenu.js
@@ -1,0 +1,169 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { TextInput, MenuList, MenuItem, Select, SelectVariant, MenuGroup, Checkbox } from '@patternfly/react-core';
+
+import './global-filter-menu.scss';
+
+export const groupType = {
+  checkbox: 'checkbox',
+  radio: 'radio',
+  button: 'button',
+  plain: 'plain',
+};
+
+const getMenuItems = (groups, filterValueRegex, onChange, calculateSelected) => {
+  const result = groups.map(({ value, label, id, type, items, ...group }) => ({
+    label,
+    value,
+    items: items
+      .filter(
+        (item) =>
+          group.noFilter ||
+          (value && filterValueRegex.test(value)) ||
+          (label && filterValueRegex.test(label)) ||
+          (item.value && filterValueRegex.test(item.value)) ||
+          (item.label && filterValueRegex.test(item.label))
+      )
+      .map((item, index) => ({
+        ...item,
+        key: item.id || item.value || index,
+        value: String(item.value || item.id || index),
+        onClick: (event) => {
+          onChange(
+            event,
+            calculateSelected(type, value, item.value),
+            {
+              value,
+              label,
+              id,
+              type,
+              items,
+              ...group,
+            },
+            item,
+            value,
+            item.value
+          );
+        },
+      })),
+  }));
+  return result.filter(({ noFilter, items = [] }) => noFilter || items.length > 0);
+};
+
+const GlobalFilterMenu = (props) => {
+  const { filterBy, onFilter, groups = [], onChange, selectedTags } = props;
+  const [isOpen, setIsOpen] = useState(false);
+
+  const calculateSelected = (type, groupKey, itemKey) => {
+    const activeGroup = selectedTags[groupKey];
+    if (activeGroup) {
+      if (type !== groupType.radio && (activeGroup[itemKey] instanceof Object ? activeGroup[itemKey].isSelected : Boolean(activeGroup[itemKey]))) {
+        return {
+          ...selectedTags,
+          [groupKey]: {
+            ...(activeGroup || {}),
+            [itemKey]: false,
+          },
+        };
+      }
+
+      return {
+        ...selectedTags,
+        [groupKey]: {
+          ...(type !== groupType.radio ? activeGroup || {} : {}),
+          [itemKey]: true,
+        },
+      };
+    }
+
+    return {
+      ...selectedTags,
+      [groupKey]: {
+        [itemKey]: true,
+      },
+    };
+  };
+  const sanitizedFilterRegex = useMemo(() => {
+    try {
+      return new RegExp(filterBy, 'i');
+    } catch (err) {
+      return new RegExp(filterBy.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    }
+  }, [filterBy]);
+
+  const menuItems = getMenuItems(groups, sanitizedFilterRegex, onChange, calculateSelected);
+  const menu = [
+    <div key="x" className="pf-c-menu ins-c-global-filter__menu" style={{ boxShadow: 'none' }}>
+      {menuItems.map(({ value, label, items }) => (
+        <MenuGroup key={value} label={label} value={value}>
+          <MenuList>
+            {items.map(({ value, label, onClick, ...props }) => (
+              <MenuItem key={value} onClick={onClick}>
+                <Checkbox
+                  className="ins-c-global-filter__checkbox"
+                  // eslint-disable-next-line react/prop-types
+                  id={props.id}
+                  // eslint-disable-next-line react/prop-types
+                  isChecked={!!Object.values(selectedTags).find((group = {}) => group[props.tagKey]?.isSelected)}
+                  label={label}
+                />
+              </MenuItem>
+            ))}
+          </MenuList>
+        </MenuGroup>
+      ))}
+    </div>,
+  ];
+
+  return (
+    <Select
+      className={classNames('ins-c-global-filter__select', {
+        expanded: isOpen,
+      })}
+      placeholderText={
+        <TextInput
+          onClick={(event) => {
+            if (isOpen) {
+              event.stopPropagation();
+            }
+          }}
+          value={filterBy}
+          onChange={onFilter}
+          placeholder="Filter by status"
+        />
+      }
+      variant={SelectVariant.typeahead}
+      onTypeaheadInputChanged={onFilter}
+      onToggle={(isOpen) => {
+        setIsOpen(isOpen);
+      }}
+      isOpen={isOpen}
+      hasInlineFilter
+      customContent={menu}
+    >
+      {menu}
+    </Select>
+  );
+};
+
+GlobalFilterMenu.propTypes = {
+  filterBy: PropTypes.string,
+  onFilter: PropTypes.func.isRequired,
+  groups: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.node,
+      items: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string,
+          tagKey: PropTypes.string,
+        })
+      ),
+    })
+  ),
+  onChange: PropTypes.func.isRequired,
+  selectedTags: PropTypes.shape({}),
+};
+
+export default GlobalFilterMenu;

--- a/src/js/App/GlobalFilter/global-filter-menu.scss
+++ b/src/js/App/GlobalFilter/global-filter-menu.scss
@@ -1,0 +1,29 @@
+.ins-c-global-filter__menu {
+  max-height: 400px;
+  overflow-y: auto;
+  width: 450px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.ins-c-global-filter__select {
+  &.expanded {
+    width: 450px;
+  }
+  .pf-c-select__toggle-text {
+    flex-grow: 1;
+    > input.pf-c-form-control {
+      border: none;
+    }
+  }
+}
+.ins-c-global-filter__checkbox {
+  .pf-c-check__label {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      .pf-c-badge {
+          margin-left: 8px;
+          padding-top: 3px;
+      }
+  }
+}

--- a/src/js/App/GlobalFilter/global-filter-menu.scss
+++ b/src/js/App/GlobalFilter/global-filter-menu.scss
@@ -4,6 +4,7 @@
   width: 450px;
   padding-top: 0;
   padding-bottom: 0;
+  box-shadow: none !important;
 }
 .ins-c-global-filter__select {
   &.expanded {


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-15651

### Changes
- use "custom" select component for global filter

Why? Because in a new version of PF the select children are always one render cycle behind. For example, if you select a value, the checkbox will be set only after you select another one and so on.

This might be also used a base for the new conditional filter implementation. This no longer uses a lot of hacks required before.
