### PR TITLE
Add flex-grow: 1 to default layout

### DIFF
--- a/src/js/App/RootApp/DefaultLayout.scss
+++ b/src/js/App/RootApp/DefaultLayout.scss
@@ -27,6 +27,7 @@
 }
 
 .chr-scope__default-layout {
+  flex-grow: 1;
   display: inherit;
   flex-direction: inherit;
 }


### PR DESCRIPTION
### Description

The default layout does not span over entire height of the content. This is caused by flex display set on the parent component and if the content does not occupy entire screen it will be cutt off.

#### Current

![Screenshot from 2022-08-10 09-15-45](https://user-images.githubusercontent.com/3439771/183838748-f0c47f71-d49d-4c52-baea-ac71201cd5aa.png)

#### New

![Screenshot from 2022-08-10 09-15-51](https://user-images.githubusercontent.com/3439771/183838777-03211029-69b7-4800-9db6-dbdffacc48be.png)


