### PR TITLE
Preserve chrome 1 root element in DOM.

### DIFF
--- a/src/js/App/Routes/ChromeRoute.js
+++ b/src/js/App/Routes/ChromeRoute.js
@@ -25,8 +25,9 @@ const ChromeRoute = ({ scope, module, insightsContentRef, dynamic, ...props }) =
   }, [scope]);
 
   useEffect(() => {
+    let contentElement;
     if (dynamic === false) {
-      const contentElement = document.getElementById('root');
+      contentElement = document.getElementById('root');
       if (contentElement && insightsContentRef) {
         insightsContentRef.current.appendChild(contentElement);
         contentElement.hidden = false;
@@ -39,6 +40,13 @@ const ChromeRoute = ({ scope, module, insightsContentRef, dynamic, ...props }) =
        * Reset global filter when switching application
        */
       dispatch(toggleGlobalFilter(false));
+      /**
+       * We need to preserve the chrome 1 element in case the route is destroyed re-created.
+       */
+      if (dynamic === false && contentElement) {
+        document.body.appendChild(contentElement);
+        insightsContentRef.current.id = 'root';
+      }
     };
   }, []);
 


### PR DESCRIPTION
Fixes ansible hub UI not rendering in production.

### Changes
- preserve the chrome 1 root element on route unmount

This one was quite fun to find. The cause of the issue is this line: https://github.com/RedHatInsights/insights-chrome/blob/master/src/js/App/RootApp/ScalprumRoot.js#L34. Not because `Quickstarts` would for some reason delete specific DOM elements, but because we mutate VirtualDOM by chancing the component from `Fragment` to the `QuickStartContainer`.

Here is the scenario.

1. Chrome is initialized
2. Chrome 1 app (hub UI) is mounted into the `<main id="root"></main>` element.
3. Chrome identifies the current route as chrome 1 route and moves the `#root` element to a new container, which is a child in a `ChromeRoute` within VirtualDOM
4. Quickstarts are initialized and a parent component of the `ChromeRoute` is changed from `Fragment` to `QuickStartContainer`. That fill force the `ChromeRoute` unmount and new initialization. The `#root` element ins now a part of the VirtualDOM, which is re-created, affecting the actual DOM, thus deleting the original `#root` element, because it is not supposed to exist in the VirtualDOM tree
5. Nothing is rendered

cc @himdel
