### PR TITLE
Clear jwt token after the logout promise has been called

### DIFF
--- a/src/js/jwt/jwt.ts
+++ b/src/js/jwt/jwt.ts
@@ -226,9 +226,6 @@ export function login() {
 
 export function logout(bounce?: boolean) {
   log('Logging out');
-
-  // Clear cookies and tokens
-  priv.clearToken();
   const cookieName = priv.getCookie()?.cookieName;
   if (cookieName) {
     cookie.remove(cookieName);
@@ -254,6 +251,9 @@ export function logout(bounce?: boolean) {
     priv.logout({
       redirectUri: `https://${window.location.host}${isBeta}`,
     });
+
+    // Clear cookies and tokens
+    priv.clearToken();
   }
 }
 


### PR DESCRIPTION
If we delete the tokens before as we used to, the KC will try to append
a token to the logout URL which no longer exists. This breaks the SSO as
it receives an unexpected query parameter.

jira: https://issues.redhat.com/browse/RHCLOUD-20213