### PR TITLE
Render feedback button in a portal

### DIFF
--- a/src/js/App/Feedback/Feedback.scss
+++ b/src/js/App/Feedback/Feedback.scss
@@ -1,4 +1,4 @@
-.chr-c-button-feedback {
+button.chr-c-button-feedback {
   svg { margin-right: var(--pf-global--spacer--sm); }
   position: fixed;
   z-index: 19000;

--- a/src/js/App/Header/Header.js
+++ b/src/js/App/Header/Header.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Tools from './Tools';
 import UnAuthtedHeader from './UnAuthtedHeader';
@@ -35,7 +36,7 @@ export const Header = () => {
         </MastheadBrand>
       </MastheadMain>
       <MastheadContent>
-        {user && <FeedbackRoute user={user} />}
+        {user && ReactDOM.createPortal(<FeedbackRoute user={user} />, document.body)}
         <Toolbar isFullHeight>
           <ToolbarContent>
             <ToolbarGroup variant="filter-group">


### PR DESCRIPTION
Made feedback button render in a ReactDOM portal to prevent it from interrupting in DOM. It caused unwanted rendering in the top navbar in some apps (eg. Registration) - see image before.

Before:
![beforefeedback](https://user-images.githubusercontent.com/50696716/154440936-476fd95e-aa3a-498f-85c7-654565fbd327.png)

Now:
![afterfeedback](https://user-images.githubusercontent.com/50696716/154440954-b0ef9158-48d5-4064-a0fd-2332a953d785.png)

cc @Hyperkid123 