### PR TITLE
Add help topics update workaround.

### DIFF
--- a/src/js/App/QuickStart/useHelpTopicState.ts
+++ b/src/js/App/QuickStart/useHelpTopicState.ts
@@ -1,8 +1,14 @@
 import { HelpTopic } from '@patternfly/quickstarts';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 const useHelpTopicState = (...topics: HelpTopic[]) => {
   const [helpTopics, setHelpTopics] = useState<HelpTopic[]>(topics);
+  /**
+   * There is a bug in help topics provider.
+   * It does not update the context after first render.
+   * We use the render count to update the component key and force-reinitialization
+   * */
+  const updates = useRef(0);
 
   function updateHelpTopics(...topics: HelpTopic[]) {
     setHelpTopics((prev) => {
@@ -12,6 +18,7 @@ const useHelpTopicState = (...topics: HelpTopic[]) => {
         if (topicIndex > -1) {
           return [...acc.slice(0, topicIndex), curr, ...acc.slice(topicIndex + 1)];
         }
+        updates.current += 1;
         return [...acc, curr];
       }, prev);
     });
@@ -20,6 +27,7 @@ const useHelpTopicState = (...topics: HelpTopic[]) => {
   return {
     helpTopics,
     updateHelpTopics,
+    updates: updates.current,
   };
 };
 

--- a/src/js/App/RootApp/ScalprumRoot.js
+++ b/src/js/App/RootApp/ScalprumRoot.js
@@ -28,7 +28,7 @@ const loaderWrapper = (Component, props = {}) => (
 const ScalprumRoot = ({ config, ...props }) => {
   const history = useHistory();
   const { allQuickStartStates, setAllQuickStartStates, activeQuickStartID, setActiveQuickStartID } = useQuickstartsStates();
-  const { helpTopics, updateHelpTopics } = useHelpTopicState();
+  const { helpTopics, updateHelpTopics, updates } = useHelpTopicState();
   const globalFilterRemoved = useSelector(({ globalFilter: { globalFilterRemoved } }) => globalFilterRemoved);
   const dispatch = useDispatch();
   const quickStarts = useSelector(
@@ -80,7 +80,7 @@ const ScalprumRoot = ({ config, ...props }) => {
      * - add deprecation warning to the window functions
      */
     <QuickStartContainer className="pf-u-h-100vh" {...quickStartProps}>
-      <HelpTopicProvider helpTopics={helpTopics}>
+      <HelpTopicProvider key={updates.toString()} helpTopics={helpTopics}>
         <ScalprumProvider
           config={config}
           api={{


### PR DESCRIPTION
There is a bug in the help topics provider. If you update the context value after the initial render, the data is ignored. It only stores the topics on first render.

Until it's fixed, we will force re-initialization with the `key` prop.