### PR TITLE
Allow multiple emails to check for visibility

### DIFF
--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -80,12 +80,12 @@ export const visibilityFunctions = {
   isProd: () => insights.chrome.isProd,
   isBeta: () => insights.chrome.isBeta(),
   isHidden: () => true,
-  withEmail: async (toHave) => {
+  withEmail: async (...toHave) => {
     const data = await insights.chrome.auth.getUser();
     const {
       identity: { user },
     } = data || {};
-    return user?.email?.includes(toHave);
+    return toHave?.some((item) => user?.email?.includes(item));
   },
   loosePermissions: (permissions) => checkPermissions(permissions, 'some'),
   hasPermissions: checkPermissions,


### PR DESCRIPTION
### Multiple emails

There's a request from edge team to check if user has at least one if the emails proveded trough the visibility function. The config already has the change https://github.com/RedHatInsights/cloud-services-config/pull/1061 we just have to check if any given email is included in the user's email address.