### PR TITLE
Use remediations fed modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@redhat-cloud-services/entitlements-client": "^1.0.97",
         "@redhat-cloud-services/frontend-components": "^3.3.0",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.2",
-        "@redhat-cloud-services/frontend-components-remediations": "^3.2.5",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.2",
         "@redhat-cloud-services/host-inventory-client": "^1.0.97",
         "@redhat-cloud-services/keycloak-js": "0.0.3",
@@ -2416,52 +2415,6 @@
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "redux-promise-middleware": "6.1.2"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-remediations": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-3.2.5.tgz",
-      "integrity": "sha512-ltlbxgf9oti8Oev7Rdx5cBNlXwy0jLjDgAWTQt8s+j5pV+SS8rl5AriH7f9cyPylkTAORGB3q4Jdvt6QGCVnqA==",
-      "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^2.23.3",
-        "@data-driven-forms/react-form-renderer": "^2.23.3",
-        "@redhat-cloud-services/frontend-components": ">=3.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
-        "@redhat-cloud-services/host-inventory-client": "^1.0.94",
-        "redux-promise-middleware": "^6.1.2",
-        "urijs": "^1.19.4"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": ">=4.18.5",
-        "@patternfly/react-icons": ">=4.3.5",
-        "@patternfly/react-table": ">=4.5.7",
-        "prop-types": ">=15.6.2",
-        "react": ">=16.14.0 || >=17.0.0",
-        "react-dom": ">=16.14.0 || >=17.0.0",
-        "react-redux": ">=5.0.7"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-remediations/node_modules/@data-driven-forms/pf4-component-mapper": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-2.24.0.tgz",
-      "integrity": "sha512-GRReWOSGcDdLgypmbRLFSt+XJQjUcIUylMbjb8Oc2qUbOL/EqlkspKD8aRx5ViLuq9lT9CdQO+f2SBuJ8eJdrw==",
-      "dependencies": {
-        "downshift": "^5.4.3",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-remediations/node_modules/@data-driven-forms/react-form-renderer": {
-      "version": "2.24.1",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-2.24.1.tgz",
-      "integrity": "sha512-0UeHFFNPCc2XiYMHwnlW+N4Wrag9eygZD+mkPwKu6MAFweH1eWn4D4N3LUkE4O6FJw16mPMzfI3iizXN8T9uQA==",
-      "dependencies": {
-        "final-form": "^4.20.0",
-        "final-form-arrays": "^3.0.2",
-        "final-form-focus": "^1.1.2",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "react-final-form": "^6.5.0",
-        "react-final-form-arrays": "^3.1.1"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
@@ -13918,8 +13871,7 @@
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "peer": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/require-package-name": {
       "version": "2.0.1",
@@ -14524,8 +14476,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "peer": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -14618,7 +14569,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
       "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "peer": true,
       "dependencies": {
         "yargs": "^14.2"
       },
@@ -14630,7 +14580,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14639,7 +14588,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "peer": true,
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -14649,14 +14597,12 @@
     "node_modules/showdown/node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "peer": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "node_modules/showdown/node_modules/find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "peer": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -14668,7 +14614,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14677,7 +14622,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "peer": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -14690,7 +14634,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -14702,7 +14645,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14711,7 +14653,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -14725,7 +14666,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -14737,7 +14677,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -14750,14 +14689,12 @@
     "node_modules/showdown/node_modules/y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "peer": true
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/showdown/node_modules/yargs": {
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
       "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-      "peer": true,
       "dependencies": {
         "cliui": "^5.0.0",
         "decamelize": "^1.2.0",
@@ -14776,7 +14713,6 @@
       "version": "15.0.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
       "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-      "peer": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -16889,8 +16825,7 @@
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "peer": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "node_modules/which-typed-array": {
       "version": "1.1.4",
@@ -19238,7 +19173,8 @@
       "requires": {
         "@patternfly/react-catalog-view-extension": "4.12.15",
         "dompurify": "^2.2.6",
-        "history": "^5.0.0"
+        "history": "^5.0.0",
+        "showdown": "1.8.6"
       },
       "dependencies": {
         "history": {
@@ -19374,45 +19310,6 @@
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "redux-promise-middleware": "6.1.2"
-      }
-    },
-    "@redhat-cloud-services/frontend-components-remediations": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-3.2.5.tgz",
-      "integrity": "sha512-ltlbxgf9oti8Oev7Rdx5cBNlXwy0jLjDgAWTQt8s+j5pV+SS8rl5AriH7f9cyPylkTAORGB3q4Jdvt6QGCVnqA==",
-      "requires": {
-        "@data-driven-forms/pf4-component-mapper": "^2.23.3",
-        "@data-driven-forms/react-form-renderer": "^2.23.3",
-        "@redhat-cloud-services/frontend-components": ">=3.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
-        "@redhat-cloud-services/host-inventory-client": "^1.0.94",
-        "redux-promise-middleware": "^6.1.2",
-        "urijs": "^1.19.4"
-      },
-      "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": {
-          "version": "2.24.0",
-          "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-2.24.0.tgz",
-          "integrity": "sha512-GRReWOSGcDdLgypmbRLFSt+XJQjUcIUylMbjb8Oc2qUbOL/EqlkspKD8aRx5ViLuq9lT9CdQO+f2SBuJ8eJdrw==",
-          "requires": {
-            "downshift": "^5.4.3",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@data-driven-forms/react-form-renderer": {
-          "version": "2.24.1",
-          "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-2.24.1.tgz",
-          "integrity": "sha512-0UeHFFNPCc2XiYMHwnlW+N4Wrag9eygZD+mkPwKu6MAFweH1eWn4D4N3LUkE4O6FJw16mPMzfI3iizXN8T9uQA==",
-          "requires": {
-            "final-form": "^4.20.0",
-            "final-form-arrays": "^3.0.2",
-            "final-form-focus": "^1.1.2",
-            "lodash": "^4.17.15",
-            "prop-types": "^15.7.2",
-            "react-final-form": "^6.5.0",
-            "react-final-form-arrays": "^3.1.1"
-          }
-        }
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
@@ -28898,8 +28795,7 @@
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "peer": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "require-package-name": {
       "version": "2.0.1",
@@ -29386,8 +29282,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "peer": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -29458,10 +29353,8 @@
       "dev": true
     },
     "showdown": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "version": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
       "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "peer": true,
       "requires": {
         "yargs": "^14.2"
       },
@@ -29469,14 +29362,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "peer": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "peer": true,
           "requires": {
             "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
@@ -29486,14 +29377,12 @@
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "peer": true
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "peer": true,
           "requires": {
             "locate-path": "^3.0.0"
           }
@@ -29501,14 +29390,12 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "peer": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "peer": true,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -29518,7 +29405,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "peer": true,
           "requires": {
             "p-limit": "^2.0.0"
           }
@@ -29526,14 +29412,12 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "peer": true
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "peer": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -29544,7 +29428,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "peer": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -29553,7 +29436,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "peer": true,
           "requires": {
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
@@ -29563,14 +29445,12 @@
         "y18n": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-          "peer": true
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
         },
         "yargs": {
           "version": "14.2.3",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
           "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-          "peer": true,
           "requires": {
             "cliui": "^5.0.0",
             "decamelize": "^1.2.0",
@@ -29589,7 +29469,6 @@
           "version": "15.0.3",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
           "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-          "peer": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -31361,8 +31240,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "peer": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-typed-array": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "@redhat-cloud-services/entitlements-client": "^1.0.97",
     "@redhat-cloud-services/frontend-components": "^3.3.0",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.2",
-    "@redhat-cloud-services/frontend-components-remediations": "^3.2.5",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.2",
     "@redhat-cloud-services/host-inventory-client": "^1.0.97",
     "@redhat-cloud-services/keycloak-js": "0.0.3",

--- a/src/js/chrome/render-chrome.js
+++ b/src/js/chrome/render-chrome.js
@@ -18,7 +18,12 @@ window.insights.loadInventory = () => {
     'Do not use `loadInventory` anymore! We have async inventory https://github.com/RedHatInsights/frontend-components/blob/master/packages/components/src/Inventory/InventoryTable.js '
   );
 };
-window.insights.experimental.loadRemediations = loadRemediations;
+window.insights.experimental.loadRemediations = () => {
+  console.log(
+    'Do not use `loadRemediations` anymore! We have FED modules for it - https://github.com/RedHatInsights/frontend-components/blob/master/packages/remediations/doc/remediations.md#hot-loading-the-wizard-directly'
+  );
+  return loadRemediations();
+};
 
 const App = () => {
   const modules = useSelector(({ chrome }) => chrome?.modules);

--- a/src/js/remediations/index.js
+++ b/src/js/remediations/index.js
@@ -1,22 +1,21 @@
 import React from 'react';
-import setDependencies from '../externalDependencies';
 import Deferred from '@redhat-cloud-services/frontend-components-utilities/Deffered';
 
-export default async function loadRemediation(dependencies) {
-  setDependencies(dependencies);
-
-  const remediationsData = await import(/* webpackChunkName: "remediations" */ '@redhat-cloud-services/frontend-components-remediations');
+export default async function loadRemediation() {
   const RenderWrapper = await import(/* webpackChunkName: "remediations-render-wrapper" */ './Wrapper');
-  const deferred = new Deferred();
+  let deferred = new Deferred();
   return {
-    ...remediationsData,
     openWizard: async (data, basePath) => {
-      const wizardRef = await deferred.promise;
-      remediationsData.openWizard(data, basePath, wizardRef);
+      deferred.resolve({ data, basePath });
     },
     // eslint-disable-next-line react/display-name
     RemediationWizard: () => (
-      <RenderWrapper.default cmp={remediationsData.RemediationWizard} onAppRender={(wizardRef) => deferred.resolve(wizardRef)} />
+      <RenderWrapper.default
+        promise={deferred.promise}
+        onClose={(newDeffered) => {
+          deferred = newDeffered;
+        }}
+      />
     ),
   };
 }


### PR DESCRIPTION
### Open FED modules wizard with `openWizard`
We have to preserve the old way of loading remediations with `openWizard` callback, this PR does that by passing deffered function. It's really ugly solution, however some apps are using direct `loadRemediations` function and we also have to support old version of remediations button delivered trough FEC.