### PR TITLE
Silence missing translations on non prod environments

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -11,3 +11,4 @@ There are some localStorage values for you to enable debuging information or ena
 * `shortSession` - to enable short session in order to test automatic logouts
 * `forcePendo` - to force Pendo initializtion
 * `segmentDev` - force usage of common segment dev API key
+* `intlDebug` - show missing translation keys

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
-import { IntlProvider } from 'react-intl';
+import { IntlProvider, ReactIntlErrorCode } from 'react-intl';
 import { spinUpStore } from './redux-config';
 import RootApp from './App/RootApp';
 import { loadModulesSchema } from './redux/actions';
@@ -13,6 +13,7 @@ import createChromeInstance from './chrome/create-chrome';
 import registerUrlObserver from './url-observer';
 import { loadFedModules, noop, trustarcScriptSetup } from './utils.ts';
 import messages from '../locales/data.json';
+import { getEnv } from './utils';
 
 const language = navigator.language.slice(0, 2) || 'en';
 
@@ -84,7 +85,19 @@ const App = () => {
 };
 
 ReactDOM.render(
-  <IntlProvider locale={language} messages={messages[language]}>
+  <IntlProvider
+    locale={language}
+    messages={messages[language]}
+    onError={(error) => {
+      if (
+        (getEnv() === 'stage' && !window.location.origin.includes('foo')) ||
+        localStorage.getItem('chrome:intl:debug') === 'true' ||
+        !(error.code === ReactIntlErrorCode.MISSING_TRANSLATION)
+      ) {
+        console.error(error);
+      }
+    }}
+  >
     <Provider store={spinUpStore()?.store}>
       <App />
     </Provider>

--- a/src/js/debugFunctions.ts
+++ b/src/js/debugFunctions.ts
@@ -20,4 +20,5 @@ export default {
   quickstartsDebug: () => functionBuilder('chrome:experimental:quickstarts', true),
   darkMode: () => functionBuilder('chrome:darkmode', true),
   segmentDev: () => functionBuilder('chrome:analytics:dev', true),
+  intlDebug: () => functionBuilder('chrome:intl:debug', true),
 };


### PR DESCRIPTION
### Description

Since we don't want to pollute the browser's console let's ignore all missing translations. If someone would like to see them they can go to stage environment or turning them on by calling `intlDebug` which sets localStorage item `chrome:intl:debug`