### PR TITLE
[RHCLOUD-19247] Add new containerized stage callback url

### DIFF
--- a/src/js/jwt/constants.ts
+++ b/src/js/jwt/constants.ts
@@ -22,7 +22,7 @@ export const DEFAULT_ROUTES = {
     portal: 'https://access.redhat.com',
   },
   stage: {
-    url: ['stage.foo.redhat.com', 'cloud.stage.redhat.com', 'console.stage.redhat.com'],
+    url: ['stage.foo.redhat.com', 'cloud.stage.redhat.com', 'console.stage.redhat.com', 'env-stage.apps.crcs02ue1.urby.p1.openshiftapps.com'],
     sso: 'https://sso.stage.redhat.com/auth',
     portal: 'https://access.stage.redhat.com',
   },


### PR DESCRIPTION
Adds the new url for our test stage deployment so we can SSO auth in. I want to make sure this won't break anything, but will only allow this url to get around the `invalid_uri redirect` issue. There is an entry in stage.sso for this url as well. 