### PR TITLE
Add bypassCache option to getUserPermissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "insights-chrome",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/js/rbac/fetchPermissions.js
+++ b/src/js/rbac/fetchPermissions.js
@@ -27,12 +27,12 @@ const fetchPermissions = (userToken, app = '') => {
 
 export const createFetchPermissionsWatcher = () => {
   let currentCall = {};
-  return async (userToken, app = '') => {
+  return async (userToken, app = '', bypassCache) => {
     const user = await insights.chrome.auth.getUser();
     if (user?.identity && [undefined, -1].includes(user.identity.account_number)) {
       return Promise.resolve([]);
     }
-    if (typeof currentCall?.[app] === 'undefined') {
+    if (typeof currentCall?.[app] === 'undefined' || bypassCache) {
       currentCall[app] = await fetchPermissions(userToken, app);
     }
     return currentCall?.[app];

--- a/src/js/rbac/fetchPermissions.test.js
+++ b/src/js/rbac/fetchPermissions.test.js
@@ -1,8 +1,12 @@
 import mockedRbac from '../../../testdata/rbacAccess.json';
+
 jest.mock('./rbac', () => () => {
   const mockedRbac = require('../../../testdata/rbacAccess.json');
   return {
-    getPrincipalAccess: () => Promise.resolve(mockedRbac),
+    getPrincipalAccess: () => {
+      global.rbacApiCalled++;
+      return Promise.resolve(mockedRbac);
+    },
   };
 });
 
@@ -15,6 +19,11 @@ describe('fetchPermissions', () => {
   beforeEach(() => {
     const chromeInstance = { cache: { getItem: () => undefined, setItem: () => undefined } };
     fetchPermissions = createFetchPermissionsWatcher(chromeInstance);
+    global.rbacApiCalled = 0;
+  });
+
+  afterAll(() => {
+    delete global.rbacApiCalled;
   });
 
   it('should send all the paginated data as array', async () => {
@@ -27,5 +36,31 @@ describe('fetchPermissions', () => {
     const data = fetchPermissions('uSeRtOkEn');
     expect.assertions(1);
     return data.then((permissions) => expect(permissions).toEqual(mockedRbac.data));
+  });
+
+  it('should cache results', async () => {
+    await fetchPermissions('uSeRtOkEn', 'sources');
+
+    expect(global.rbacApiCalled).toEqual(1);
+
+    await fetchPermissions('uSeRtOkEn', 'sources');
+
+    expect(global.rbacApiCalled).toEqual(1);
+
+    await fetchPermissions('uSeRtOkEn', 'inventory');
+
+    expect(global.rbacApiCalled).toEqual(2);
+  });
+
+  it('should not cache results', async () => {
+    const bypasCache = true;
+
+    await fetchPermissions('uSeRtOkEn', 'sources', bypasCache);
+
+    expect(global.rbacApiCalled).toEqual(1);
+
+    await fetchPermissions('uSeRtOkEn', 'sources', bypasCache);
+
+    expect(global.rbacApiCalled).toEqual(2);
   });
 });


### PR DESCRIPTION
We have encountered a bug in Sources: Sources now require write permissions that users can set up in RBAC application, but because both of these application are in the same bundle, Chrome is not being reloaded and the old permissions are cached, so users have to do hard refresh. This can create confusion amongst users.

cc @karelhala @Hyperkid123 

It would be great to backport this PR to prod-stable/beta and stable branches.