### PR TITLE
Store refresh token in localStorage

### DIFF
--- a/src/js/auth.ts
+++ b/src/js/auth.ts
@@ -32,7 +32,7 @@ export default ({ ssoUrl }: { ssoUrl?: string }) => {
 
   wipePostbackParamsThatAreNotForUs();
   const token = cookie.get(options.cookieName);
-  const refreshToken = cookie.get('cs_jwt_refresh');
+  const refreshToken = localStorage.getItem('cs_jwt_refresh');
 
   // If we find an existing token, use it
   // so that we dont auth even when a valid token is present

--- a/src/js/jwt/jwt.ts
+++ b/src/js/jwt/jwt.ts
@@ -355,7 +355,7 @@ export function setCookie(token?: string) {
 function setRefresh(refreshToken?: string) {
   log('Setting the refresh token');
   if (refreshToken) {
-    cookie.set('cs_jwt_refresh', refreshToken, { secure: true });
+    localStorage.setItem('cs_jwt_refresh', refreshToken);
   }
 }
 

--- a/src/js/jwt/modules/useChromeAuth.ts
+++ b/src/js/jwt/modules/useChromeAuth.ts
@@ -22,7 +22,7 @@ export const initChromeAuth = () => {
 
   wipePostbackParamsThatAreNotForUs();
   const token = cookie.get(options.cookieName);
-  const refreshToken = cookie.get('cs_jwt_refresh');
+  const refreshToken = localStorage.getItem('cs_jwt_refresh');
 
   // If we find an existing token, use it
   // so that we dont auth even when a valid token is present


### PR DESCRIPTION
### Description

We are hitting a problem with header too large on static assets. This is because we are including the SSO cookies with each request. Let's remove at least part of the problem `cs_jwt_refresh` from all of the requests by storing this token in localstorage. We'll save at least 800b (which 1/10th of Akamai upper limit for header).