### PR TITLE
Use config instead of custom config in frontend config

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -16,7 +16,8 @@ objects:
         versions:
           - v1
       module:
-        customConfig:
+        manifestLocation: "/apps/chrome/fed-modules.json"
+        config:
           ssoUrl: ${SSO_URL}
       frontend:
         paths:


### PR DESCRIPTION
### Description

The customConfig is one level above the modules config. However we can use the `config` field in module section to pass the SSO url down the line.