### PR TITLE
[POC] WS browser events

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <title>
         console.redhat.com
     </title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: wss: data: 'unsafe-inline' 'unsafe-eval' https://*.redhat.com/ https://www.redhat.com  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com https://www.redhat.com https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: wss: data: 'unsafe-inline' 'unsafe-eval' ws://localhost:8080 https://*.redhat.com/ https://www.redhat.com  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com https://www.redhat.com https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com;">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/src/js/App/Header/Tools.js
+++ b/src/js/App/Header/Tools.js
@@ -4,6 +4,7 @@ import { Badge, Button, Divider, DropdownItem, ToolbarItem, ToolbarGroup, Switch
 import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import RedhatIcon from '@patternfly/react-icons/dist/js/icons/redhat-icon';
+import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import UserToggle from './UserToggle';
 import ToolbarToggle from './ToolbarToggle';
 import HeaderAlert from './HeaderAlert';
@@ -11,6 +12,7 @@ import cookie from 'js-cookie';
 import { getUrl, getSection, isBeta } from '../../utils';
 import { spinUpStore } from '../../redux-config';
 import classnames from 'classnames';
+import { useDispatch } from 'react-redux';
 
 export const switchRelease = (isBeta, pathname) => {
   cookie.set('cs_toggledRelease', 'true');
@@ -81,6 +83,8 @@ const Tools = () => {
     isRhosakEntitled: false,
     isDemoAcc: false,
   });
+
+  const dispatch = useDispatch();
 
   useEffect(() => {
     window.insights.chrome.auth.getUser().then((user) => {
@@ -178,6 +182,11 @@ const Tools = () => {
       spaceItems={{ default: 'spaceItemsNone' }}
       widget-type="InsightsToolbar"
     >
+      <ToolbarItem>
+        <Button onClick={() => dispatch({ type: 'toggle-notifications-drawer' })} variant="plain">
+          <BellIcon />
+        </Button>
+      </ToolbarItem>
       {isBeta() && (
         <ToolbarItem>
           <Badge className="chr-c-badge-beta">beta</Badge>

--- a/src/js/App/Notifications/index.js
+++ b/src/js/App/Notifications/index.js
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelContent,
+  NotificationDrawer,
+  NotificationDrawerBody,
+  NotificationDrawerGroup,
+  NotificationDrawerGroupList,
+  NotificationDrawerHeader,
+  NotificationDrawerList,
+  NotificationDrawerListItem,
+  NotificationDrawerListItemBody,
+  NotificationDrawerListItemHeader,
+} from '@patternfly/react-core';
+import { useDispatch, useSelector } from 'react-redux';
+
+const NotificationsContent = () => {
+  const [isBroadcastExpanded, setBroadcastExpanded] = useState(false);
+  const notifications = useSelector(({ chrome: { notifications } }) => notifications || []);
+  const dispatch = useDispatch();
+  return (
+    <DrawerPanelContent>
+      <NotificationDrawer>
+        <NotificationDrawerHeader customText="Foo bar">
+          <DrawerActions>
+            <DrawerCloseButton onClick={() => dispatch({ type: 'toggle-notifications-drawer' })} />
+          </DrawerActions>
+        </NotificationDrawerHeader>
+        <NotificationDrawerBody>
+          <NotificationDrawerGroupList>
+            <NotificationDrawerGroup onExpand={(_e, value) => setBroadcastExpanded(value)} isExpanded={isBroadcastExpanded} title="Boradcast">
+              <NotificationDrawerList isHidden={!isBroadcastExpanded}>
+                {notifications.map(({ variant = 'info', title, description }, idx) => (
+                  <NotificationDrawerListItem key={idx} variant={variant}>
+                    <NotificationDrawerListItemHeader variant={variant} title={title} />
+                    <NotificationDrawerListItemBody timestamp="Just now">{description}</NotificationDrawerListItemBody>
+                  </NotificationDrawerListItem>
+                ))}
+              </NotificationDrawerList>
+            </NotificationDrawerGroup>
+          </NotificationDrawerGroupList>
+        </NotificationDrawerBody>
+      </NotificationDrawer>
+    </DrawerPanelContent>
+  );
+};
+
+const Notifications = ({ children }) => {
+  const isNotificationsDrawerOpen = useSelector(({ chrome: { isNotificationsDrawerOpen } }) => isNotificationsDrawerOpen);
+  return (
+    <Drawer isExpanded={isNotificationsDrawerOpen}>
+      <DrawerContent panelContent={<NotificationsContent />}>
+        <DrawerContentBody>{children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default Notifications;

--- a/src/js/App/RootApp/DefaultLayout.js
+++ b/src/js/App/RootApp/DefaultLayout.js
@@ -18,6 +18,7 @@ import '../Sidenav/Navigation/Navigation.scss';
 import './DefaultLayout.scss';
 import { CROSS_ACCESS_ACCOUNT_NUMBER } from '../../consts';
 import { getUrl } from '../../utils';
+import Notifications from '../Notifications';
 
 const ShieldedRoot = memo(
   ({ hideNav, insightsContentRef, isGlobalFilterEnabled, initialized, Sidebar }) => {
@@ -85,12 +86,14 @@ const ShieldedRoot = memo(
         }
         sidebar={hideNav ? undefined : <PageSidebar isNavOpen={isNavOpen} id="chr-c-sidebar" nav={Sidebar} />}
       >
-        <div ref={insightsContentRef} className={classnames('chr-render', { 'pf-u-h-100vh': !isGlobalFilterEnabled })}>
-          {isGlobalFilterEnabled && <GlobalFilter />}
-          {selectedAccountNumber && <div className="chr-viewing-as">Viewing as Account {selectedAccountNumber}</div>}
-          <Routes routesProps={{ scopeClass: 'chr-scope__default-layout' }} insightsContentRef={insightsContentRef} />
-          <main className="pf-c-page__main" id="no-access"></main>
-        </div>
+        <Notifications>
+          <div ref={insightsContentRef} className={classnames('chr-render', { 'pf-u-h-100vh': !isGlobalFilterEnabled })}>
+            {isGlobalFilterEnabled && <GlobalFilter />}
+            {selectedAccountNumber && <div className="chr-viewing-as">Viewing as Account {selectedAccountNumber}</div>}
+            <Routes routesProps={{ scopeClass: 'chr-scope__default-layout' }} insightsContentRef={insightsContentRef} />
+            <main className="pf-c-page__main" id="no-access"></main>
+          </div>
+        </Notifications>
       </Page>
     );
   },

--- a/src/js/App/RootApp/RootApp.js
+++ b/src/js/App/RootApp/RootApp.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Router } from 'react-router-dom';
 import { HelpTopicContainer, QuickStartContainer } from '@patternfly/quickstarts';
 
@@ -14,6 +14,10 @@ import { LazyQuickStartCatalog } from '../QuickStart/LazyQuickStartCatalog';
 import useHelpTopicState from '../QuickStart/useHelpTopicState';
 
 const RootApp = (props) => {
+  useEffect(() => {
+    const x = new WebSocket('ws://localhost:8080/ws');
+    x.onmessage = console.log;
+  }, []);
   const { allQuickStartStates, setAllQuickStartStates, activeQuickStartID, setActiveQuickStartID } = useQuickstartsStates();
   const { helpTopics, addHelpTopics, disableTopics, enableTopics } = useHelpTopicState();
   const dispatch = useDispatch();

--- a/src/js/App/RootApp/ScalprumRoot.js
+++ b/src/js/App/RootApp/ScalprumRoot.js
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useContext, useEffect, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { ScalprumProvider } from '@scalprum/react-core';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
@@ -21,7 +21,7 @@ const loaderWrapper = (Component, props = {}) => (
   </Suspense>
 );
 
-const ScalprumRoot = ({ config, helpTopicsAPI, quickstartsAPI, ...props }) => {
+const ScalprumRoot = ({ registerEvent, config, helpTopicsAPI, quickstartsAPI, ...props }) => {
   const { setActiveHelpTopicByName, helpTopics, activeHelpTopic } = useContext(HelpTopicContext);
   const [activeTopicName, setActiveTopicName] = useState();
   const [prevActiveTopic, setPrevActiveTopic] = useState(activeHelpTopic?.name);
@@ -91,6 +91,7 @@ const ScalprumRoot = ({ config, helpTopicsAPI, quickstartsAPI, ...props }) => {
               setActiveTopic('');
             },
           },
+          registerEvent,
           chromeHistory: history,
         },
       }}
@@ -123,6 +124,7 @@ ScalprumRoot.propTypes = {
     toggle: PropTypes.func.isRequired,
     Catalog: PropTypes.elementType.isRequired,
   }).isRequired,
+  registerEvent: PropTypes.func.isRequired,
 };
 
 export default ScalprumRoot;

--- a/src/js/redux/index.js
+++ b/src/js/redux/index.js
@@ -19,6 +19,8 @@ import {
   populateQuickstartsReducer,
   disableQuickstartsReducer,
   documentTitleReducer,
+  notificationsDrawerReducer,
+  addNewNotificationReducer,
 } from './reducers';
 import {
   onGetAllTags,
@@ -80,6 +82,8 @@ const reducers = {
   [POPULATE_QUICKSTARTS_CATALOG]: populateQuickstartsReducer,
   [DISABLE_QUICKSTARTS]: disableQuickstartsReducer,
   [UPDATE_DOCUMENT_TITLE_REDUCER]: documentTitleReducer,
+  'toggle-notifications-drawer': notificationsDrawerReducer,
+  'add-notification': addNewNotificationReducer,
 };
 
 const globalFilter = {
@@ -109,6 +113,7 @@ export default function () {
         quickstarts: {
           quickstarts: {},
         },
+        notifications: [],
       },
       action
     ) => applyReducerHash(reducers)(state, action),

--- a/src/js/redux/reducers.js
+++ b/src/js/redux/reducers.js
@@ -201,3 +201,17 @@ export function documentTitleReducer(state, { payload }) {
     documentTitle: payload,
   };
 }
+
+export function notificationsDrawerReducer(state) {
+  return {
+    ...state,
+    isNotificationsDrawerOpen: !state.isNotificationsDrawerOpen,
+  };
+}
+
+export function addNewNotificationReducer(state, { payload }) {
+  return {
+    ...state,
+    notifications: [...(state.notifications || []), payload],
+  };
+}


### PR DESCRIPTION
### Description

This is a POC of the upcoming dynamic browser events service (web sockets in short)

It adds two main features
1. Notification drawer. That is something we will have to support.
2. Allow application WS listeners registration. This is something that can provide a huge potential

The WS service is not published anywhere yet but it does these things

1. Emit events based on Kafka messages. Currently, it listens on `chrome-events` channel. Tapping into existing channels might be an issue due to frequency and due to the fact that the messages probably do not follow strict structures.
2. Emit events based on a POST request. Just passes along the payload.
3. Emit events based on a client event send from the browser connection.

The WS service has 3 types of granularity setup
1. Broadcast: send message to every client connected
2. Tennant based (org): send message to every connected client in a tenant
3. User ID based: only a user that matches the ID will receive a message

Each message can have multiple targets. Meaning that we can send a message to more than tenants or users or combinations.

Do not take any code seriously it will change. The Notification drawer has a high priority as it is a future requirement.

Let me know your thoughts. You can check this RBAC POC to see advanced caching and data invalidation options: https://github.com/RedHatInsights/insights-rbac-ui/pull/1139.