### PR TITLE
Add option to use global config SSO url

### DIFF
--- a/src/js/auth.ts
+++ b/src/js/auth.ts
@@ -24,7 +24,7 @@ export function crossAccountBouncer() {
   window.location.reload();
 }
 
-export default () => {
+export default ({ ssoUrl }: { ssoUrl?: string }) => {
   console.time(TIMER_STR); // eslint-disable-line no-console
   const options = {
     ...defaultOptions,
@@ -43,10 +43,10 @@ export default () => {
     options.token = token;
   }
 
-  const promise = jwt.init(options).then(bouncer);
+  const promise = jwt.init(options, ssoUrl).then(bouncer);
 
   return {
-    getOfflineToken: () => getOfflineToken(options.realm, options.clientId),
+    getOfflineToken: () => getOfflineToken(options.realm, options.clientId, ssoUrl),
     jwt: jwt,
     initPromise: promise,
   };

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -30,8 +30,8 @@ const initializeAccessRequestCookies = () => {
   }
 };
 
-const libjwtSetup = () => {
-  const libjwt = auth();
+const libjwtSetup = (chromeConfig) => {
+  const libjwt = auth(chromeConfig || {});
 
   libjwt.initPromise.then(() => {
     libjwt.jwt
@@ -55,20 +55,21 @@ const App = () => {
   const [jwtState, setJwtState] = useState(false);
 
   useEffect(() => {
-    initializeAccessRequestCookies();
-    const libjwt = libjwtSetup();
-    libjwt.initPromise.then(() => setJwtState(true));
+    loadFedModules().then(({ data }) => {
+      const { chrome: chromeConfig } = data;
+      dispatch(loadModulesSchema(data));
+      initializeAccessRequestCookies();
+      const libjwt = libjwtSetup(chromeConfig);
+      libjwt.initPromise.then(() => setJwtState(true));
 
-    window.insights = createChromeInstance(libjwt, window.insights);
-
+      window.insights = createChromeInstance(libjwt, window.insights, data);
+    });
     if (typeof _satellite !== 'undefined' && typeof window._satellite.pageBottom === 'function') {
       window._satellite.pageBottom();
       registerUrlObserver(window._satellite.pageBottom);
     }
 
     trustarcScriptSetup();
-
-    loadFedModules().then(({ data }) => dispatch(loadModulesSchema(data)));
   }, []);
 
   useEffect(() => {

--- a/src/js/chrome/create-chrome.js
+++ b/src/js/chrome/create-chrome.js
@@ -8,7 +8,7 @@ import { createFetchPermissionsWatcher } from '../rbac/fetchPermissions';
  * @param {object} jwt JWT auth functions
  * @param {object} insights existing insights instance
  */
-const createChromeInstance = (jwt, insights) => {
+const createChromeInstance = (jwt, insights, globalConfig) => {
   const libjwt = jwt;
   const chromeInstance = {
     cache: undefined,
@@ -65,7 +65,7 @@ const createChromeInstance = (jwt, insights) => {
 
   const fetchPermissions = bufferAsyncFunction(createFetchPermissionsWatcher(chromeInstance));
 
-  const chromeFunctions = bootstrap(libjwt, init, getUser);
+  const chromeFunctions = bootstrap(libjwt, init, getUser, globalConfig);
 
   chromeFunctions.chrome.getUserPermissions = async (app = '', bypassCache) => {
     await getUser();

--- a/src/js/chrome/entry.js
+++ b/src/js/chrome/entry.js
@@ -97,12 +97,12 @@ export function chromeInit() {
   };
 }
 
-export function bootstrap(libjwt, initFunc, getUser) {
+export function bootstrap(libjwt, initFunc, getUser, globalConfig) {
   return {
     chrome: {
       auth: {
         getOfflineToken: () => libjwt.getOfflineToken(),
-        doOffline: () => libjwt.jwt.doOffline(consts.noAuthParam, consts.offlineToken),
+        doOffline: () => libjwt.jwt.doOffline(consts.noAuthParam, consts.offlineToken, globalConfig?.chrome?.ssoUrl),
         getToken: () => libjwt.initPromise.then(() => libjwt.jwt.getUserInfo().then(() => libjwt.jwt.getEncodedToken())),
         getUser,
         qe: qe,
@@ -123,6 +123,7 @@ export function bootstrap(libjwt, initFunc, getUser) {
       init: initFunc,
       isChrome2: true,
       enable: debugFunctions,
+      globalConfig,
     },
     experimental: {},
   };

--- a/src/js/jwt/insights/offline.ts
+++ b/src/js/jwt/insights/offline.ts
@@ -40,7 +40,7 @@ export function wipePostbackParamsThatAreNotForUs() {
   }
 }
 
-export async function getOfflineToken(realm: string, clientId: string) {
+export async function getOfflineToken(realm: string, clientId: string, configSsoUrl?: string) {
   const postbackUrl = getPostbackUrl();
 
   if (priv.response) {
@@ -54,7 +54,7 @@ export async function getOfflineToken(realm: string, clientId: string) {
     return Promise.reject('not available');
   }
 
-  const ssoUrl = await insightsUrl(DEFAULT_ROUTES);
+  const ssoUrl = await insightsUrl(DEFAULT_ROUTES, configSsoUrl);
 
   const tokenURL = `${ssoUrl}/realms/${realm}/protocol/openid-connect/token`;
   const params = parseHashString(postbackUrl);

--- a/src/js/jwt/insights/url.ts
+++ b/src/js/jwt/insights/url.ts
@@ -4,10 +4,14 @@ const log = logger('insights/url.js');
 const ssoUrl = import(/* webpackChunkName: "sso-url" */ './ssoUrl').then((sso) => sso.default);
 
 // Parse through keycloak options routes
-export default async (env: typeof DEFAULT_ROUTES) => {
+export default async (env: typeof DEFAULT_ROUTES, configSsoUrl?: string) => {
   if (await ssoUrl) {
     log('Using dynamic SSO_URL found! ' + ssoUrl);
     return ssoUrl;
+  }
+
+  if (configSsoUrl) {
+    return configSsoUrl;
   }
 
   const ssoEnv = Object.entries(env).find(([, { url }]) => url.includes(location.hostname));

--- a/src/js/jwt/jwt.ts
+++ b/src/js/jwt/jwt.ts
@@ -67,12 +67,12 @@ export function decodeToken(str: string): DecodedToken {
   return res;
 }
 
-export const doOffline = (key: string, val: string) => {
+export const doOffline = (key: string, val: string, configSsoUrl?: string) => {
   const url = urijs(window.location.href);
   url.removeSearch(key);
   url.addSearch(key, val);
 
-  Promise.resolve(insightsUrl(DEFAULT_ROUTES)).then(async (ssoUrl) => {
+  Promise.resolve(insightsUrl(DEFAULT_ROUTES, configSsoUrl)).then(async (ssoUrl) => {
     const options: KeycloakInitOptions & KeycloakConfig & { promiseType: string; redirectUri: string; url: string } = {
       ...defaultOptions,
       promiseType: 'native',
@@ -102,14 +102,14 @@ export interface JWTInitOptions extends KeycloakInitOptions {
 }
 
 /*** Initialization ***/
-export const init = (options: JWTInitOptions) => {
+export const init = (options: JWTInitOptions, configSsoUrl?: string) => {
   log('Initializing');
 
   const cookieName = options.cookieName ? options.cookieName : DEFAULT_COOKIE_NAME;
 
   priv.setCookie({ cookieName });
 
-  return Promise.resolve(insightsUrl(options.routes ? options.routes : DEFAULT_ROUTES)).then((ssoUrl) => {
+  return Promise.resolve(insightsUrl(options.routes ? options.routes : DEFAULT_ROUTES, configSsoUrl)).then((ssoUrl) => {
     //constructor for new Keycloak Object?
     options.url = ssoUrl;
     options.clientId = 'cloud-services';
@@ -377,6 +377,6 @@ export const getEncodedToken = () => {
 };
 
 // Keycloak server URL
-export const getUrl = () => {
-  return insightsUrl(DEFAULT_ROUTES);
+export const getUrl = (ssoUrl?: string) => {
+  return insightsUrl(DEFAULT_ROUTES, ssoUrl);
 };

--- a/src/js/jwt/jwt.unit.test.ts
+++ b/src/js/jwt/jwt.unit.test.ts
@@ -318,5 +318,10 @@ describe('JWT', () => {
       const url = await jwt.getUrl();
       expect(url).toBe('https://sso.qa.redhat.com/auth');
     });
+
+    test('getUrl with custom URL', async () => {
+      const url = await jwt.getUrl('https://custom-url.com/auth');
+      expect(url).toBe('https://custom-url.com/auth');
+    });
   });
 });


### PR DESCRIPTION
### Custom SSO url

There's a request to change SSO url when app starts in eph environment. This PR adds option to consume chrome config from global fed-mods.json where `ssoUrl` will be located.

### Pass global config to global chrome

With addition of said SSO url we want to also add option to observe this global config from within running app. To do so this PR adds `globalConfig` entry to global chrome object which contains every available app and its config (including fed mods stuff).