### PR TITLE
Update AAP filter usage

### DIFF
--- a/src/js/App/GlobalFilter/tagsApi.js
+++ b/src/js/App/GlobalFilter/tagsApi.js
@@ -28,12 +28,7 @@ const buildFilter = (workloads, SID) => ({
     ...(workloads?.SAP?.isSelected && { sap_system: true }),
     // enable once AAP filter is enabled
     ...(workloads?.[AAP_KEY]?.isSelected && {
-      ansible: {
-        controller_version: 'not_nil',
-        hub_version: 'not_nil',
-        catalog_worker_version: 'not_nil',
-        sso_version: 'not_nil',
-      },
+      ansible: 'not_nil',
     }),
     ...(workloads?.[MSSQL_KEY]?.isSelected && {
       mssql: { version: 'not_nil' },


### PR DESCRIPTION
The current AAP filter does not work, as it will only fetch hosts which have _all_ of ansible's child fields populated
On the API side, we're adding the ability to filter on whether a parent field has any child field with a value. This PR should not be merged until the API change is ready.

[This PR](https://github.com/RedHatInsights/insights-inventory-frontend/pull/1502) updates the implementation on the HBI front-end.