### PR TITLE
Fix missing token from create support case request headers.

### DIFF
--- a/src/js/chrome/entry.ts
+++ b/src/js/chrome/entry.ts
@@ -139,7 +139,7 @@ export function bootstrap(
       getApp: () => getUrl('app'),
       getEnvironment: () => getEnv(),
       getEnvironmentDetails: () => getEnvDetails(),
-      createCase: (fields?: any) => window.insights.chrome.auth.getUser().then((user) => createSupportCase(user.identity, fields)),
+      createCase: (fields?: any) => window.insights.chrome.auth.getUser().then((user) => createSupportCase(user.identity, libjwt, fields)),
       visibilityFunctions,
       init: initFunc,
       isChrome2: true,

--- a/src/js/createCase.ts
+++ b/src/js/createCase.ts
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie';
 import * as Sentry from '@sentry/browser';
 import logger from './jwt/logger';
 import URI from 'urijs';
@@ -8,6 +7,7 @@ import { getEnvDetails, getUrl } from './utils';
 import { HYDRA_ENDPOINT } from './consts';
 import { spinUpStore } from './redux-config';
 import { ChromeUser } from '@redhat-cloud-services/types';
+import { LibJWT } from './auth';
 
 // Lit of products that are bundles
 const BUNDLE_PRODUCTS = [
@@ -72,6 +72,7 @@ async function getProductData() {
 
 export async function createSupportCase(
   userInfo: ChromeUser['identity'],
+  libjwt: LibJWT,
   fields?: {
     caseFields: Record<string, unknown>;
   }
@@ -83,11 +84,12 @@ export async function createSupportCase(
 
   log('Creating a support case');
 
+  const token = await libjwt.initPromise.then(() => libjwt.jwt.getUserInfo().then(() => libjwt.jwt.getEncodedToken()));
   fetch(caseUrl, {
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${Cookies.get('cs_jwt')}`,
+      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-21134

The `cs_jwt` is no longer a readable cookie because we are setting the `path=/api` to not send cookies to CDN. The token has to be accessed via KC.