### PR TITLE
Enable browser document title updates via CSC

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>
-        <Chrome>| console.redhat.com</Chrome>
+        <Chrome>console.redhat.com</Chrome>
     </title>
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">

--- a/src/js/App/Routes/ChromeRoute.js
+++ b/src/js/App/Routes/ChromeRoute.js
@@ -3,8 +3,8 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 import LoadingFallback from '../../utils/loading-fallback';
-import { useDispatch, useSelector } from 'react-redux';
-import { changeActiveModule, toggleGlobalFilter } from '../../redux/actions';
+import { useDispatch, useSelector, batch } from 'react-redux';
+import { changeActiveModule, toggleGlobalFilter, updateDocumentTitle } from '../../redux/actions';
 import ErrorComponent from '../ErrorComponent/ErrorComponent';
 import { getPendoConf } from '../../analytics';
 import classNames from 'classnames';
@@ -13,7 +13,14 @@ const ChromeRoute = ({ scope, module, insightsContentRef, dynamic, scopeClass, .
   const dispatch = useDispatch();
   const user = useSelector(({ chrome: { user } }) => user);
   useEffect(() => {
-    dispatch(changeActiveModule(scope));
+    batch(() => {
+      dispatch(changeActiveModule(scope));
+      /**
+       * Default document title update. If application won't update its title chrome sets a title using module scope
+       * TODO: add required module config to CSC set fallback document title
+       */
+      dispatch(updateDocumentTitle(scope));
+    });
     /**
      * update pendo metadata on application change
      */

--- a/src/js/App/Routes/ChromeRoute.js
+++ b/src/js/App/Routes/ChromeRoute.js
@@ -18,7 +18,7 @@ const ChromeRoute = ({ scope, module, insightsContentRef, dynamic, scopeClass, .
      * update pendo metadata on application change
      */
     try {
-      window.pendo.updateOptions(getPendoConf(user));
+      window?.pendo?.updateOptions(getPendoConf(user));
     } catch (error) {
       console.error('Unable to update pendo options');
       console.error(error);

--- a/src/js/App/Routes/ChromeRoute.js
+++ b/src/js/App/Routes/ChromeRoute.js
@@ -12,14 +12,17 @@ import classNames from 'classnames';
 const ChromeRoute = ({ scope, module, insightsContentRef, dynamic, scopeClass, ...props }) => {
   const dispatch = useDispatch();
   const user = useSelector(({ chrome: { user } }) => user);
+  /**
+   * If default title was not set, use module scope (appId)
+   */
+  const defaultTitle = useSelector(({ chrome: { modules } }) => modules?.[scope]?.defaultDocumentTitle || scope);
   useEffect(() => {
     batch(() => {
       dispatch(changeActiveModule(scope));
       /**
-       * Default document title update. If application won't update its title chrome sets a title using module scope
-       * TODO: add required module config to CSC set fallback document title
+       * Default document title update. If application won't update its title chrome sets a title using module config
        */
-      dispatch(updateDocumentTitle(scope));
+      dispatch(updateDocumentTitle(defaultTitle));
     });
     /**
      * update pendo metadata on application change

--- a/src/js/chrome/render-chrome.js
+++ b/src/js/chrome/render-chrome.js
@@ -28,7 +28,9 @@ window.insights.experimental.loadRemediations = () => {
 const App = () => {
   const modules = useSelector(({ chrome }) => chrome?.modules);
   const scalprumConfig = useSelector(({ chrome }) => chrome?.scalprumConfig);
+  const documentTitle = useSelector(({ chrome }) => chrome?.documentTitle);
   const dispatch = useDispatch();
+
   useEffect(() => {
     axios
       .get(`${window.location.origin}${isBeta() ? '/beta' : ''}/config/chrome/fed-modules.json?ts=${Date.now()}`, {
@@ -42,6 +44,14 @@ const App = () => {
         dispatch(loadModuesSchema(response.data));
       });
   }, []);
+
+  useEffect(() => {
+    if (typeof documentTitle === 'string') {
+      document.title = `${documentTitle} | console.redhat.com`;
+    } else {
+      document.title = `console.redhat.com`;
+    }
+  }, [documentTitle]);
 
   if (!modules || !scalprumConfig) {
     return null;

--- a/src/js/redux/action-types.js
+++ b/src/js/redux/action-types.js
@@ -26,6 +26,7 @@ export const SET_PENDO_FEEDBACK_FLAG = '@@chrome/set-pendo-feedback-flag';
 export const TOGGLE_FEEDBACK_MODAL = '@@chrome/toggle-feedback-modal';
 export const UPDATE_ACCESS_REQUESTS_NOTIFICATIONS = '@@chrome/update-access-requests-notifications';
 export const MARK_REQUEST_NOTIFICATION_SEEN = '@@chrome/mark-request-notification-seen';
+export const UPDATE_DOCUMENT_TITLE_REDUCER = '@@chrome/update-document-title';
 
 export const STORE_INITIAL_HASH = '@@chrome/store-initial-hash';
 

--- a/src/js/redux/actions.js
+++ b/src/js/redux/actions.js
@@ -156,3 +156,8 @@ export const populateQuickstartsCatalog = (app, quickstarts) => ({
 export const disableQuickstarts = () => ({
   type: actionTypes.DISABLE_QUICKSTARTS,
 });
+
+export const updateDocumentTitle = (title) => ({
+  type: actionTypes.UPDATE_DOCUMENT_TITLE_REDUCER,
+  payload: title,
+});

--- a/src/js/redux/index.js
+++ b/src/js/redux/index.js
@@ -18,6 +18,7 @@ import {
   storeInitialHashReducer,
   populateQuickstartsReducer,
   disableQuickstartsReducer,
+  documentTitleReducer,
 } from './reducers';
 import {
   onGetAllTags,
@@ -57,6 +58,7 @@ import {
   STORE_INITIAL_HASH,
   POPULATE_QUICKSTARTS_CATALOG,
   DISABLE_QUICKSTARTS,
+  UPDATE_DOCUMENT_TITLE_REDUCER,
 } from './action-types';
 
 const reducers = {
@@ -77,6 +79,7 @@ const reducers = {
   [STORE_INITIAL_HASH]: storeInitialHashReducer,
   [POPULATE_QUICKSTARTS_CATALOG]: populateQuickstartsReducer,
   [DISABLE_QUICKSTARTS]: disableQuickstartsReducer,
+  [UPDATE_DOCUMENT_TITLE_REDUCER]: documentTitleReducer,
 };
 
 const globalFilter = {

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -194,3 +194,10 @@ export function disableQuickstartsReducer(state) {
     },
   };
 }
+
+export function documentTitleReducer(state, { payload }) {
+  return {
+    ...state,
+    documentTitle: payload,
+  };
+}


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-17548

In order to enable single HTML, we must provide the document title configuration to apps. The app will use the current title from their HTML template to CSC. Any additional runtime changes to the document title stay the same.

Chrome will also update the title to module id (`appId`) if no configuration exists.