### PR TITLE
Push chrome history mutation to the end of the queue

### DIFF
--- a/src/js/utils/useNavigation.js
+++ b/src/js/utils/useNavigation.js
@@ -69,13 +69,15 @@ const useNavigation = () => {
           dispatch(loadLeftNavSegment(schema, currentNamespace, prevPathname));
         }
 
-        if (activeQSId.current && shouldPreseverQuickstartSearch(window.location.search, activeQSId.current)) {
-          replace({
-            ...activeLocation.current,
-            pathname: newPathname.replace(/^\/beta\//, '/'),
-            search: appendQSSearch(window.location.search, activeQSId.current),
-          });
-        }
+        setTimeout(() => {
+          if (activeQSId.current && shouldPreseverQuickstartSearch(window.location.search, activeQSId.current)) {
+            replace({
+              ...activeLocation.current,
+              pathname: newPathname.replace(/^\/beta\//, '/'),
+              search: appendQSSearch(window.location.search, activeQSId.current),
+            });
+          }
+        });
       });
     });
   };


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-19050

### Changes
- fix chrome/quickstarts history mutation race condition that causes infinite loops

There is a race condition between chrome history mutations and quickstarts mutations. We have no way of quickly fixing it in quickstarts so we will have to use poor man's solution. We should talk to the QS developers and ask them about adding a callback so we can handle the mutations ourselves (through our history instance).