### PR TITLE
Fix broken dynamic nav by using default empty object

### DIFF
--- a/src/js/App/Sidenav/Navigation/DynamicNav.js
+++ b/src/js/App/Sidenav/Navigation/DynamicNav.js
@@ -15,7 +15,7 @@ const DynamicNav = ({ dynamicNav }) => {
   const [appName] = dynamicNav.split('/');
   const currentNamespace = pathname.split('/')[1];
   const schema = useSelector(({ chrome: { navigation } }) => navigation[currentNamespace]);
-  const { default: navigation } = useModule(appName, './Navigation', {});
+  const { default: navigation } = useModule(appName, './Navigation', {}) || {};
   useEffect(() => {
     if (navigation) {
       if (typeof navigation === 'function') {


### PR DESCRIPTION
### Error while using dynamic nav

When dynamic nav is used in different app it breaks because the app is not properly loaded. This PR fixes such issue by sending empty object if no module is loaded. There will be a followup PR to properly fix this by importing the app in DOM.