### PR TITLE
Add cache control tags to HTML templates.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,8 @@
     <title>
         <Chrome>| console.redhat.com</Chrome>
     </title>
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <base href="/">

--- a/src/pug/templates/head-block.pug
+++ b/src/pug/templates/head-block.pug
@@ -1,3 +1,5 @@
+meta(http-equiv="Pragma" content="no-cache")
+meta(http-equiv="cache-control" content="no-cache, no-store, must-revalidate")
 meta(http-equiv="x-ua-compatible" content="ie=edge")
 meta(name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no")
 meta(meta name="google-site-verification" content="HR3Hh5U0b2Fevl_JnxOG8wExAVjrnOR810epP5_1QHs")


### PR DESCRIPTION
This change should force every browser not to cache the index.html files. We currently don't have cache issues with this, but it can be useful in the future.