### PR TITLE
Disable pendo badge hiding.

### DIFF
--- a/src/js/App/RootApp/ScalprumRoot.js
+++ b/src/js/App/RootApp/ScalprumRoot.js
@@ -95,8 +95,8 @@ const ScalprumRoot = ({ config, ...props }) => {
   }, []);
 
   useEffect(() => {
-    const body = document.getElementsByTagName('body')[0];
-    activeQuickStartID !== '' ? body.classList.add('quickstarts-open') : body.classList.remove('quickstarts-open');
+    // const body = document.getElementsByTagName('body')[0];
+    // activeQuickStartID !== '' ? body.classList.add('quickstarts-open') : body.classList.remove('quickstarts-open');
   }, [activeQuickStartID]);
 
   return (


### PR DESCRIPTION
We have found a bug with the hiding. If there is a in-progress quickstart, it still has the active ID, even though the drawer is closed and it causes the pendo badge to be hidden forever.

Disabling it for now until we have a 100% bug free solution to hide the badge.

cc @arivepr 