### PR TITLE
Make updateDocumentTitle add document.title suffix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -51,10 +51,9 @@ insights.chrome.identifyApp('advisor', 'App title');
 ```
 
 ### Using updateDocumentTitle function
-Can be used for changing app title in different app pages.
+Can be used for changing app title in different app pages with a ` | console.redhat.com` suffix added automatically if not disabled by a second param.
 ```js
-insights.chrome.updateDocumentTitle('New title')
-
+insights.chrome.updateDocumentTitle('New title without suffix', true)
 ```
 
 ## Global events

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -150,12 +150,13 @@ export function isFedRamp() {
   return getEnv() === 'gov';
 }
 
-export function updateDocumentTitle(title?: string) {
+export function updateDocumentTitle(title?: string, noSuffix = false) {
+  const titleSuffix = '| console.redhat.com';
   if (typeof title === 'undefined') {
     return;
   }
   if (typeof title === 'string') {
-    document.title = title;
+    document.title = title.includes(titleSuffix) || noSuffix ? title : `${title} ${titleSuffix}`;
   } else {
     console.warn(`Title is not a string. Got ${typeof title} instead.`);
   }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/RHCLOUD-19768

Enabled automatic adding of ` | console.redhat.com` suffix to the `document.title` when calling `updateDocumentTitle`, also added optional `noSuffix` param to disable this behavior.

@Hyperkid123 