### PR TITLE
Add bundle and appId to Url on user-pref redirect

### DIFF
--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -3,10 +3,10 @@ import { DropdownToggle, KebabToggle, DropdownItem, DropdownSeparator, DropdownP
 import UserIcon from './UserIcon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { isBeta } from '../../utils';
+import { isBeta, getUrl } from '../../utils';
 import ChromeLink from '../Sidenav/Navigation/ChromeLink';
 
-function buildItems(username, isOrgAdmin, accountNumber = -1, isInternal, extraItems) {
+function buildItems(username, isOrgAdmin, accountNumber = -1, isInternal, extraItems, appId) {
   return [
     <DropdownItem key="Username" isDisabled>
       <dl className="ins-c-dropdown-item__stack">
@@ -51,7 +51,7 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, isInternal, extraI
       {accountNumber > -1 && (
         <DropdownItem
           component={
-            <ChromeLink href="/user-preferences/email" isBeta={isBeta()} appId="userPreferences">
+            <ChromeLink href={`/user-preferences/email#bundle=${getUrl('bundle')}&appId=${appId}`} isBeta={isBeta()} appId="userPreferences">
               User Preferences
             </ChromeLink>
           }
@@ -95,7 +95,7 @@ export class UserToggle extends Component {
 
   render() {
     const { isOpen } = this.state;
-    const { account, isSmall, extraItems } = this.props;
+    const { account, isSmall, extraItems, appId } = this.props;
     const toggle = isSmall ? (
       <KebabToggle onToggle={this.onToggle} className="data-hj-suppress" />
     ) : (
@@ -118,7 +118,7 @@ export class UserToggle extends Component {
         toggle={toggle}
         isPlain
         isOpen={isOpen}
-        dropdownItems={buildItems(account.username, account.isOrgAdmin, account.number, account.isInternal, extraItems)}
+        dropdownItems={buildItems(account.username, account.isOrgAdmin, account.number, account.isInternal, extraItems, appId)}
       />
     );
   }
@@ -132,6 +132,7 @@ UserToggle.propTypes = {
     isOrgAdmin: PropTypes.bool,
     isInternal: PropTypes.bool,
   }),
+  appId: PropTypes.string,
   isSmall: PropTypes.bool,
   extraItems: PropTypes.arrayOf(PropTypes.node),
 };
@@ -156,6 +157,7 @@ export default connect(
           user: { username, first_name, last_name, is_org_admin, is_internal },
         },
       },
+      appId,
     },
   }) => ({
     account: {
@@ -165,6 +167,7 @@ export default connect(
       isInternal: is_internal,
       name: `${first_name} ${last_name}`,
     },
+    appId,
   })
 )(UserToggle);
 

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -7,6 +7,7 @@ import { isBeta, getUrl } from '../../utils';
 import ChromeLink from '../Sidenav/Navigation/ChromeLink';
 
 function buildItems(username, isOrgAdmin, accountNumber = -1, isInternal, extraItems, appId) {
+  const bundle = getUrl('bundle');
   return [
     <DropdownItem key="Username" isDisabled>
       <dl className="ins-c-dropdown-item__stack">
@@ -51,7 +52,7 @@ function buildItems(username, isOrgAdmin, accountNumber = -1, isInternal, extraI
       {accountNumber > -1 && (
         <DropdownItem
           component={
-            <ChromeLink href={`/user-preferences/email#bundle=${getUrl('bundle')}&appId=${appId}`} isBeta={isBeta()} appId="userPreferences">
+            <ChromeLink href={`/user-preferences/email#${bundle ? `bundle=${bundle}&` : ''}appId=${appId}`} isBeta={isBeta()} appId="userPreferences">
               User Preferences
             </ChromeLink>
           }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14545

When navigating to user-preferences `bundle` name and `appId` of the previous location are passed to the URL as a hash eg.
`https://ci.foo.redhat.com:1337/user-preferences/email#bundle=settings&appId=rbac`