### PR TITLE
Add quickstarts HelpTopic provider component.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@data-driven-forms/pf4-component-mapper": "^3.12.0",
         "@data-driven-forms/react-form-renderer": "^3.12.0",
         "@patternfly/patternfly": "^4.164.2",
-        "@patternfly/quickstarts": "2.1.0",
+        "@patternfly/quickstarts": "2.2.0",
         "@patternfly/react-core": "^4.181.1",
         "@patternfly/react-icons": "^4.32.1",
         "@patternfly/react-table": "^4.50.1",
@@ -2978,9 +2978,9 @@
       "integrity": "sha512-gezQi83JKd6tW0z1J6Q5VvMCW/a58+ys4TWcTuXUMqcV3APQdNxVP+ZV6FIv5353oIPi9HuWAaApVwcCxYZYYg=="
     },
     "node_modules/@patternfly/quickstarts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-2.1.0.tgz",
-      "integrity": "sha512-vyiZ+zenJ72C9/lNYtHcKa3m7bBE5iTeIdPBKo2R5GLk0vKp+2nhXn31v4txetx0+/SsB2/ZOdDTpCJav7T8WQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-2.2.0.tgz",
+      "integrity": "sha512-W2FtTKAkSL2FWLe7Tip2pkGtl34Ch7aQRMZZtEEJE7HHkbZxSKuXfvmz2e0tGfc9SR/vbVpS7SkU5GlkyYfHZw==",
       "dependencies": {
         "@patternfly/react-catalog-view-extension": "4.12.15",
         "dompurify": "^2.2.6",
@@ -23807,9 +23807,9 @@
       "integrity": "sha512-gezQi83JKd6tW0z1J6Q5VvMCW/a58+ys4TWcTuXUMqcV3APQdNxVP+ZV6FIv5353oIPi9HuWAaApVwcCxYZYYg=="
     },
     "@patternfly/quickstarts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-2.1.0.tgz",
-      "integrity": "sha512-vyiZ+zenJ72C9/lNYtHcKa3m7bBE5iTeIdPBKo2R5GLk0vKp+2nhXn31v4txetx0+/SsB2/ZOdDTpCJav7T8WQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-2.2.0.tgz",
+      "integrity": "sha512-W2FtTKAkSL2FWLe7Tip2pkGtl34Ch7aQRMZZtEEJE7HHkbZxSKuXfvmz2e0tGfc9SR/vbVpS7SkU5GlkyYfHZw==",
       "requires": {
         "@patternfly/react-catalog-view-extension": "4.12.15",
         "dompurify": "^2.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.15",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^7.0.2",
+        "@types/jest": "^27.4.1",
         "@types/react-router-dom": "^5.3.3",
         "@typescript-eslint/eslint-plugin": "^5.13.0",
         "@typescript-eslint/parser": "^5.13.0",
@@ -4441,6 +4442,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "27.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "dev": true,
+      "dependencies": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -25011,6 +25022,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "27.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "dev": true,
+      "requires": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.15",
     "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^7.0.2",
+    "@types/jest": "^27.4.1",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@data-driven-forms/pf4-component-mapper": "^3.12.0",
     "@data-driven-forms/react-form-renderer": "^3.12.0",
     "@patternfly/patternfly": "^4.164.2",
-    "@patternfly/quickstarts": "2.1.0",
+    "@patternfly/quickstarts": "2.2.0",
     "@patternfly/react-core": "^4.181.1",
     "@patternfly/react-icons": "^4.32.1",
     "@patternfly/react-table": "^4.50.1",

--- a/src/js/App/QuickStart/HelpTopicProvider.tsx
+++ b/src/js/App/QuickStart/HelpTopicProvider.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { HelpTopicContainer, HelpTopicContainerProps } from '@patternfly/quickstarts';
+
+import dataMock from './helpTopicDataMock.json';
+
+const HelpTopicProvider: React.FC = ({ children }) => {
+  const inContextHelpProps: HelpTopicContainerProps = {
+    helpTopics: dataMock,
+    loading: false,
+  };
+  return <HelpTopicContainer {...inContextHelpProps}>{children}</HelpTopicContainer>;
+};
+
+export default HelpTopicProvider;

--- a/src/js/App/QuickStart/HelpTopicProvider.tsx
+++ b/src/js/App/QuickStart/HelpTopicProvider.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { HelpTopicContainer, HelpTopicContainerProps } from '@patternfly/quickstarts';
+import { HelpTopic, HelpTopicContainer, HelpTopicContainerProps } from '@patternfly/quickstarts';
 
-import dataMock from './helpTopicDataMock.json';
+interface HelpTopicProviderProps {
+  helpTopics: HelpTopic[];
+}
 
-const HelpTopicProvider: React.FC = ({ children }) => {
+const HelpTopicProvider: React.FC<HelpTopicProviderProps> = ({ children, helpTopics }) => {
   const inContextHelpProps: HelpTopicContainerProps = {
-    helpTopics: dataMock,
+    helpTopics,
     loading: false,
   };
   return <HelpTopicContainer {...inContextHelpProps}>{children}</HelpTopicContainer>;

--- a/src/js/App/QuickStart/helpTopicDataMock.json
+++ b/src/js/App/QuickStart/helpTopicDataMock.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "chrome-data-mock",
+    "name": "chrome-data-mock-1",
     "tags": [
       "page-1"
     ],
@@ -12,7 +12,7 @@
     ]
   },
   {
-    "name": "workspace",
+    "name": "chrome-data-mock-2",
     "tags": [
       "page-1",
       "page-2",

--- a/src/js/App/QuickStart/helpTopicDataMock.json
+++ b/src/js/App/QuickStart/helpTopicDataMock.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "chrome-data-mock",
+    "tags": [
+      "page-1"
+    ],
+    "title": "Automatic Deployment",
+    "content": "**An Automatic Deployment** is...\n\nEtiam viverra et tortor et maximus. Aliquam quis scelerisque metus. Proin luctus pretium sodales. Mauris nibh nibh, auctor eu scelerisque et, hendrerit a metus. Vivamus pharetra bibendum finibus. Sed a pulvinar ipsum. Fusce pharetra venenatis porttitor. Praesent justo metus, consectetur quis erat id, congue varius metus. Suspendisse dui est, tempor nec diam quis, facilisis sodales erat. Curabitur viverra convallis ex. Ut egestas condimentum augue, id euismod leo volutpat vitae. Quisque aliquet ac dolor quis pretium. Nunc at nibh quis arcu maximus elementum vel a mi.",
+    "links": [
+      "[Creating quick starts](https://docs.openshift.com/container-platform/4.9/web_console/creating-quick-start-tutorials.html)",
+      "[Redhat Console](https://console.redhat.com/)"
+    ]
+  },
+  {
+    "name": "workspace",
+    "tags": [
+      "page-1",
+      "page-2",
+      "page-3"
+    ],
+    "title": "Workspace",
+    "content": "**A Workspace** is...\n\nFusce nunc risus, vehicula feugiat pellentesque sit amet, pretium non urna. Phasellus nibh mi, ornare quis euismod a, iaculis et eros. Vivamus auctor nunc odio, quis porttitor diam pellentesque nec. In et varius tellus, eget porta urna. Etiam bibendum, est eget mollis lobortis, velit risus efficitur lacus, sed pulvinar sem est vel libero. In sodales placerat tincidunt. Proin vitae risus elit. Ut lobortis ligula est, cursus rhoncus enim scelerisque ac. Donec lacus nisl, tempor porta hendrerit nec, volutpat vitae arcu. Curabitur ornare ullamcorper mi in tincidunt. Aenean efficitur posuere auctor. Pellentesque accumsan mauris vel arcu congue, nec sagittis nisl condimentum. Suspendisse mauris nulla, dignissim at viverra sed, fringilla eu purus.",
+    "links": [
+      "[Creating quick starts](https://docs.openshift.com/container-platform/4.9/web_console/creating-quick-start-tutorials.html)",
+      "[Redhat Console](https://console.redhat.com/)"
+    ]
+  }
+]

--- a/src/js/App/QuickStart/useHelpTopicState.test.ts
+++ b/src/js/App/QuickStart/useHelpTopicState.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import helpTopicDataMock from './helpTopicDataMock.json';
+import useHelpTopicState from './useHelpTopicState';
+
+describe('useHelpTopicState', () => {
+  test('should initialize with help topics', () => {
+    const { result } = renderHook(() => useHelpTopicState(...helpTopicDataMock));
+
+    expect(result.current.helpTopics).toEqual(helpTopicDataMock);
+  });
+
+  test('should add one new topic that is not in the array', () => {
+    const { result } = renderHook(() => useHelpTopicState());
+
+    act(() => {
+      result.current.updateHelpTopics(helpTopicDataMock[0]);
+    });
+
+    expect(result.current.helpTopics).toEqual([helpTopicDataMock[0]]);
+  });
+
+  test('should add two new topics that is not in the array', () => {
+    const { result } = renderHook(() => useHelpTopicState());
+
+    act(() => {
+      result.current.updateHelpTopics(...helpTopicDataMock);
+    });
+
+    expect(result.current.helpTopics).toEqual(helpTopicDataMock);
+  });
+
+  test('should update existing telp topic based on name', () => {
+    const { result } = renderHook(() => useHelpTopicState(...helpTopicDataMock));
+
+    expect(result.current.helpTopics).toEqual(helpTopicDataMock);
+
+    act(() => {
+      result.current.updateHelpTopics({ ...helpTopicDataMock[0], title: 'Foo' });
+    });
+
+    expect(result.current.helpTopics[0].title).toEqual('Foo');
+    expect(result.current.helpTopics[1]).toEqual(helpTopicDataMock[1]);
+    expect(result.current.helpTopics).toHaveLength(2);
+  });
+
+  test('should update existing topic and add a new topic', () => {
+    const { result } = renderHook(() => useHelpTopicState(...helpTopicDataMock));
+
+    expect(result.current.helpTopics).toEqual(helpTopicDataMock);
+
+    act(() => {
+      result.current.updateHelpTopics({ ...helpTopicDataMock[0], title: 'Foo' }, { ...helpTopicDataMock[1], name: 'New Topic' });
+    });
+
+    expect(result.current.helpTopics[0].title).toEqual('Foo');
+    expect(result.current.helpTopics).toHaveLength(3);
+  });
+});

--- a/src/js/App/QuickStart/useHelpTopicState.ts
+++ b/src/js/App/QuickStart/useHelpTopicState.ts
@@ -1,0 +1,26 @@
+import { HelpTopic } from '@patternfly/quickstarts';
+import { useState } from 'react';
+
+const useHelpTopicState = (...topics: HelpTopic[]) => {
+  const [helpTopics, setHelpTopics] = useState<HelpTopic[]>(topics);
+
+  function updateHelpTopics(...topics: HelpTopic[]) {
+    setHelpTopics((prev) => {
+      /** Add or update new topics based on topics name */
+      return topics.reduce((acc, curr) => {
+        const topicIndex = acc.findIndex(({ name }) => name === curr.name);
+        if (topicIndex > -1) {
+          return [...acc.slice(0, topicIndex), curr, ...acc.slice(topicIndex + 1)];
+        }
+        return [...acc, curr];
+      }, prev);
+    });
+  }
+
+  return {
+    helpTopics,
+    updateHelpTopics,
+  };
+};
+
+export default useHelpTopicState;

--- a/src/js/App/RootApp/ScalprumRoot.js
+++ b/src/js/App/RootApp/ScalprumRoot.js
@@ -15,6 +15,7 @@ import historyListener from '../../utils/historyListener';
 import { isFedRamp } from '../../utils';
 import useQuickstartsStates from '../QuickStart/useQuickstartsStates';
 import HelpTopicProvider from '../QuickStart/HelpTopicProvider';
+import useHelpTopicState from '../QuickStart/useHelpTopicState';
 
 const Navigation = lazy(() => import('../Sidenav/Navigation'));
 const LandingNav = lazy(() => import('../Sidenav/LandingNav'));
@@ -43,6 +44,7 @@ QSWrapper.propTypes = {
 const ScalprumRoot = ({ config, ...props }) => {
   const history = useHistory();
   const { allQuickStartStates, setAllQuickStartStates, activeQuickStartID, setActiveQuickStartID } = useQuickstartsStates();
+  const { helpTopics, updateHelpTopics } = useHelpTopicState();
   const globalFilterRemoved = useSelector(({ globalFilter: { globalFilterRemoved } }) => globalFilterRemoved);
   const dispatch = useDispatch();
   const [quickstartsLoaded, setQuickstarsLoaded] = useState(false);
@@ -104,7 +106,7 @@ const ScalprumRoot = ({ config, ...props }) => {
      * - add deprecation warning to the window functions
      */
     <QSWrapper quickstartsLoaded={quickstartsLoaded} className="pf-u-h-100vh" {...quickStartProps}>
-      <HelpTopicProvider>
+      <HelpTopicProvider helpTopics={helpTopics}>
         <ScalprumProvider
           config={config}
           api={{
@@ -119,6 +121,9 @@ const ScalprumRoot = ({ config, ...props }) => {
                 set: updateQuickStarts,
                 toggle: setActiveQuickStartID,
                 Catalog: LazyQuickStartCatalog,
+              },
+              helpTopics: {
+                updateHelpTopics,
               },
               chromeHistory: history,
             },

--- a/src/js/App/RootApp/ScalprumRoot.js
+++ b/src/js/App/RootApp/ScalprumRoot.js
@@ -14,6 +14,7 @@ import { disableQuickstarts, populateQuickstartsCatalog, toggleFeedbackModal } f
 import historyListener from '../../utils/historyListener';
 import { isFedRamp } from '../../utils';
 import useQuickstartsStates from '../QuickStart/useQuickstartsStates';
+import HelpTopicProvider from '../QuickStart/HelpTopicProvider';
 
 const Navigation = lazy(() => import('../Sidenav/Navigation'));
 const LandingNav = lazy(() => import('../Sidenav/LandingNav'));
@@ -95,11 +96,6 @@ const ScalprumRoot = ({ config, ...props }) => {
     };
   }, []);
 
-  useEffect(() => {
-    // const body = document.getElementsByTagName('body')[0];
-    // activeQuickStartID !== '' ? body.classList.add('quickstarts-open') : body.classList.remove('quickstarts-open');
-  }, [activeQuickStartID]);
-
   return (
     /**
      * Once all applications are migrated to chrome 2:
@@ -108,37 +104,39 @@ const ScalprumRoot = ({ config, ...props }) => {
      * - add deprecation warning to the window functions
      */
     <QSWrapper quickstartsLoaded={quickstartsLoaded} className="pf-u-h-100vh" {...quickStartProps}>
-      <ScalprumProvider
-        config={config}
-        api={{
-          chrome: {
-            experimentalApi: true,
-            ...window.insights.chrome,
-            isFedramp: isFedRamp(),
-            usePendoFeedback,
-            toggleFeedbackModal: (...args) => dispatch(toggleFeedbackModal(...args)),
-            quickStarts: {
-              version: 1,
-              set: updateQuickStarts,
-              toggle: setActiveQuickStartID,
-              Catalog: LazyQuickStartCatalog,
+      <HelpTopicProvider>
+        <ScalprumProvider
+          config={config}
+          api={{
+            chrome: {
+              experimentalApi: true,
+              ...window.insights.chrome,
+              isFedramp: isFedRamp(),
+              usePendoFeedback,
+              toggleFeedbackModal: (...args) => dispatch(toggleFeedbackModal(...args)),
+              quickStarts: {
+                version: 1,
+                set: updateQuickStarts,
+                toggle: setActiveQuickStartID,
+                Catalog: LazyQuickStartCatalog,
+              },
+              chromeHistory: history,
             },
-            chromeHistory: history,
-          },
-        }}
-      >
-        <Switch>
-          <Route exact path="/">
-            <DefaultLayout Sidebar={loaderWrapper(LandingNav)} {...props} globalFilterRemoved={globalFilterRemoved} />
-          </Route>
-          <Route path="/security">
-            <DefaultLayout {...props} globalFilterRemoved={globalFilterRemoved} />
-          </Route>
-          <Route>
-            <DefaultLayout Sidebar={loaderWrapper(Navigation)} {...props} globalFilterRemoved={globalFilterRemoved} />
-          </Route>
-        </Switch>
-      </ScalprumProvider>
+          }}
+        >
+          <Switch>
+            <Route exact path="/">
+              <DefaultLayout Sidebar={loaderWrapper(LandingNav)} {...props} globalFilterRemoved={globalFilterRemoved} />
+            </Route>
+            <Route path="/security">
+              <DefaultLayout {...props} globalFilterRemoved={globalFilterRemoved} />
+            </Route>
+            <Route>
+              <DefaultLayout Sidebar={loaderWrapper(Navigation)} {...props} globalFilterRemoved={globalFilterRemoved} />
+            </Route>
+          </Switch>
+        </ScalprumProvider>
+      </HelpTopicProvider>
     </QSWrapper>
   );
 };

--- a/src/js/App/Routes/ChromeRoute.js
+++ b/src/js/App/Routes/ChromeRoute.js
@@ -1,5 +1,5 @@
 import { ScalprumComponent } from '@scalprum/react-core';
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 import LoadingFallback from '../../utils/loading-fallback';
@@ -8,9 +8,11 @@ import { changeActiveModule, toggleGlobalFilter, updateDocumentTitle } from '../
 import ErrorComponent from '../ErrorComponent/ErrorComponent';
 import { getPendoConf } from '../../analytics';
 import classNames from 'classnames';
+import { HelpTopicContext } from '@patternfly/quickstarts';
 
 const ChromeRoute = ({ scope, module, insightsContentRef, dynamic, scopeClass, ...props }) => {
   const dispatch = useDispatch();
+  const { setActiveHelpTopicByName } = useContext(HelpTopicContext);
   const user = useSelector(({ chrome: { user } }) => user);
   /**
    * If default title was not set, use module scope (appId)
@@ -33,6 +35,12 @@ const ChromeRoute = ({ scope, module, insightsContentRef, dynamic, scopeClass, .
       console.error('Unable to update pendo options');
       console.error(error);
     }
+
+    /**
+     * TODO: Discuss default close feature of topics
+     * Topics drawer has no close button, therefore there might be an issue with opened topics after user changes route and does not clear the active topic trough the now non existing elements.
+     */
+    setActiveHelpTopicByName && setActiveHelpTopicByName('');
   }, [scope]);
 
   useEffect(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-18567

### Changes
- Adds the HelpTopic provider to chrome. This will enable consumption of the features through the module federation.
- Expose API to add help topics

### TODO
Once we have the integration with quickstart API (next task) we will change the way the topics are added to the provider. Mostly implement API calls and caching.