### PR TITLE
Fix missing quickstarts state object.

### DIFF
--- a/src/js/App/QuickStart/useQuickstartsStates.js
+++ b/src/js/App/QuickStart/useQuickstartsStates.js
@@ -7,7 +7,7 @@ import { getEnv } from '../../utils';
 const isStage = getEnv() === 'stage';
 
 const statePersistor = isStage ? useState : useLocalStorage;
-const initiStatesArgs = isStage ? ['insights-quickstarts', {}] : [{}];
+const initiStatesArgs = ['insights-quickstarts', {}];
 const initialIdArgs = isStage ? ['', ''] : [undefined];
 
 const useQuickstartsStates = () => {


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-18159

In non-stage environment, the quickstarts state object is not initialized properly and can cause a runtime crash when opening the quickstart drawer.