### PR TITLE
Adjust expectation in user spec

### DIFF
--- a/src/js/jwt/insights/user.unit.test.js
+++ b/src/js/jwt/insights/user.unit.test.js
@@ -23,7 +23,7 @@ describe('User', () => {
 
   describe('buildUser', () => {
     test('transforms a token into a User object', () => {
-      expect(user.buildUser(token)).toMatchObject(userOutput);
+      expect(user.buildUser(token)).toEqual(userOutput);
     });
   });
 

--- a/testdata/user.json
+++ b/testdata/user.json
@@ -1,6 +1,7 @@
 {
   "identity": {
     "account_number": "540155",
+    "org_id": "1979710",
     "internal": {
       "account_id": 5299389,
       "org_id": "1979710"


### PR DESCRIPTION
The test for the user object structure was still passing after https://github.com/RedHatInsights/insights-chrome/pull/1939
which was due to the `toMatchObject` matcher, which matches a subject. This updates
the test data and the expectation to match the shape completely.