### PR TITLE
Update fonts and image assets build config.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -75,28 +75,12 @@ const commonConfig = ({ dev, publicPath = '/', noHash }) => ({
         ],
       },
       {
-        test: /\.(jpg|png|svg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: '../assets/images/',
-            },
-          },
-        ],
+        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        type: 'asset/resource',
       },
       {
-        test: /\.(woff(2)?|ttf|jpg|eot)(\?v=\d+\.\d+\.\d+)?$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: '../assets/fonts/',
-            },
-          },
-        ],
+        test: /\.(woff|woff2|eot|ttf|otf)$/i,
+        type: 'asset/resource',
       },
     ],
   },


### PR DESCRIPTION
Used new asset management webpack config: https://webpack.js.org/guides/asset-management/#loading-fonts

FIxes an issue with corrupted fonts error in browsers:
```
downloadable font: rejected by sanitizer (font-family: "RedHatText" style:normal weight:400 stretch:100 src index:0) source: https://console.stage.redhat.com/beta/apps/chrome/js/0a577b1f79123323ff3c.woff2
```
I was able to reproduce and fix the issue locally using the Firefox browser. Hopefully, it will fix the deployed versions as well.
