### PR TITLE
Add aria-label to global filter input field

### DIFF
--- a/src/js/App/GlobalFilter/GlobalFilterMenu.js
+++ b/src/js/App/GlobalFilter/GlobalFilterMenu.js
@@ -132,6 +132,7 @@ const GlobalFilterMenu = (props) => {
           value={filterBy}
           onChange={onFilter}
           placeholder="Filter by status"
+          aria-label="Filter by status"
         />
       }
       variant={SelectVariant.typeahead}


### PR DESCRIPTION
Placeholder attribute is not sufficient for a11y. Fix this error whenever global filter is shown.
![err](https://user-images.githubusercontent.com/8426204/131105279-bc18bb85-199d-44f3-a857-be661a071211.png)
