### PR TITLE
Ensure the `org_id` is on the top-level of the user object

### DIFF
--- a/src/js/jwt/insights/user.ts
+++ b/src/js/jwt/insights/user.ts
@@ -36,6 +36,7 @@ export function buildUser(token: SSOParsedToken) {
     ? {
         identity: {
           account_number: token.account_number,
+          org_id: token.org_id,
           type: token.type,
           ...(token.idp && { idp: token.idp }),
           user: {


### PR DESCRIPTION
The identity header now adds `identity.org_id`, and the UI user object should also
reflect this change.