### PR TITLE
[prod-stable] Cast path to string before checking for AppSRE sentry

### DIFF
--- a/src/js/chrome/iqeEnablement.js
+++ b/src/js/chrome/iqeEnablement.js
@@ -48,9 +48,12 @@ function init() {
    * Check response errors for cross_account requests.
    * If we get error response with specific cross account error message, we kick the user out of the corss account session.
    */
-  window.fetch = function fetchReplacement(path, options, ...rest) {
+  window.fetch = function fetchReplacement(path = '', options, ...rest) {
     // check if fetch request is made agains the AppSRE sentry
-    const isAppSRESentry = path.includes('https://sentry.devshift.net/api');
+    let isAppSRESentry = false;
+    if (path?.toString()) {
+      isAppSRESentry = path?.toString().includes('https://sentry.devshift.net/api');
+    }
     let tid = Math.random().toString(36);
     let prom = oldFetch.apply(this, [
       path,


### PR DESCRIPTION
Fetch accepts also URL object that does not have the includes function. We first have to call the toString method