### PR TITLE
Menu styling fix

### DIFF
--- a/src/js/App/Sidenav/Navigation/Navigation.scss
+++ b/src/js/App/Sidenav/Navigation/Navigation.scss
@@ -55,7 +55,6 @@
       }
     }
     .pf-c-nav__item.ins-c-navigation__additional-links {
-      border: none !important;
       .pf-c-nav__link {
         padding-left: var(--pf-global--spacer--lg);
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-17467

Add border above "Additional Links" items at the end of each section

Ansible dashboard (bef)

![Screen Shot 2022-01-07 at 11 25 51 AM](https://user-images.githubusercontent.com/1287144/148574528-cfebfdad-65e1-4d57-a43f-5d058619e375.png)

Ansible dashboard (after)
![Screen Shot 2022-01-07 at 11 25 16 AM](https://user-images.githubusercontent.com/1287144/148574526-9e57d323-12ea-4644-812b-9b4bd9caed99.png)
