### PR TITLE
Use JWT token only on API routes

### DIFF
--- a/src/js/jwt/jwt.ts
+++ b/src/js/jwt/jwt.ts
@@ -347,7 +347,7 @@ export function setCookie(token?: string) {
   if (token && token.length > 10) {
     const cookieName = priv.getCookie()?.cookieName;
     if (cookieName) {
-      setCookieWrapper(`${cookieName}=${token};` + `path=/;` + `secure=true;` + `expires=${getCookieExpires(decodeToken(token).exp)}`);
+      setCookieWrapper(`${cookieName}=${token};` + `path=/api;` + `secure=true;` + `expires=${getCookieExpires(decodeToken(token).exp)}`);
     }
   }
 }

--- a/src/js/jwt/jwt.unit.test.ts
+++ b/src/js/jwt/jwt.unit.test.ts
@@ -52,7 +52,7 @@ describe('JWT', () => {
   describe('setCookie', () => {
     test('sets a cookie that expires on the same second the JWT expires', () => {
       jwt.setCookie(encodedToken);
-      expect(window.document.cookie).toEqual(`cs_jwt=${encodedToken};` + `path=/;` + `secure=true;` + `expires=Wed, 24 Apr 2019 17:13:47 GMT`);
+      expect(window.document.cookie).toEqual(`cs_jwt=${encodedToken};` + `path=/api;` + `secure=true;` + `expires=Wed, 24 Apr 2019 17:13:47 GMT`);
     });
   });
 


### PR DESCRIPTION
### Description

Since we don't need to include JWT token to each static assets request we can attach the `cs_jwt` token only to `/api` paths. This way we'll remove huge amount of request header.

Only place where this is currently failing is landing page, however that's because landing page is touching cookies directly. This PR fixes such issue https://github.com/RedHatInsights/landing-page-frontend/pull/415