### PR TITLE
Update ErrorComponent.js

### DIFF
--- a/src/js/App/ErrorComponent/ErrorComponent.js
+++ b/src/js/App/ErrorComponent/ErrorComponent.js
@@ -47,7 +47,7 @@ const ErrorComponent = (props) => {
             <a href="https://status.redhat.com/" target="_blank" rel="noreferrer">
               status page
             </a>{' '}
-            for known outages.
+            for known outages. If your browser is old, try updating to a recent version.
           </p>
           <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'column' }}>
             <FlexItem>


### PR DESCRIPTION
Sufficiently old browsers can fail to load JS and show this screen.  
I don't believe users actively seek out documentation on which browsers we support, so I want some hint here that an old browser might be the problem.

Example seen on console of ancient Chrome 77 choking on `?.` syntax in apps/openshift:

    Uncaught SyntaxError: Unexpected token '.'
    ChunkLoadError: Loading chunk 677 failed.
