### PR TITLE
lock router-dom to 5.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "react-dom": "^17.0.2",
         "react-intl": "^5.20.10",
         "react-redux": "^7.2.4",
-        "react-router-dom": "^5.2.1",
+        "react-router-dom": "5.2.1",
         "react-test-renderer": "^17.0.2",
         "redux": "^4.1.1",
         "redux-promise-middleware": "^6.1.2",
@@ -11481,41 +11481,6 @@
       "peerDependencies": {
         "prop-types": "^15.0.0",
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.2.2.tgz",
-      "integrity": "sha512-eUjQ/q1rQIeHWgIx7ny/DNgXHcMXHdBwgrZQK7Ev8dbR+HxhroFM2Cb6kMiswOYaq05IRJhPuQqXWUABIjjA3g==",
-      "dependencies": {
-        "schema-utils": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "react-dom": "^17.0.2",
     "react-intl": "^5.20.10",
     "react-redux": "^7.2.4",
-    "react-router-dom": "^5.2.1",
+    "react-router-dom": "5.2.1",
     "react-test-renderer": "^17.0.2",
     "redux": "^4.1.1",
     "redux-promise-middleware": "^6.1.2",


### PR DESCRIPTION
Required for application services versioning bug. We have to find a more stable solution later on.