### PR TITLE
Remove nav onLinkClick callback with missing event.

### DIFF
--- a/src/js/App/Sidenav/Navigation/ChromeLink.js
+++ b/src/js/App/Sidenav/Navigation/ChromeLink.js
@@ -65,7 +65,6 @@ const LinkWrapper = ({ href, isBeta, onLinkClick, className, currAppId, appId, c
      * Add reference to the DOM link element
      */
     domEvent.target = linkRef.current;
-    onLinkClick?.();
     dispatch(appNavClick({ id: actionId }, domEvent));
   };
 

--- a/src/js/App/Sidenav/Navigation/ChromeLink.test.js
+++ b/src/js/App/Sidenav/Navigation/ChromeLink.test.js
@@ -146,7 +146,7 @@ describe('ChromeLink', () => {
     ]);
   });
 
-  test('should trigger onLinkClick callback only once', () => {
+  test('should not trigger onLinkClick callback', () => {
     const onLinkClickSpy = jest.fn();
     const store = mockStore({
       chrome: {
@@ -173,7 +173,7 @@ describe('ChromeLink', () => {
       fireEvent.click(buttton);
     });
 
-    expect(onLinkClickSpy).toHaveBeenCalledTimes(1);
+    expect(onLinkClickSpy).toHaveBeenCalledTimes(0);
   });
 
   test('should trigger onLinkClick callback', () => {


### PR DESCRIPTION
@fhlavac this reverts this change: https://github.com/RedHatInsights/insights-chrome/commit/7933ed10f5f52ff604401ced90786c31217b84d8#diff-fe9c5907429f899a0761986650c98336b83a3574a08786ca133c1b1cc7df585aR68

It was breaking the nav in non-beta envs. Can you please take another look at the related jira issue?