### PR TITLE
Functionality for hiding badge when opening QS

### DIFF
--- a/src/js/App/RootApp/ScalprumRoot.js
+++ b/src/js/App/RootApp/ScalprumRoot.js
@@ -94,6 +94,11 @@ const ScalprumRoot = ({ config, ...props }) => {
     };
   }, []);
 
+  useEffect(() => {
+    const body = document.getElementsByTagName('body')[0];
+    activeQuickStartID !== '' ? body.classList.add('quickstarts-open') : body.classList.remove('quickstarts-open');
+  }, [activeQuickStartID]);
+
   return (
     /**
      * Once all applications are migrated to chrome 2:

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -31,6 +31,10 @@ aside {
     overflow: auto !important;
 }
 
+.quickstarts-open ._pendo-badge {
+  display:none !important;
+} 
+
 .inc-c-chrome__root-element {
     min-height: 100vh;
 }


### PR DESCRIPTION
This PR addresses [this ticket](https://issues.redhat.com/browse/RHCLOUD-16796)
![E80B10AA-2390-4857-A3E1-B570ED646378](https://user-images.githubusercontent.com/56621323/142474891-072cbced-84b2-44c8-882b-cea5516bf35b.jpeg)

Changes now hide the pendo bage completely whenever there is an activeQuickstart, hence addressing the issue. User can just close the quickstart for the badge to reappear. 