### PR TITLE
Push development version of chrome from master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,22 @@ jobs:
     - stage: Test
       if: branch != nightly
       script: npm run circular && npm run lint && npm run test && npx codecov
-    - stage: Deploy Stable
-      if: branch IN (master-stable, prod-stable, qa-stable, ci-stable) AND type != pull_request
-      name: deploy:stable
+    - stage: Deploy prod-stable
+      if: branch = prod-stable AND type != pull_request
+      name: deploy:prod-stable
       script: npm run build && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
-    - stage: Deploy Beta
-      if: branch IN (master, prod-beta, qa-beta) AND type != pull_request
-      name: deploy:beta
+    - stage: Deploy prod-beta
+      if: branch = prod-beta AND type != pull_request
+      name: deploy:prod-beta
       script: npm run build:beta && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
+    - stage: Deploy dev-stable
+      if: branch IN (master-stable, qa-stable, ci-stable) AND type != pull_request
+      name: deploy:dev-stable
+      script: npm run build:dev && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
+    - stage: Deploy dev-beta
+      if: branch IN (master, qa-beta) AND type != pull_request
+      name: deploy:dev-beta
+      script: BETA=true npm run build:dev && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
 env:
   global:
     - REPO="git@github.com:RedHatInsights/insights-chrome-build"

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -12,6 +12,12 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
         rm -rf ./build/.git
         .travis/release.sh "${env}-beta"
     done
+
+    echo
+    echo
+    echo "PUSHING dev-build"
+    rm -rf ./build/.git
+    .travis/release.sh "dev-beta"
 fi
 
 if [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
@@ -23,6 +29,12 @@ if [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
         rm -rf ./build/.git
         .travis/release.sh "${env}-stable"
     done
+
+    echo
+    echo
+    echo "PUSHING dev-build"
+    rm -rf ./build/.git
+    .travis/release.sh "dev-stable"
 fi
 
 if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "analyze": "NODE_ENV=production webpack --config config/webpack.config.js --env analyze=true --mode=production",
     "build": "NODE_ENV=production webpack --config config/webpack.config.js  --mode=production",
     "build:beta": "BETA=true npm run build",
+    "build:dev": "NODE_ENV=development webpack --config config/webpack.config.js  --mode=development",
     "dev": "webpack serve --config config/webpack.config.js --mode=development --env devServer=true",
     "dev:beta": "BETA=true npm run dev",
     "lint": "npm-run-all lint:*",


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-19837

TLDR: There are some issues with apps running the production version of React in the development environment

This one pushes development version of the build to stage environments
And exposes one extra development build branch to the build repo that apps can use if they have to develop on prod.foo (like app services or openshift are doing). That build will be enabled from our webpack proxy.