### PR TITLE
Return initilized chrome when calling init

### DIFF
--- a/src/js/chrome/create-chrome.js
+++ b/src/js/chrome/create-chrome.js
@@ -24,10 +24,14 @@ const createChromeInstance = (jwt, insights) => {
     if (rootEl) {
       rootEl.setAttribute('data-ouia-safe', true);
     }
-    window.insights.chrome = {
+
+    const initializedChrome = {
       ...window.insights.chrome,
       ...chromeInit(),
     };
+    window.insights.chrome = initializedChrome;
+
+    return initializedChrome;
   };
 
   /**


### PR DESCRIPTION
### Allows for consuming updated chrome API

When `init` is called the consumed chrome is not updated. This PR returns the whole chrome API after it is initialized.

### Usage

```JSX
import React, { useEffect } from 'react'
import useChrome from '@redhat-cloud-services/frontend-components/useChrome';

const App = () => {
 const chrome = useChrome();
 useEffect(() => {
  const { on: onChromeEvent } = chrome?.init();
  const unregister = onChromeEvent('APP_NAVIGATION', (event) => history.push(`/${event.navId}`));
  return () => {
    unregister();
  };
 }, []);
 return <div>App</div>
};
```
