### PR TITLE
Remove extra expanded classname from user toggle.

### DIFF
--- a/src/js/App/Header/HeaderTests/__snapshots__/Header.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/Header.test.js.snap
@@ -151,7 +151,7 @@ exports[`Header should render correctly 1`] = `
             >
               <div
                 aria-label="Overflow actions"
-                class="pf-c-dropdown pf-m-align-right pf-m-expanded chr-c-dropdown-user-toggle"
+                class="pf-c-dropdown pf-m-align-right chr-c-dropdown-user-toggle"
                 data-ouia-component-id="chrome-user-menu"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
@@ -206,7 +206,7 @@ exports[`Header should render correctly 1`] = `
             >
               <div
                 aria-label="Overflow actions"
-                class="pf-c-dropdown pf-m-align-right pf-m-expanded chr-c-dropdown-user-toggle"
+                class="pf-c-dropdown pf-m-align-right chr-c-dropdown-user-toggle"
                 data-ouia-component-id="chrome-user-menu"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"

--- a/src/js/App/Header/HeaderTests/__snapshots__/UserToggle.test.js.snap
+++ b/src/js/App/Header/HeaderTests/__snapshots__/UserToggle.test.js.snap
@@ -4,7 +4,7 @@ exports[`ConnectedUserToggle -- not org admin should render correctly 1`] = `
 <div>
   <div
     aria-label="Overflow actions"
-    class="pf-c-dropdown pf-m-align-right pf-m-expanded chr-c-dropdown-user-toggle"
+    class="pf-c-dropdown pf-m-align-right chr-c-dropdown-user-toggle"
     data-ouia-component-id="chrome-user-menu"
     data-ouia-component-type="PF4/Dropdown"
     data-ouia-safe="true"
@@ -56,7 +56,7 @@ exports[`ConnectedUserToggle -- org admin should render correctly 1`] = `
 <div>
   <div
     aria-label="Overflow actions"
-    class="pf-c-dropdown pf-m-align-right pf-m-expanded chr-c-dropdown-user-toggle"
+    class="pf-c-dropdown pf-m-align-right chr-c-dropdown-user-toggle"
     data-ouia-component-id="chrome-user-menu"
     data-ouia-component-type="PF4/Dropdown"
     data-ouia-safe="true"
@@ -108,7 +108,7 @@ exports[`UserToggle should render correctly with isSmall false 1`] = `
 <div>
   <div
     aria-label="Overflow actions"
-    class="pf-c-dropdown pf-m-align-right pf-m-expanded chr-c-dropdown-user-toggle"
+    class="pf-c-dropdown pf-m-align-right chr-c-dropdown-user-toggle"
     data-ouia-component-id="chrome-user-menu"
     data-ouia-component-type="PF4/Dropdown"
     data-ouia-safe="true"
@@ -160,7 +160,7 @@ exports[`UserToggle should render correctly with isSmall true 1`] = `
 <div>
   <div
     aria-label="Overflow actions"
-    class="pf-c-dropdown pf-m-align-right pf-m-expanded chr-c-dropdown-user-toggle"
+    class="pf-c-dropdown pf-m-align-right chr-c-dropdown-user-toggle"
     data-ouia-component-id="chrome-user-menu"
     data-ouia-component-type="PF4/Dropdown"
     data-ouia-safe="true"

--- a/src/js/App/Header/UserToggle.js
+++ b/src/js/App/Header/UserToggle.js
@@ -112,7 +112,7 @@ export class UserToggle extends Component {
         ouiaId="chrome-user-menu"
         onSelect={this.onSelect}
         toggle={toggle}
-        className="pf-m-expanded chr-c-dropdown-user-toggle"
+        className="chr-c-dropdown-user-toggle"
         isOpen={isOpen}
         dropdownItems={buildItems(account.username, account.isOrgAdmin, account.number, account.isInternal, extraItems)}
       />


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-17044

@epwinchell do you know if there was a specific reason why the classname is there?