### PR TITLE
Restrict ansible fedramps

### DIFF
--- a/src/js/App/Header/AppFilter/useAppFilter.js
+++ b/src/js/App/Header/AppFilter/useAppFilter.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isBeta, getEnv, isFedRamp } from '../../../utils';
 import { evaluateVisibility } from '../../../utils/isNavItemVisible';
+import { computeFedrampResult } from '../../../utils/useRenderFedramp';
 
 export const requiredBundles = ['application-services', 'openshift', 'insights', ...(getEnv() !== 'prod' ? ['edge'] : []), 'ansible', 'settings'];
 const bundlesOrder = ['application-services', 'openshift', 'rhel', 'edge', 'ansible', 'settings', 'cost-management', 'subscriptions'];
@@ -14,7 +15,7 @@ function getBundleLink({ title, isExternal, href, routes, expandable, ...rest },
   const subscriptionsLinks = [];
   let url = href;
   let appId = rest.appId;
-  let isFedramp = modules[appId]?.isFedramp;
+  let isFedramp = computeFedrampResult(isFedrampEnv, url, modules[appId]);
   if (expandable) {
     routes.forEach(({ href, title, ...rest }) => {
       if (href.includes('/openshift/cost-management') && rest.filterable !== false) {
@@ -33,7 +34,7 @@ function getBundleLink({ title, isExternal, href, routes, expandable, ...rest },
       if (!url && href.match(/^\//)) {
         url = isExternal ? href : href.split('/').slice(0, 3).join('/');
         appId = rest.appId ? rest.appId : appId;
-        isFedramp = modules[appId]?.isFedramp;
+        isFedramp = computeFedrampResult(isFedrampEnv, url, modules[appId]);
       }
     });
   }

--- a/src/js/App/Routes/index.js
+++ b/src/js/App/Routes/index.js
@@ -25,7 +25,7 @@ const generateRoutesList = (modules) =>
             routes.map((route) => ({
               scope,
               module,
-              isFedramp,
+              isFedramp: typeof route === 'string' ? isFedramp : route.isFedramp,
               path: typeof route === 'string' ? route : route.pathname,
               manifestLocation,
               dynamic: typeof dynamic === 'boolean' ? dynamic : typeof route === 'string' ? true : route.dynamic,

--- a/src/js/App/Sidenav/Navigation/ChromeNavExapandable.js
+++ b/src/js/App/Sidenav/Navigation/ChromeNavExapandable.js
@@ -4,16 +4,18 @@ import { NavExpandable } from '@patternfly/react-core';
 import ChromeNavItemFactory from './ChromeNavItemFactory';
 import { useSelector } from 'react-redux';
 import { isFedRamp } from '../../../utils';
+import { computeFedrampResult } from '../../../utils/useRenderFedramp';
 
 const ChromeNavExapandable = ({ title, routes, active, isHidden, id }) => {
   const modules = useSelector((state) => state.chrome.modules);
   let filteredFedrampRoutes = routes;
   if (isFedRamp()) {
-    filteredFedrampRoutes = routes.filter(({ appId }) => {
-      return modules[appId]?.isFedramp === true;
+    filteredFedrampRoutes = routes.filter(({ appId, href }) => {
+      return computeFedrampResult(appId, href, modules[appId]);
     });
   }
-  if (isHidden || filteredFedrampRoutes.length === 0) {
+
+  if (isHidden || filteredFedrampRoutes.filter(({ appId }) => !!appId).length === 0) {
     return null;
   }
 

--- a/src/js/App/Sidenav/Navigation/ChromeNavExapandable.test.js
+++ b/src/js/App/Sidenav/Navigation/ChromeNavExapandable.test.js
@@ -31,7 +31,7 @@ describe('ChromeNavExapandable', () => {
     appId: 'testModule',
     href: '/foo',
     title: expandableTitle,
-    routes: [{ title: 'title', href: '/foo/bar' }],
+    routes: [{ appId: 'bar', title: 'title', href: '/foo/bar' }],
     id: 'test-id',
   };
   const store = mockStore({

--- a/src/js/App/Sidenav/Navigation/ChromeNavItem.js
+++ b/src/js/App/Sidenav/Navigation/ChromeNavItem.js
@@ -11,12 +11,12 @@ import { isBeta } from '../../../utils';
 import { betaBadge } from '../../Header/Tools';
 import ChromeLink from './ChromeLink';
 import { useSelector } from 'react-redux';
-import { isFedRamp } from '../../../utils';
+import useRenderFedramp from '../../../utils/useRenderFedramp';
 
 const ChromeNavItem = ({ appId, className, href, isHidden, ignoreCase, title, isExternal, isBeta: isBetaEnv, active, notifier = '' }) => {
   const hasNotifier = useSelector((state) => get(state, notifier));
-  const modules = useSelector((state) => state.chrome.modules);
-  if (isFedRamp() && modules[appId]?.isFedramp !== true) {
+  const renderFedramp = useRenderFedramp(appId, href);
+  if (renderFedramp !== true) {
     return null;
   }
 

--- a/src/js/App/Sidenav/Navigation/ChromeNavItemFactory.test.js
+++ b/src/js/App/Sidenav/Navigation/ChromeNavItemFactory.test.js
@@ -39,7 +39,7 @@ describe('ChromeNavItemFactory', () => {
     id: 'test-id',
     title: expandableTitle,
     expandable: true,
-    routes: [{ title: linkTitle, href: '/foo/bar' }],
+    routes: [itemProps],
   };
   const groupItemProps = {
     groupId: 'group',

--- a/src/js/App/Sidenav/Navigation/__snapshots__/ChromeNavItemFactory.test.js.snap
+++ b/src/js/App/Sidenav/Navigation/__snapshots__/ChromeNavItemFactory.test.js.snap
@@ -54,10 +54,9 @@ exports[`ChromeNavItemFactory should render chrome expandable nav item 1`] = `
         >
           <a
             class="pf-c-nav__link"
-            data-quickstart-id="/foo/bar"
-            data-testid="native-link"
-            href="http://localhost/foo/bar"
-            itemid="/foo/bar"
+            data-quickstart-id="foo"
+            data-testid="router-link"
+            href="/foo"
           >
             Foo
              

--- a/src/js/utils/useRenderFedramp.js
+++ b/src/js/utils/useRenderFedramp.js
@@ -1,0 +1,56 @@
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { matchPath } from 'react-router-dom';
+
+import { isFedRamp } from '../utils';
+const isFedrampEnv = isFedRamp();
+
+export const computeFedrampResult = (isFedrampEnv, linkHref = '', { modules, isFedramp } = { modules: [] }) => {
+  /**
+   * Render everything on non-fedramp env
+   */
+  if (!isFedrampEnv) {
+    return undefined;
+  }
+
+  /**
+   * Look for module routes with fedramp flag that match the link
+   */
+  const configs = modules
+    .map(({ routes }) => routes)
+    .flat()
+    .filter((route) => {
+      if (typeof route !== 'object') {
+        return false;
+      }
+
+      const match = matchPath(linkHref, {
+        path: route.pathname,
+      });
+
+      return match !== null;
+    })
+    .filter(({ isFedramp }) => typeof isFedramp === 'boolean');
+  const result = configs.length > 0 ? configs.some(({ isFedramp }) => isFedramp === true) : undefined;
+
+  if (typeof result === 'boolean') {
+    return result;
+  }
+  /**
+   * Global module setting has the lowest priority
+   */
+  return isFedramp;
+};
+
+const useRenderFedramp = (appId, linkHref) => {
+  const module = useSelector(({ chrome: { modules } }) => modules[appId]);
+  const [shouldRender, setShouldRender] = useState(() => computeFedrampResult(isFedrampEnv, linkHref, module));
+
+  useEffect(() => {
+    setShouldRender(computeFedrampResult(isFedrampEnv, linkHref, module));
+  }, [appId, linkHref]);
+
+  return isFedrampEnv ? shouldRender : true;
+};
+
+export default useRenderFedramp;


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-14323

This PR allows consuming more granular fedramp settings. Sample configuration can be found it this CSC PR: https://github.com/RedHatInsights/cloud-services-config/pull/898

This is required for modules that live at multiple routes but only some of them are eligible for fedramp usage.