### PR TITLE
Add height property to enable content scrolling.

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -36,7 +36,7 @@ aside {
 } 
 
 .inc-c-chrome__root-element {
-    min-height: 100vh;
+    height: 100vh !important;
 }
 
 .pf-c-page.ins-c-page__hasBanner {


### PR DESCRIPTION
The single HTML template does not have the correct height property and the nav and content are not scrollable, only the body element.

### Before
![screenshot-stage foo redhat com_1337-2021 11 19-12_59_27](https://user-images.githubusercontent.com/22619452/142619610-0137d6ca-d81b-4af6-9bd6-8471a2487fb7.png)


### After
![screenshot-stage foo redhat com_1337-2021 11 19-13_00_13](https://user-images.githubusercontent.com/22619452/142619628-fdf11e10-3d11-40d5-8c05-da48452f4171.png)

