### PR TITLE
Use client side routing where possible

### DIFF
--- a/src/js/App/Header/ToolbarToggle.js
+++ b/src/js/App/Header/ToolbarToggle.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 
 import { DropdownToggle, DropdownItem, DropdownPosition, Dropdown } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import ChromeLink from '../Sidenav/Navigation/ChromeLink';
+import { isBeta } from '../../utils';
 
 class ToolbarToggle extends Component {
   constructor(props) {
@@ -34,28 +36,41 @@ class ToolbarToggle extends Component {
 
   render() {
     // Render the questionmark icon items
-    const dropdownItems = this.props.dropdownItems.map(({ url, title, onClick, isHidden, target = '_blank', rel = 'noopener noreferrer', ...rest }) =>
-      !isHidden ? (
-        <DropdownItem
-          key={title}
-          ouiaId={title}
-          component={url ? 'a' : 'button'}
-          // Because the urls are using 'a', don't use onClick for accessibility
-          // If it is a button, use the onClick prop
-          {...(url
-            ? {
-                href: url,
-                target,
-                rel,
-                ...rest,
-              }
-            : { onClick: (ev) => this.onClick(ev, url, onClick) })}
-        >
-          {title}
-        </DropdownItem>
-      ) : (
-        <React.Fragment key="fragment" />
-      )
+    const dropdownItems = this.props.dropdownItems.map(
+      ({ url, appId, title, onClick, isHidden, target = '_blank', rel = 'noopener noreferrer', ...rest }) =>
+        !isHidden ? (
+          <DropdownItem
+            key={title}
+            ouiaId={title}
+            component={
+              appId ? (
+                <ChromeLink href={url} target={target} rel={rel} isBeta={isBeta()} appId={appId}>
+                  {title}
+                </ChromeLink>
+              ) : url ? (
+                'a'
+              ) : (
+                'button'
+              )
+            }
+            // Because the urls are using 'a', don't use onClick for accessibility
+            // If it is a button, use the onClick prop
+            {...(appId
+              ? {}
+              : url
+              ? {
+                  href: url,
+                  target,
+                  rel,
+                  ...rest,
+                }
+              : { onClick: (ev) => this.onClick(ev, url, onClick) })}
+          >
+            {title}
+          </DropdownItem>
+        ) : (
+          <React.Fragment key="fragment" />
+        )
     );
 
     const toggle = (

--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -63,7 +63,7 @@ SettingsButton.propTypes = {
   settingsMenuDropdownItems: PropTypes.array.isRequired,
 };
 
-const settingsPath = `${document.baseURI}settings/my-user-access`;
+const settingsPath = `/settings/my-user-access`;
 const betaSwitcherTitle = `${isBeta() ? 'Stop using' : 'Use'} the beta release`;
 /* list out the items for the settings menu */
 const settingsMenuDropdownItems = [
@@ -71,6 +71,7 @@ const settingsMenuDropdownItems = [
     url: settingsPath,
     title: 'Settings',
     target: '_self',
+    appId: 'rbac',
   },
   {
     title: betaSwitcherTitle,
@@ -108,7 +109,8 @@ const Tools = () => {
     },
     {
       title: 'API documentation',
-      url: `${document.baseURI}docs/api`,
+      url: `/docs/api`,
+      appId: 'apiDocs',
     },
     {
       title: 'Demo mode',

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -3,6 +3,8 @@ import { DropdownToggle, KebabToggle, DropdownItem, DropdownSeparator, DropdownP
 import UserIcon from './UserIcon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { isBeta } from '../../utils';
+import ChromeLink from '../Sidenav/Navigation/ChromeLink';
 
 function buildItems(username, isOrgAdmin, accountNumber = -1, isInternal, extraItems) {
   return [
@@ -35,16 +37,26 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, isInternal, extraI
     </DropdownItem>,
     <React.Fragment key="My user access wrapper">
       {accountNumber > -1 && window.insights.chrome.isBeta() && (
-        <DropdownItem key="My user access" href="./settings/my-user-access">
-          My User Access
-        </DropdownItem>
+        <DropdownItem
+          component={
+            <ChromeLink href="/settings/my-user-access" isBeta={isBeta()} appId="rbac">
+              My User Access
+            </ChromeLink>
+          }
+          key="My user access"
+        />
       )}
     </React.Fragment>,
     <React.Fragment key="user prefs wrapper">
       {accountNumber > -1 && (
-        <DropdownItem key="User preferences" href="./user-preferences/email">
-          User Preferences
-        </DropdownItem>
+        <DropdownItem
+          component={
+            <ChromeLink href="/user-preferences/email" isBeta={isBeta()} appId="userPreferences">
+              User Preferences
+            </ChromeLink>
+          }
+          key="User preferences"
+        />
       )}
     </React.Fragment>,
     <React.Fragment key="internal wrapper">

--- a/src/js/App/RootApp/ScalprumRoot.js
+++ b/src/js/App/RootApp/ScalprumRoot.js
@@ -1,8 +1,8 @@
-import React, { lazy, Suspense, useState } from 'react';
+import React, { lazy, Suspense, useEffect, useState } from 'react';
 import { ScalprumProvider } from '@scalprum/react-core';
 import PropTypes from 'prop-types';
-import { useDispatch, useSelector } from 'react-redux';
-import { Route, Switch } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { Route, Switch, useHistory } from 'react-router-dom';
 import { QuickStartContainer, useLocalStorage } from '@patternfly/quickstarts';
 import cookie from 'js-cookie';
 
@@ -12,6 +12,7 @@ import NavLoader from '../Sidenav/Navigation/Loader';
 import { LazyQuickStartCatalog } from '../QuickStart/LazyQuickStartCatalog';
 import { usePendoFeedback } from '../Feedback';
 import { toggleFeedbackModal } from '../../redux/actions';
+import historyListener from '../../utils/historyListener';
 
 const Navigation = lazy(() => import('../Sidenav/Navigation'));
 const LandingNav = lazy(() => import('../Sidenav/LandingNav'));
@@ -23,6 +24,7 @@ const loaderWrapper = (Component, props = {}) => (
 );
 
 const ScalprumRoot = ({ config, ...props }) => {
+  const history = useHistory();
   const globalFilterRemoved = useSelector(({ globalFilter: { globalFilterRemoved } }) => globalFilterRemoved);
   const dispatch = useDispatch();
   const [activeQuickStartID, setActiveQuickStartID] = useLocalStorage('insights-quickstartId', '');
@@ -64,6 +66,15 @@ const ScalprumRoot = ({ config, ...props }) => {
     setAllQuickStartStates,
     showCardFooters: false,
   };
+
+  useEffect(() => {
+    const unregister = history.listen(historyListener);
+    return () => {
+      if (typeof unregister === 'function') {
+        return unregister();
+      }
+    };
+  }, []);
 
   return (
     /**

--- a/src/js/App/Sidenav/LandingNav.js
+++ b/src/js/App/Sidenav/LandingNav.js
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import axios from 'axios';
 import { loadNavigationLandingPage } from '../../redux/actions';
 import NavLoader from './Navigation/Loader';
+import ChromeLink from './Navigation/ChromeLink';
 
 const LandingNav = () => {
   const isBetaEnv = isBeta();
@@ -44,8 +45,14 @@ const LandingNav = () => {
         <div className="ins-c-app-title">
           <b>Home</b>
         </div>
-        {schema.map(({ title, id, href }) => (
-          <NavItem className="ins-m-navigation-align" key={id} ouiaId={id} to={`${isBetaEnv ? '/beta' : ''}${href}`}>
+        {schema.map(({ title, id, href, appId }) => (
+          <NavItem
+            component={(props) => <ChromeLink {...props} isBeta={isBetaEnv} appId={appId} />}
+            className="ins-m-navigation-align"
+            key={id}
+            ouiaId={id}
+            to={href}
+          >
             {title}
           </NavItem>
         ))}

--- a/src/js/utils/historyListener.js
+++ b/src/js/utils/historyListener.js
@@ -1,0 +1,25 @@
+/**
+ * Maximum SPA application switches
+ */
+const SWITCHES_LIMIT = 20;
+let contextSwitches = 0;
+let prevApp = '';
+const historyListener = (location, action) => {
+  const app = location.pathname.split('/').filter((s) => s.length > 0)[1];
+
+  /**
+   * If the browser hist the reload limit, force the browser refresh for current URL
+   */
+  if (contextSwitches === SWITCHES_LIMIT) {
+    window.location.reload();
+  }
+  /**
+   * Update app switches data
+   */
+  if (action === 'PUSH' && prevApp !== app) {
+    prevApp = app;
+    contextSwitches += 1;
+  }
+};
+
+export default historyListener;


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-15777

### Changes
- use client-side routing in landing nav
- use client-side routing in chrome header
- add client-side routing limiter (20 app switches atm)

We can use client-side routing for the following

- header red hat logo link to landing page (landing page is not using chrome 2 in all envs yet)
- nav to internal bundle (the entry point `commitTracker` is not migrated to chrome 2)