### PR TITLE
add org_id for entitlements call

### DIFF
--- a/src/js/App/Activation/Activation.js
+++ b/src/js/App/Activation/Activation.js
@@ -20,7 +20,7 @@ const Activation = ({ user, request }) => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          description: `Username: ${user.identity.user.username}, Account ID: ${user.identity.account_number}, Email: ${user.identity.user.email}, Send to rbernlei@redhat.com`, //eslint-disable-line
+          description: `Username: ${user.identity.user.username}, Account ID: ${user.identity.account_number}, Org ID: ${user.identity.org_id}, Email: ${user.identity.user.email}, Send to rbernlei@redhat.com`, //eslint-disable-line
           summary: `Activation Request - assign to rbernlei@redhat.com`,
           labels: [request],
         }),

--- a/src/js/App/Feedback/Feedback.js
+++ b/src/js/App/Feedback/Feedback.js
@@ -9,6 +9,7 @@ import { toggleFeedbackModal } from '../../redux/actions';
 import { isProd } from '../../utils.ts';
 
 const Feedback = ({ user }) => {
+  console.log('USER', user);
   const usePendoFeedback = useSelector(({ chrome: { usePendoFeedback } }) => usePendoFeedback);
   const isOpen = useSelector(({ chrome: { isFeedbackModalOpen } }) => isFeedbackModalOpen);
   const dispatch = useDispatch();
@@ -30,7 +31,7 @@ const Feedback = ({ user }) => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          description: `Feedback: ${textAreaValue}, Username: ${user.identity.user.username}, Account ID: ${user.identity.account_number}, Email: ${user.identity.user.email}, URL: ${window.location.href}`, //eslint-disable-line
+          description: `Feedback: ${textAreaValue}, Username: ${user.identity.user.username}, Account ID: ${user.identity.account_number}, Org ID: ${user.identity.org_id}, Email: ${user.identity.user.email}, URL: ${window.location.href}`, //eslint-disable-line
           summary: `${addFeedbackTag()} App Feedback`,
           labels: [app, bundle],
         }),

--- a/src/js/App/Feedback/Feedback.js
+++ b/src/js/App/Feedback/Feedback.js
@@ -9,7 +9,6 @@ import { toggleFeedbackModal } from '../../redux/actions';
 import { isProd } from '../../utils.ts';
 
 const Feedback = ({ user }) => {
-  console.log('USER', user);
   const usePendoFeedback = useSelector(({ chrome: { usePendoFeedback } }) => usePendoFeedback);
   const isOpen = useSelector(({ chrome: { isFeedbackModalOpen } }) => isFeedbackModalOpen);
   const dispatch = useDispatch();

--- a/src/js/jwt/insights/user.ts
+++ b/src/js/jwt/insights/user.ts
@@ -116,13 +116,16 @@ export default async (token: SSOParsedToken) => {
   }
 
   if (user) {
-    log(`Account Number: ${user.identity.account_number}`);
+    log(`Account Number: ${user.identity.account_number}, Org ID: ${user.identity.org_id}`);
     let data;
+    const accNumber =  user.identity.account_number;
+    const orgId = user.identity.org_id;
+
     try {
-      if (user.identity.account_number) {
+      if (accNumber || orgId) {
         data = await servicesApi(token.jti).servicesGet();
       } else {
-        console.log('Cannot call entitlements API, no account number');
+        console.log(`Cannot call entitlements API. Account number: ${accNumber}, Org ID: ${orgId}`);
       }
     } catch {
       // let's swallow error from services API


### PR DESCRIPTION
entitlements can use org_id instead of account number now. Add org_id as another restriction so customers could have one or the other.