### PR TITLE
Pass sso URL to frontend.yml config from env var

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -15,6 +15,9 @@ objects:
       API:
         versions:
           - v1
+      module:
+        customConfig:
+          ssoUrl: ${SSO_URL}
       frontend:
         paths:
           - /
@@ -23,6 +26,8 @@ parameters:
   - name: ENV_NAME
     required: true
   - name: IMAGE_TAG
+    required: true
+  - name: SSO_URL
     required: true
   - name: IMAGE
     value: quay.io/cloudservices/insights-chrome-frontend

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -64,7 +64,7 @@ const App = () => {
       const { chrome: chromeConfig } = data;
       dispatch(loadModulesSchema(data));
       initializeAccessRequestCookies();
-      const libjwt = libjwtSetup(chromeConfig, setJwtState);
+      const libjwt = libjwtSetup(chromeConfig.config || chromeConfig, setJwtState);
 
       window.insights = createChromeInstance(libjwt, window.insights, data);
     });

--- a/src/js/chrome/create-chrome.ts
+++ b/src/js/chrome/create-chrome.ts
@@ -10,7 +10,11 @@ import { ChromeAPI, ChromeUser } from '@redhat-cloud-services/types';
  * @param {object} jwt JWT auth functions
  * @param {object} insights existing insights instance
  */
-const createChromeInstance = (jwt: LibJWT, insights: Partial<ChromeAPI>, globalConfig: { chrome?: { ssoUrl?: string } }) => {
+const createChromeInstance = (
+  jwt: LibJWT,
+  insights: Partial<ChromeAPI>,
+  globalConfig: { chrome?: { ssoUrl?: string; config?: { ssoUrl?: string } } }
+) => {
   const libjwt = jwt;
   const chromeInstance = {
     cache: undefined,

--- a/src/js/chrome/entry.ts
+++ b/src/js/chrome/entry.ts
@@ -117,13 +117,14 @@ export function bootstrap(
   libjwt: LibJWT,
   initFunc: () => ChromeAPI,
   getUser: () => Promise<ChromeUser | void>,
-  globalConfig: { chrome?: { ssoUrl?: string } }
+  globalConfig: { chrome?: { ssoUrl?: string; config?: { ssoUrl?: string } } }
 ) {
   return {
     chrome: {
       auth: {
         getOfflineToken: () => libjwt.getOfflineToken(),
-        doOffline: () => libjwt.jwt.doOffline(consts.noAuthParam, consts.offlineToken, globalConfig?.chrome?.ssoUrl),
+        doOffline: () =>
+          libjwt.jwt.doOffline(consts.noAuthParam, consts.offlineToken, globalConfig?.chrome?.ssoUrl || globalConfig?.chrome?.config?.ssoUrl),
         getToken: () => libjwt.initPromise.then(() => libjwt.jwt.getUserInfo().then(() => libjwt.jwt.getEncodedToken())),
         getUser,
         qe: qe,


### PR DESCRIPTION
### Description

We now have option to pass custom frontend config to any frontend app in module. This PR adds SSO url to chrome config which will then be consumed by chrome on runtime.