### PR TITLE
Add account requests notifications

### DIFF
--- a/src/js/App/CrossRequestNotifier/CrossRequestNotifier.js
+++ b/src/js/App/CrossRequestNotifier/CrossRequestNotifier.js
@@ -22,14 +22,14 @@ const defaultNotificationConfig = {
 
 const DescriptionComponent = ({ id, markRead }) => (
   <span onClick={() => markRead(id)}>
-    <ChromeLink href={`/settings/rbac/access-requests/${id}`} appId="rbac">
+    <ChromeLink href={id === 'mark-all' ? '/settings/rbac/access-requests' : `/settings/rbac/access-requests/${id}`} appId="rbac">
       View request
     </ChromeLink>
   </span>
 );
 
 DescriptionComponent.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]).isRequired,
   markRead: PropTypes.func.isRequired,
 };
 

--- a/src/js/App/CrossRequestNotifier/CrossRequestNotifier.js
+++ b/src/js/App/CrossRequestNotifier/CrossRequestNotifier.js
@@ -1,6 +1,9 @@
 import React, { useReducer } from 'react';
+import PropTypes from 'prop-types';
 import Portal from '@redhat-cloud-services/frontend-components-notifications/Portal';
 import { ACTIVE_ACCOUNT_SWITCH_NOTIFICATION } from '../../consts';
+import useAccessRequestNotifier from '../../utils/useAccessRequestNotifier';
+import ChromeLink from '../Sidenav/Navigation/ChromeLink';
 
 const ACCOUNT_CHANGE_ID = 'account_change';
 
@@ -11,18 +14,57 @@ const accountSwitchNotification = {
   variant: 'info',
 };
 
+const defaultNotificationConfig = {
+  variant: 'info',
+  dismissable: true,
+  title: 'You have a new access request that needs your review',
+};
+
+const DescriptionComponent = ({ id, markRead }) => (
+  <span onClick={() => markRead(id)}>
+    <ChromeLink href={`/settings/rbac/access-requests/${id}`} appId="rbac">
+      View request
+    </ChromeLink>
+  </span>
+);
+
+DescriptionComponent.propTypes = {
+  id: PropTypes.string.isRequired,
+  markRead: PropTypes.func.isRequired,
+};
+
 const CrossRequestNotifier = () => {
   const [, forceRender] = useReducer((state = false) => !state);
-  const notifications = localStorage.getItem(ACTIVE_ACCOUNT_SWITCH_NOTIFICATION) === 'true' ? [accountSwitchNotification] : [];
+  const [{ data }, markRead] = useAccessRequestNotifier();
+  const crossAccountNotifications = data.filter(({ seen }) => !seen);
+
   const removeNotification = (id) => {
     if (id === ACCOUNT_CHANGE_ID) {
       localStorage.removeItem(ACTIVE_ACCOUNT_SWITCH_NOTIFICATION);
       /**
        * We need this because local storage does not trigger render function and notification would be hanging
        */
-      forceRender();
+      return forceRender();
     }
+    markRead(id);
   };
+
+  const notifications = localStorage.getItem(ACTIVE_ACCOUNT_SWITCH_NOTIFICATION) === 'true' ? [accountSwitchNotification] : [];
+  if (crossAccountNotifications.length > 1) {
+    notifications.push({
+      ...defaultNotificationConfig,
+      id: 'mark-all',
+      description: <DescriptionComponent markRead={markRead} id="mark-all" />,
+    });
+  } else {
+    notifications.push(
+      ...crossAccountNotifications.map(({ request_id }) => ({
+        ...defaultNotificationConfig,
+        id: request_id,
+        description: <DescriptionComponent markRead={markRead} id={request_id} />,
+      }))
+    );
+  }
   return <Portal removeNotification={removeNotification} notifications={notifications} />;
 };
 

--- a/src/js/App/Header/ContextSwitcher.js
+++ b/src/js/App/Header/ContextSwitcher.js
@@ -11,7 +11,7 @@ import { onToggleContextSwitcher } from '../../redux/actions';
 import './ContextSwitcher.scss';
 import { Fragment } from 'react';
 import Cookies from 'js-cookie';
-import { ACTIVE_ACCOUNT_SWITCH_NOTIFICATION } from '../../consts';
+import { ACTIVE_ACCOUNT_SWITCH_NOTIFICATION, REQUESTS_COUNT, REQUESTS_DATA } from '../../consts';
 
 const ContextSwitcher = ({ user, className }) => {
   const dispatch = useDispatch();
@@ -28,6 +28,8 @@ const ContextSwitcher = ({ user, className }) => {
       return;
     }
     localStorage.removeItem(ACTIVE_ACCOUNT_SWITCH_NOTIFICATION);
+    localStorage.removeItem(REQUESTS_COUNT);
+    localStorage.removeItem(REQUESTS_DATA);
     setSelectedAccountNumber(target_account);
     Cookies.set('cross_access_account_number', target_account);
     /**

--- a/src/js/App/Sidenav/Navigation/ChromeNavItem.js
+++ b/src/js/App/Sidenav/Navigation/ChromeNavItem.js
@@ -2,21 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { NavItem } from '@patternfly/react-core';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import { titleCase } from 'title-case';
 import classNames from 'classnames';
+import get from 'lodash/get';
 
 import { isBeta } from '../../../utils';
 import { betaBadge } from '../../Header/Tools';
 import ChromeLink from './ChromeLink';
+import { useSelector } from 'react-redux';
 
-const ChromeNavItem = ({ appId, className, href, isHidden, ignoreCase, title, isExternal, isBeta: isBetaEnv, active }) => {
+const ChromeNavItem = ({ appId, className, href, isHidden, ignoreCase, title, isExternal, isBeta: isBetaEnv, active, notifier = '' }) => {
+  const hasNotifier = useSelector((state) => get(state, notifier));
   if (isHidden) {
     return null;
   }
 
   return (
     <NavItem
-      className={classNames(className, { 'ins-c-navigation__additional-links': isExternal })}
+      className={classNames(className, { 'ins-c-navigation__additional-links': isExternal, 'ins-c-navigation__with-notifier': hasNotifier })}
       itemID={href}
       data-quickstart-id={href}
       preventDefault
@@ -27,6 +31,7 @@ const ChromeNavItem = ({ appId, className, href, isHidden, ignoreCase, title, is
     >
       {typeof title === 'string' && !ignoreCase ? titleCase(title) : title} {isExternal && <ExternalLinkAltIcon />}
       {isBetaEnv && !isBeta() && !isExternal && betaBadge('ins-c-navigation__beta-badge')}
+      {hasNotifier && <BellIcon size="md" className="notifier-icon" color="var(--pf-global--default-color--200)" />}
     </NavItem>
   );
 };
@@ -41,6 +46,7 @@ ChromeNavItem.propTypes = {
   className: PropTypes.string,
   active: PropTypes.bool,
   appId: PropTypes.string,
+  notifier: PropTypes.string,
 };
 
 export default ChromeNavItem;

--- a/src/js/App/Sidenav/Navigation/Navigation.scss
+++ b/src/js/App/Sidenav/Navigation/Navigation.scss
@@ -74,6 +74,16 @@
   svg { margin-left: var(--pf-global--spacer--sm); }
 }
 
+.pf-c-nav__item {
+  a.ins-c-navigation__with-notifier {
+    align-items: center;
+    .notifier-icon {
+      margin-left: auto;
+      margin-right: 8px;
+    }
+  }
+}
+
 .pf-c-nav__item .pf-c-nav__link .ins-c-navigation__beta-badge {
   float: right;
   margin-right: 0px;

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -9,6 +9,11 @@ const obj = {
 };
 
 export const HYDRA_ENDPOINT = '/hydra/rest/se/sessions';
+/**
+ * Keys for storing acess reqeusts data
+ */
+export const REQUESTS_COUNT = 'chrome:cross-account-requests:pending:count';
+export const REQUESTS_DATA = 'chrome:cross-account-requests:pending:data';
 export const ACTIVE_ACCOUNT_SWITCH_NOTIFICATION = 'chrome:cross-account-requests:active-notification';
 
 const matcherMapper = {

--- a/src/js/redux-config.js
+++ b/src/js/redux-config.js
@@ -15,6 +15,10 @@ const reduxRegistry = new ReducerRegistry(
   {
     chrome: {
       navigation: {},
+      accessRequests: {
+        count: 0,
+        data: [],
+      },
     },
   },
   [promise, middlewareListener.getMiddleware(), ...basicMiddlewares]

--- a/src/js/redux/action-types.js
+++ b/src/js/redux/action-types.js
@@ -24,3 +24,5 @@ export const LOAD_MODULES_SCHEMA = '@@chrome/load-modules-schema';
 export const CHANGE_ACTIVE_MODULE = '@@chrome/change-active-module';
 export const SET_PENDO_FEEDBACK_FLAG = '@@chrome/set-pendo-feedback-flag';
 export const TOGGLE_FEEDBACK_MODAL = '@@chrome/toggle-feedback-modal';
+export const UPDATE_ACCESS_REQUESTS_NOTIFICATIONS = '@@chrome/update-access-requests-notifications';
+export const MARK_REQUEST_NOTIFICATION_SEEN = '@@chrome/mark-request-notification-seen';

--- a/src/js/redux/actions.js
+++ b/src/js/redux/actions.js
@@ -125,3 +125,13 @@ export const toggleFeedbackModal = (payload) => ({
   type: actionTypes.TOGGLE_FEEDBACK_MODAL,
   payload,
 });
+
+export const updateAccessRequestsNotifications = (payload) => ({
+  type: actionTypes.UPDATE_ACCESS_REQUESTS_NOTIFICATIONS,
+  payload,
+});
+
+export const markAccessRequestNotification = (payload) => ({
+  type: actionTypes.MARK_REQUEST_NOTIFICATION_SEEN,
+  payload,
+});

--- a/src/js/redux/index.js
+++ b/src/js/redux/index.js
@@ -13,6 +13,8 @@ import {
   changeActiveModuleReducer,
   setPendoFeedbackFlag,
   toggleFeedbackModal,
+  accessRequestsNotificationsReducer,
+  markAccessRequestRequestReducer,
 } from './reducers';
 import {
   onGetAllTags,
@@ -47,6 +49,8 @@ import {
   CHANGE_ACTIVE_MODULE,
   SET_PENDO_FEEDBACK_FLAG,
   TOGGLE_FEEDBACK_MODAL,
+  UPDATE_ACCESS_REQUESTS_NOTIFICATIONS,
+  MARK_REQUEST_NOTIFICATION_SEEN,
 } from './action-types';
 
 const reducers = {
@@ -62,6 +66,8 @@ const reducers = {
   [CHANGE_ACTIVE_MODULE]: changeActiveModuleReducer,
   [SET_PENDO_FEEDBACK_FLAG]: setPendoFeedbackFlag,
   [TOGGLE_FEEDBACK_MODAL]: toggleFeedbackModal,
+  [UPDATE_ACCESS_REQUESTS_NOTIFICATIONS]: accessRequestsNotificationsReducer,
+  [MARK_REQUEST_NOTIFICATION_SEEN]: markAccessRequestRequestReducer,
 };
 
 const globalFilter = {
@@ -84,6 +90,10 @@ export default function () {
     chrome: (
       state = {
         navigation: {},
+        accessRequests: {
+          count: 0,
+          data: [],
+        },
       },
       action
     ) => applyReducerHash(reducers)(state, action),

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -137,6 +137,7 @@ export function accessRequestsNotificationsReducer(state, { payload: { count, da
     accessRequests: {
       ...state.accessRequests,
       count,
+      hasUnseen: newData.length > 0,
       data: newData,
     },
   };

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -1,3 +1,4 @@
+import { REQUESTS_COUNT, REQUESTS_DATA } from '../consts';
 import { isBeta } from '../utils';
 
 export function contextSwitcherBannerReducer(state) {
@@ -120,5 +121,35 @@ export function toggleFeedbackModal(state, { payload }) {
   return {
     ...state,
     isFeedbackModalOpen: payload,
+  };
+}
+
+export function accessRequestsNotificationsReducer(state, { payload: { count, data } }) {
+  const newData = data.map(({ request_id, created, seen }) => ({
+    request_id,
+    created,
+    seen: seen === true || !!state.accessRequests.data.find((item) => request_id === item.request_id)?.seen || false,
+  }));
+  localStorage.setItem(REQUESTS_COUNT, newData.length);
+  localStorage.setItem(REQUESTS_DATA, JSON.stringify(newData));
+  return {
+    ...state,
+    accessRequests: {
+      ...state.accessRequests,
+      count,
+      data: newData,
+    },
+  };
+}
+
+export function markAccessRequestRequestReducer(state, { payload }) {
+  const newData = state.accessRequests.data.map((item) => (item.request_id === payload ? { ...item, seen: true } : item));
+  localStorage.setItem(REQUESTS_DATA, JSON.stringify(newData));
+  return {
+    ...state,
+    accessRequests: {
+      ...state.accessRequests,
+      data: newData,
+    },
   };
 }

--- a/src/js/utils/useAccessRequestNotifier.js
+++ b/src/js/utils/useAccessRequestNotifier.js
@@ -1,0 +1,71 @@
+import axios from 'axios';
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { REQUESTS_COUNT, REQUESTS_DATA } from '../consts';
+import { markAccessRequestNotification, updateAccessRequestsNotifications } from '../redux/actions';
+
+const useAccessRequestNotifier = () => {
+  const user = useSelector(({ chrome }) => chrome?.user);
+  const isMounted = useRef(false);
+  const state = useSelector(({ chrome: { accessRequests } }) => accessRequests);
+  const dispatch = useDispatch();
+
+  const markRead = (id) => {
+    dispatch(markAccessRequestNotification(id));
+  };
+
+  const notifier = () => {
+    axios.get('/api/rbac/v1/cross-account-requests/?limit=10&status=pending&order_by=-created').then(
+      ({
+        data: {
+          meta: { count },
+          data,
+        },
+      }) => {
+        if (isMounted.current && state.count < count) {
+          dispatch(updateAccessRequestsNotifications({ count, data }));
+        }
+      }
+    );
+  };
+
+  useEffect(() => {
+    isMounted.current = true;
+    dispatch(
+      updateAccessRequestsNotifications({
+        count: parseInt(localStorage.getItem(REQUESTS_COUNT) || 0),
+        data: JSON.parse(localStorage.getItem(REQUESTS_DATA) || '[]'),
+      })
+    );
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    /**
+     * register notifier only for org admin
+     */
+    let interval;
+    if (user?.identity?.user?.is_org_admin && !interval) {
+      try {
+        notifier();
+        interval = setInterval(notifier, 20000);
+      } catch (err) {
+        console.error(err);
+        if (interval) {
+          clearInterval(interval);
+        }
+      }
+    }
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [user]);
+
+  return [state, markRead];
+};
+
+export default useAccessRequestNotifier;

--- a/src/js/utils/useAccessRequestNotifier.js
+++ b/src/js/utils/useAccessRequestNotifier.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, batch } from 'react-redux';
 import { REQUESTS_COUNT, REQUESTS_DATA } from '../consts';
 import { markAccessRequestNotification, updateAccessRequestsNotifications } from '../redux/actions';
 
@@ -11,7 +11,15 @@ const useAccessRequestNotifier = () => {
   const dispatch = useDispatch();
 
   const markRead = (id) => {
-    dispatch(markAccessRequestNotification(id));
+    if (id === 'mark-all') {
+      batch(() => {
+        state.data.forEach(({ request_id }) => {
+          dispatch(markAccessRequestNotification(request_id));
+        });
+      });
+    } else {
+      dispatch(markAccessRequestNotification(id));
+    }
   };
 
   const notifier = () => {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-9761

### Changes
- added a redux entry for pending access requests
- data is stored in local storage to avoid showing notifications for already viewed requests
- data is refreshed every 20s because there are no server events pushed to the browser atm
- requires: https://github.com/RedHatInsights/cloud-services-config/pull/886 to configure nav items for the bell icon

There are still a few open questions about certain scenarios. More in the jira ticket.

### Preview
![access-requests](https://user-images.githubusercontent.com/22619452/131795497-4af323ce-bdbd-41aa-826d-2dd8468b7a11.gif)
