### PR TITLE
Use download button wrapper as proxy

### DIFF
--- a/src/js/pdf/DownloadButton.js
+++ b/src/js/pdf/DownloadButton.js
@@ -1,8 +1,8 @@
 /* eslint-disable rulesdir/disallow-fec-relative-imports */
 import React from 'react';
 
-import { DownloadButton } from '@redhat-cloud-services/frontend-components-pdf-generator';
+import { DownloadButtonWrapper } from '@redhat-cloud-services/frontend-components-pdf-generator';
 
-const ProxyDownloadButton = (props) => <DownloadButton {...props} />;
+const ProxyDownloadButton = (props) => <DownloadButtonWrapper {...props} />;
 
 export default ProxyDownloadButton;


### PR DESCRIPTION
### Download button wrapper

Since want to wrap the download button in proxy let's use the wrapper in the fed module. This is linked to https://github.com/RedHatInsights/frontend-components/pull/1269 but no need to wait for that one to be merged. Nobody is using this fed mod, yet.