### PR TITLE
Enable wss connection in CSP header

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <title>
         <Chrome>console.redhat.com</Chrome>
     </title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: data: 'unsafe-inline' 'unsafe-eval' https://*.redhat.com/ https://www.redhat.com  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com https://www.redhat.com https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: wss: data: 'unsafe-inline' 'unsafe-eval' https://*.redhat.com/ https://www.redhat.com  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com https://www.redhat.com https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com;">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/src/pug/templates/head-block.pug
+++ b/src/pug/templates/head-block.pug
@@ -1,4 +1,4 @@
-meta(http-equiv="Content-Security-Policy" content="default-src 'self' https: data: 'unsafe-inline' 'unsafe-eval' https://*.redhat.com/ https://www.redhat.com  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com https://www.redhat.com https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com;")
+meta(http-equiv="Content-Security-Policy" content="default-src 'self' https: wss: data: 'unsafe-inline' 'unsafe-eval' https://*.redhat.com/ https://www.redhat.com  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com https://www.redhat.com https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com;")
 meta(http-equiv="Pragma" content="no-cache")
 meta(http-equiv="cache-control" content="no-cache, no-store, must-revalidate")
 meta(http-equiv="x-ua-compatible" content="ie=edge")


### PR DESCRIPTION
### HAC needs to connect to Websockets

Since HAC app requires some connection to websockets we have to enable them in CSP header. This PR does that by adding it next to `https:`.