### PR TITLE
Revert "Bump d3-color and @patternfly/react-charts"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3505,48 +3505,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.122.2.tgz",
       "integrity": "sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw=="
     },
-    "node_modules/@patternfly/react-charts": {
-      "version": "6.92.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.92.0.tgz",
-      "integrity": "sha512-aQl+L7zH/tWX00L2xI6B0414xweaIocR98wbyhXLi6zknkhcAUcE2zITFIW4+EsU+qPvUlptwRiRufoH8/BlEw==",
-      "dependencies": {
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0",
-        "victory-area": "^36.2.1",
-        "victory-axis": "^36.2.1",
-        "victory-bar": "^36.2.1",
-        "victory-chart": "^36.2.1",
-        "victory-core": "^36.2.1",
-        "victory-create-container": "^36.2.1",
-        "victory-cursor-container": "^36.2.1",
-        "victory-group": "^36.2.1",
-        "victory-legend": "^36.2.1",
-        "victory-line": "^36.2.1",
-        "victory-pie": "^36.2.1",
-        "victory-scatter": "^36.2.1",
-        "victory-stack": "^36.2.1",
-        "victory-tooltip": "^36.2.1",
-        "victory-voronoi-container": "^36.2.1",
-        "victory-zoom-container": "^36.2.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@patternfly/react-charts/node_modules/@patternfly/react-tokens": {
-      "version": "4.91.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.91.0.tgz",
-      "integrity": "sha512-QeQCy8o8E/16fAr8mxqXIYRmpTsjCHJXi5p5jmgEDFmYMesN6Pqfv6N5D0FHb+CIaNOZWRps7GkWvlIMIE81sw=="
-    },
-    "node_modules/@patternfly/react-charts/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/@patternfly/react-core": {
       "version": "4.236.6",
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.236.6.tgz",
@@ -3594,9 +3552,9 @@
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.89.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.89.0.tgz",
-      "integrity": "sha512-SkT+qx3Xqu70T5s+i/AUT2hI2sKAPDX4ffeiJIUDu/oyWiFdk+/9DEivnLSyJMruroXXN33zKibvzb5rH7DKTQ=="
+      "version": "4.86.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.86.6.tgz",
+      "integrity": "sha512-bniShtFAZRz6dZVCuG5LNy+WDGsWfsvHWL1MlfKqXEcqO+nCN1efcta2bYenvcSfVKKWIBrKH8G7N5t/PjkPMw=="
     },
     "node_modules/@patternfly/react-table": {
       "version": "4.71.16",
@@ -3784,6 +3742,354 @@
         "rgb-hex": "^3.0.0"
       }
     },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts": {
+      "version": "6.15.20",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.15.20.tgz",
+      "integrity": "sha512-aoHrANVAirdMs42rCSZuu2X+Sfa7jtePeoaN23p3ige3PitN4fbTsSCzu0o1jfdVKa8q56PHxxLtWa+rIWZieA==",
+      "dependencies": {
+        "@patternfly/react-styles": "^4.11.13",
+        "@patternfly/react-tokens": "^4.12.15",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.19",
+        "tslib": "^2.0.0",
+        "victory-area": "^35.9.0",
+        "victory-axis": "^35.9.0",
+        "victory-bar": "^35.9.0",
+        "victory-chart": "^35.9.0",
+        "victory-core": "^35.9.0",
+        "victory-create-container": "^35.9.1",
+        "victory-group": "^35.9.0",
+        "victory-legend": "^35.9.0",
+        "victory-line": "^35.9.0",
+        "victory-pie": "^35.9.0",
+        "victory-scatter": "^35.9.0",
+        "victory-stack": "^35.9.0",
+        "victory-tooltip": "^35.9.1",
+        "victory-voronoi-container": "^35.9.1",
+        "victory-zoom-container": "^35.9.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-area": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.11.4.tgz",
+      "integrity": "sha512-i3rN4Jvn1uwA3YvCuv3EIPEcK2SWSOq3c+TvLvVj1BKFQug11C06UjyQje+3EEzffZ/EMkvGqj2+YudIjrGEzA==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-axis": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.11.4.tgz",
+      "integrity": "sha512-KmPXC/vgbiiWckhK0LruZvsFQqESg6BflhIqS/Xemc50ymWetqbT9VZhjPWbU0arOIP5E8xcFnGUimDN//Jffw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-bar": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.11.4.tgz",
+      "integrity": "sha512-EZC+6VGwHkIcOYEppVFBIC5JymYnfF+RLF+NM0Uys7q5+AwaLx36LS9a2xBUBYO/gx20Wd1HVH8kjSHzw1rTqQ==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-chart": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.11.4.tgz",
+      "integrity": "sha512-oBTjx6ytp+/s6zswCuOUQotiISePQKuDUdOsjnbINBPSNvJuE2W9GXHD+B7ibDkCh4ZWXm8obHz7mnrRGbCGFQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^35.11.4",
+        "victory-core": "^35.11.4",
+        "victory-polar-axis": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-chart/node_modules/victory-polar-axis": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.11.4.tgz",
+      "integrity": "sha512-mnIRpfARn36TG6ZdCgKR+oWY+pIX6wLHYS0un5xM1TTObKk4IyAR3dnQhEp+3KM1SGoLg0mENFR1Ac8xrus6nQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-chart/node_modules/victory-shared-events": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+      "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-core": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.11.4.tgz",
+      "integrity": "sha512-PuqrOIn/a6GQgsp/DKvACiJBAJo71P77jltn56mlDZjAAzz+58BL4E0hx7x908GdodLXo2n9gEeuDdjOAlOt0Q==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-create-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.11.4.tgz",
+      "integrity": "sha512-baDLO4GSk/7eTVEYkhikwgwV5BtrSMuNPjKZBjZrIA3Ka9Fn5shklRG9PWg+26JIBFxqZdM6zOvpF7xhjxi37Q==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^35.11.4",
+        "victory-core": "^35.11.4",
+        "victory-cursor-container": "^35.11.4",
+        "victory-selection-container": "^35.11.4",
+        "victory-voronoi-container": "^35.11.4",
+        "victory-zoom-container": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-create-container/node_modules/victory-brush-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.11.4.tgz",
+      "integrity": "sha512-KpFYU2LxKbLIjZDhXTdveok1SWLFlG5s2R214IRq+ukYRz21CoxlvZCWhFL60lSPilD+ZD1Udv3sK/RW9CFMxA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-create-container/node_modules/victory-cursor-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.11.4.tgz",
+      "integrity": "sha512-gs6bwRd/qbGTN78w2QgshIFxlyOsss5qWOMdCcY9i0Oi99l9OJ6UFQDBzSgKsgD53KGs7JxiKevmUqc3qSZZBg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-create-container/node_modules/victory-selection-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.11.4.tgz",
+      "integrity": "sha512-Olxnjp9tvHUHeFr4zU/K1dzp0zbeqQRMr2Qqpr85Dd4pWV9bIReE/DanxGhjNg9s3KB5Vsn1GC46PXSTMM1XIQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-group": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.11.4.tgz",
+      "integrity": "sha512-ceFBll9h1sPpdMjNcvdgEhnYELVHfx9ymmk8iMEjOKpxa4fVvapMhegPmL0/zTemJ/NCu71W2xIr0VqyqK0DaA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-group/node_modules/victory-shared-events": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+      "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-legend": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.11.4.tgz",
+      "integrity": "sha512-JZzQARjxYorWlNf9RmZRPAzlgPjukiUV1aTBaeC8YA2S4PhP4PWhNwO/Pb3aCdkifpumpgsm3JULpJiCGOPdBQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-line": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.11.4.tgz",
+      "integrity": "sha512-uKX6/1b1OmlqJZOsVDCCDlyc9QItgb39vRssTwP4CJX1NLU4Sfgq2i4VVUbHXCo/I2sMEczjf3cdnxdZtC6IFA==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-pie": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.11.4.tgz",
+      "integrity": "sha512-EruxP3PIkrTPTzsC5YhiRKg2s+0UtaRU1ZHZUWK8qi+zlbMDFKYg2AlHqsEnctu5AOdOWLLiye6qUG3oxjiURg==",
+      "dependencies": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-scatter": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.11.4.tgz",
+      "integrity": "sha512-8n9rmXmVju2SqA6Xd90rRTmboaU7WStOnj1QUg4q96DDiAVf6kGPdolzCwbUBbiECLyluGoFNJ043WLXztGpiA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-stack": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.11.4.tgz",
+      "integrity": "sha512-fNTY50fN+DCHcK/9AgMUEq0uJ8IXGnMlRtkSCzMB9ZpEzB7Edx3jLM2Gl970zOkwVaDYXTlikPd1dwf+h3m0dA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-stack/node_modules/victory-shared-events": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+      "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-tooltip": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.11.4.tgz",
+      "integrity": "sha512-B+UUqzryurtMghJGiE34tg5eI44vHxyOOcuPIM3IpJLujnNIJXVykBjgQZnFq1CT/63TtDCOlzPkOjSbecPtXQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-voronoi-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.11.4.tgz",
+      "integrity": "sha512-vmwHBm/+nZ9qdRcaNd7r08AVRkus/ER6UA4KAYWkKUe50ZT9NYjDxy0wW/Y7PHQldfL9q/VxAyIE/M6jSFWkEA==",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-tooltip": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts/node_modules/victory-zoom-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.11.4.tgz",
+      "integrity": "sha512-8D4hTdvGZqyZdgWjkz/pDRVy/kijWhptFbK0KWl5J1Tt4YuCGiRC9oxQOpEjlqr8TSyeVnpyuF4QuIp9YOIrAw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
     "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-icons": {
       "version": "3.15.17",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-3.15.17.tgz",
@@ -3881,6 +4187,11 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
       "version": "3.2.19",
@@ -7535,60 +7846,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
-      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ=="
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "node_modules/@types/debounce-promise": {
       "version": "3.1.3",
@@ -11539,114 +11796,82 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-color": "1"
       }
     },
     "node_modules/d3-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
-      "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
     },
     "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
       "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "node_modules/d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-path": "1"
       }
     },
     "node_modules/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-time": "1"
       }
     },
     "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -15306,14 +15531,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/interpret": {
@@ -21543,13 +21760,13 @@
       }
     },
     "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
+        "react-is": "^16.8.1"
       }
     },
     "node_modules/prop-types-extra": {
@@ -21815,9 +22032,9 @@
       }
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "node_modules/react-final-form": {
       "version": "6.5.3",
@@ -25673,310 +25890,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "node_modules/victory-area": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.8.tgz",
-      "integrity": "sha512-aIyMuzUqiDcpTCB7FUOYDJvqiDPiluEXLOw6Lh1vrUYmV7CNqMDOIBtTau2vI41Ao0o0YJdCAcyzBib9e3UYbw==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.8.tgz",
-      "integrity": "sha512-tClVJEay1YOJAh9rRyyLx8pei7Sr1/xTz04bJmfzFoAxFoPBtvgfFwXhfZ1YjGIl7m5Wh2CiYMY3figueLzYtg==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-bar": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.8.tgz",
-      "integrity": "sha512-jLLPm3IW8/2uSLPvQD9bxzXnTraUYBIDTkbZPZy7oHP01OVzP1sj+MMHcINCWcUbyUyLZDL3u8CvViXjS273JQ==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-brush-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.8.tgz",
-      "integrity": "sha512-PN5zQ6kjVwZca1qV41WlV6J2IEyQh+2hykRe6c/wERDotVVbSrX3sJVAzUbN+7x2rrK0CL6a/XUI8jDsWTMM2A==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-chart": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.8.tgz",
-      "integrity": "sha512-kC1jL63PAmqUrvZNOfwAXNuaIwz4nvXYUuEPu59WRBCOIGDGRgv2wJ1O7O0xYXqDkI57EtAYf9KUK+miEn/Btg==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-polar-axis": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-core": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.8.tgz",
-      "integrity": "sha512-SkyEszZKGyxjqfptfFWYdI22CvCuE9LhkaDpikzIhT2gcE3SuOBO5fk/740XMYE2ZUsJ4Fu/Vy4+8jZi17y44A==",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-create-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.8.tgz",
-      "integrity": "sha512-H2BsdTbJ/RxxcEg5lzk3TDlihtOs7I/5KaIBP3yosPs702i40mL2qndkRkj08QeiZhkaKfQ2GOUvyP+t7DSdmg==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-cursor-container": "^36.6.8",
-        "victory-selection-container": "^36.6.8",
-        "victory-voronoi-container": "^36.6.8",
-        "victory-zoom-container": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-cursor-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.8.tgz",
-      "integrity": "sha512-3WIBRl+7jnZok6syLfW8RK23nliDcoD/JUTN0YZo6bKBqHeFc4+ur3mlwCfghH7sGoxJRYuOJxTd9x2MwM5HQQ==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-group": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.8.tgz",
-      "integrity": "sha512-CiupDIGPPWVgwif3ayd8glSlR41mVbuT0Nl0ay9q42w2fiM32syiJAoifIw47X4tL8ow/DXH+/5Pd8eEyA2trA==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-legend": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.8.tgz",
-      "integrity": "sha512-OnkzB82Mvt5/1LYNsrfZQoXaVvgfp1rCsFRI3imq257Sh/UPy0/eZehCMQs/SVbU0z0EuIpXokhZb3BBdoJgpw==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-line": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.8.tgz",
-      "integrity": "sha512-MozOejQRZPdzFaru5zUfqVB4TEff6nZjtQhOs+F5yyhXjLgM89zGX30r3jK5cjVdAPbTu4KPUrwktvlw+AkPRA==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-pie": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.8.tgz",
-      "integrity": "sha512-dUHWiiKd60dlt7OjFa+YYwanHAkP/T0abzy6O3SFxGre52oeqd8px1EoVhlLKpn4ao8L35koG9mvz6/pGyr8Dw==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-polar-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.8.tgz",
-      "integrity": "sha512-aU+Wp5six21POhI9oXeREnZHljpqcmwFHHnliVGrwgRsuc7TAjfXPWVOX9guEFfh6zQW6IZWWWTTLAN/PIEm9w==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-scatter": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.8.tgz",
-      "integrity": "sha512-GKSNneBxIWLsF3eBSTW5IwT5S4YdsfFl4PVCP3/wTa2myfS5DIS9FufEnJp/FEZGalEXYWxeR47rlWqABxAj5A==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-selection-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.8.tgz",
-      "integrity": "sha512-kudYbSX+o7fr64oeN7+EG/c+lqO22aypxVdCwa6BagAGoqqLR4jXxTqqIdp8tvxCgfCCXxopnTKYr46nubypGw==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-shared-events": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.8.tgz",
-      "integrity": "sha512-hWPOVqMD3Sv6Rl1iyO6ibQrwYF9/eLCnRo0T59/Hsid6On0AJJjL9gv0oEIM5fqz7R7zx9PJmMk877IctEOemw==",
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-stack": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.8.tgz",
-      "integrity": "sha512-Pkux46IqAealOi0KvqQpaJKKKpHCfZ/sh5IeUKYFy+QKWAjiQjG6hFZeHgr2YaS7OfdbvHhoAdvp03KntWzpbw==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-tooltip": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.8.tgz",
-      "integrity": "sha512-9P+QeAGyDpP0trJnQ1NtnbDhpoJB0Ghc2boYEehvL12p0OzolY9/Nq5SDP0tu5i1BBujwFXtnoCDqt+mOH25fA==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.8.tgz",
-      "integrity": "sha512-H3kyQ+2zgjMPvbPqAl7Vwm2FD5dU7/4bCTQakFQnpIsfDljeOMDojRsrmJfwh4oAlNnWhpAf+mbAoLh8u7dwyQ==",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
-      }
-    },
-    "node_modules/victory-voronoi-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.8.tgz",
-      "integrity": "sha512-x9/OOZdMm4dh38jNhSfBYT0nG6ribsINU0/WNzIn3QcDXFBInsJ7jRySxYmdmk45OdXfbDRwDMqVHk72sWQyUw==",
-      "dependencies": {
-        "delaunay-find": "0.0.6",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-tooltip": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-zoom-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.8.tgz",
-      "integrity": "sha512-gxX5iJUaxrFFZ2IGS0sQnUI+3Mhj6bVLqtOlQd3Krld+9f/ieuUbxl+P+eIyhQU/VyHSlirIZeOGOXJeYcU9jQ==",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -29565,46 +29478,6 @@
         }
       }
     },
-    "@patternfly/react-charts": {
-      "version": "6.92.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.92.0.tgz",
-      "integrity": "sha512-aQl+L7zH/tWX00L2xI6B0414xweaIocR98wbyhXLi6zknkhcAUcE2zITFIW4+EsU+qPvUlptwRiRufoH8/BlEw==",
-      "requires": {
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0",
-        "victory-area": "^36.2.1",
-        "victory-axis": "^36.2.1",
-        "victory-bar": "^36.2.1",
-        "victory-chart": "^36.2.1",
-        "victory-core": "^36.2.1",
-        "victory-create-container": "^36.2.1",
-        "victory-cursor-container": "^36.2.1",
-        "victory-group": "^36.2.1",
-        "victory-legend": "^36.2.1",
-        "victory-line": "^36.2.1",
-        "victory-pie": "^36.2.1",
-        "victory-scatter": "^36.2.1",
-        "victory-stack": "^36.2.1",
-        "victory-tooltip": "^36.2.1",
-        "victory-voronoi-container": "^36.2.1",
-        "victory-zoom-container": "^36.2.1"
-      },
-      "dependencies": {
-        "@patternfly/react-tokens": {
-          "version": "4.91.0",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.91.0.tgz",
-          "integrity": "sha512-QeQCy8o8E/16fAr8mxqXIYRmpTsjCHJXi5p5jmgEDFmYMesN6Pqfv6N5D0FHb+CIaNOZWRps7GkWvlIMIE81sw=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@patternfly/react-core": {
       "version": "4.236.6",
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.236.6.tgz",
@@ -29644,9 +29517,9 @@
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.89.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.89.0.tgz",
-      "integrity": "sha512-SkT+qx3Xqu70T5s+i/AUT2hI2sKAPDX4ffeiJIUDu/oyWiFdk+/9DEivnLSyJMruroXXN33zKibvzb5rH7DKTQ=="
+      "version": "4.86.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.86.6.tgz",
+      "integrity": "sha512-bniShtFAZRz6dZVCuG5LNy+WDGsWfsvHWL1MlfKqXEcqO+nCN1efcta2bYenvcSfVKKWIBrKH8G7N5t/PjkPMw=="
     },
     "@patternfly/react-table": {
       "version": "4.71.16",
@@ -29829,6 +29702,294 @@
         "rgb-hex": "^3.0.0"
       },
       "dependencies": {
+        "@patternfly/react-charts": {
+          "version": "6.15.20",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.15.20.tgz",
+          "integrity": "sha512-aoHrANVAirdMs42rCSZuu2X+Sfa7jtePeoaN23p3ige3PitN4fbTsSCzu0o1jfdVKa8q56PHxxLtWa+rIWZieA==",
+          "requires": {
+            "@patternfly/react-styles": "^4.11.13",
+            "@patternfly/react-tokens": "^4.12.15",
+            "hoist-non-react-statics": "^3.3.0",
+            "lodash": "^4.17.19",
+            "tslib": "^2.0.0",
+            "victory-area": "^35.9.0",
+            "victory-axis": "^35.9.0",
+            "victory-bar": "^35.9.0",
+            "victory-chart": "^35.9.0",
+            "victory-core": "^35.9.0",
+            "victory-create-container": "^35.9.1",
+            "victory-group": "^35.9.0",
+            "victory-legend": "^35.9.0",
+            "victory-line": "^35.9.0",
+            "victory-pie": "^35.9.0",
+            "victory-scatter": "^35.9.0",
+            "victory-stack": "^35.9.0",
+            "victory-tooltip": "^35.9.1",
+            "victory-voronoi-container": "^35.9.1",
+            "victory-zoom-container": "^35.9.0"
+          },
+          "dependencies": {
+            "victory-area": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.11.4.tgz",
+              "integrity": "sha512-i3rN4Jvn1uwA3YvCuv3EIPEcK2SWSOq3c+TvLvVj1BKFQug11C06UjyQje+3EEzffZ/EMkvGqj2+YudIjrGEzA==",
+              "requires": {
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-axis": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.11.4.tgz",
+              "integrity": "sha512-KmPXC/vgbiiWckhK0LruZvsFQqESg6BflhIqS/Xemc50ymWetqbT9VZhjPWbU0arOIP5E8xcFnGUimDN//Jffw==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-bar": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.11.4.tgz",
+              "integrity": "sha512-EZC+6VGwHkIcOYEppVFBIC5JymYnfF+RLF+NM0Uys7q5+AwaLx36LS9a2xBUBYO/gx20Wd1HVH8kjSHzw1rTqQ==",
+              "requires": {
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-chart": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.11.4.tgz",
+              "integrity": "sha512-oBTjx6ytp+/s6zswCuOUQotiISePQKuDUdOsjnbINBPSNvJuE2W9GXHD+B7ibDkCh4ZWXm8obHz7mnrRGbCGFQ==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-axis": "^35.11.4",
+                "victory-core": "^35.11.4",
+                "victory-polar-axis": "^35.11.4",
+                "victory-shared-events": "^35.11.4"
+              },
+              "dependencies": {
+                "victory-polar-axis": {
+                  "version": "35.11.4",
+                  "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.11.4.tgz",
+                  "integrity": "sha512-mnIRpfARn36TG6ZdCgKR+oWY+pIX6wLHYS0un5xM1TTObKk4IyAR3dnQhEp+3KM1SGoLg0mENFR1Ac8xrus6nQ==",
+                  "requires": {
+                    "lodash": "^4.17.19",
+                    "prop-types": "^15.5.8",
+                    "victory-core": "^35.11.4"
+                  }
+                },
+                "victory-shared-events": {
+                  "version": "35.11.4",
+                  "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+                  "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+                  "requires": {
+                    "json-stringify-safe": "^5.0.1",
+                    "lodash": "^4.17.19",
+                    "prop-types": "^15.5.8",
+                    "react-fast-compare": "^2.0.0",
+                    "victory-core": "^35.11.4"
+                  }
+                }
+              }
+            },
+            "victory-core": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.11.4.tgz",
+              "integrity": "sha512-PuqrOIn/a6GQgsp/DKvACiJBAJo71P77jltn56mlDZjAAzz+58BL4E0hx7x908GdodLXo2n9gEeuDdjOAlOt0Q==",
+              "requires": {
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
+              }
+            },
+            "victory-create-container": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.11.4.tgz",
+              "integrity": "sha512-baDLO4GSk/7eTVEYkhikwgwV5BtrSMuNPjKZBjZrIA3Ka9Fn5shklRG9PWg+26JIBFxqZdM6zOvpF7xhjxi37Q==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "victory-brush-container": "^35.11.4",
+                "victory-core": "^35.11.4",
+                "victory-cursor-container": "^35.11.4",
+                "victory-selection-container": "^35.11.4",
+                "victory-voronoi-container": "^35.11.4",
+                "victory-zoom-container": "^35.11.4"
+              },
+              "dependencies": {
+                "victory-brush-container": {
+                  "version": "35.11.4",
+                  "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.11.4.tgz",
+                  "integrity": "sha512-KpFYU2LxKbLIjZDhXTdveok1SWLFlG5s2R214IRq+ukYRz21CoxlvZCWhFL60lSPilD+ZD1Udv3sK/RW9CFMxA==",
+                  "requires": {
+                    "lodash": "^4.17.19",
+                    "prop-types": "^15.5.8",
+                    "react-fast-compare": "^2.0.0",
+                    "victory-core": "^35.11.4"
+                  }
+                },
+                "victory-cursor-container": {
+                  "version": "35.11.4",
+                  "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.11.4.tgz",
+                  "integrity": "sha512-gs6bwRd/qbGTN78w2QgshIFxlyOsss5qWOMdCcY9i0Oi99l9OJ6UFQDBzSgKsgD53KGs7JxiKevmUqc3qSZZBg==",
+                  "requires": {
+                    "lodash": "^4.17.19",
+                    "prop-types": "^15.5.8",
+                    "victory-core": "^35.11.4"
+                  }
+                },
+                "victory-selection-container": {
+                  "version": "35.11.4",
+                  "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.11.4.tgz",
+                  "integrity": "sha512-Olxnjp9tvHUHeFr4zU/K1dzp0zbeqQRMr2Qqpr85Dd4pWV9bIReE/DanxGhjNg9s3KB5Vsn1GC46PXSTMM1XIQ==",
+                  "requires": {
+                    "lodash": "^4.17.19",
+                    "prop-types": "^15.5.8",
+                    "victory-core": "^35.11.4"
+                  }
+                }
+              }
+            },
+            "victory-group": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.11.4.tgz",
+              "integrity": "sha512-ceFBll9h1sPpdMjNcvdgEhnYELVHfx9ymmk8iMEjOKpxa4fVvapMhegPmL0/zTemJ/NCu71W2xIr0VqyqK0DaA==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^35.11.4",
+                "victory-shared-events": "^35.11.4"
+              },
+              "dependencies": {
+                "victory-shared-events": {
+                  "version": "35.11.4",
+                  "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+                  "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+                  "requires": {
+                    "json-stringify-safe": "^5.0.1",
+                    "lodash": "^4.17.19",
+                    "prop-types": "^15.5.8",
+                    "react-fast-compare": "^2.0.0",
+                    "victory-core": "^35.11.4"
+                  }
+                }
+              }
+            },
+            "victory-legend": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.11.4.tgz",
+              "integrity": "sha512-JZzQARjxYorWlNf9RmZRPAzlgPjukiUV1aTBaeC8YA2S4PhP4PWhNwO/Pb3aCdkifpumpgsm3JULpJiCGOPdBQ==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-line": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.11.4.tgz",
+              "integrity": "sha512-uKX6/1b1OmlqJZOsVDCCDlyc9QItgb39vRssTwP4CJX1NLU4Sfgq2i4VVUbHXCo/I2sMEczjf3cdnxdZtC6IFA==",
+              "requires": {
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-pie": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.11.4.tgz",
+              "integrity": "sha512-EruxP3PIkrTPTzsC5YhiRKg2s+0UtaRU1ZHZUWK8qi+zlbMDFKYg2AlHqsEnctu5AOdOWLLiye6qUG3oxjiURg==",
+              "requires": {
+                "d3-shape": "^1.0.0",
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-scatter": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.11.4.tgz",
+              "integrity": "sha512-8n9rmXmVju2SqA6Xd90rRTmboaU7WStOnj1QUg4q96DDiAVf6kGPdolzCwbUBbiECLyluGoFNJ043WLXztGpiA==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-stack": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.11.4.tgz",
+              "integrity": "sha512-fNTY50fN+DCHcK/9AgMUEq0uJ8IXGnMlRtkSCzMB9ZpEzB7Edx3jLM2Gl970zOkwVaDYXTlikPd1dwf+h3m0dA==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^35.11.4",
+                "victory-shared-events": "^35.11.4"
+              },
+              "dependencies": {
+                "victory-shared-events": {
+                  "version": "35.11.4",
+                  "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+                  "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+                  "requires": {
+                    "json-stringify-safe": "^5.0.1",
+                    "lodash": "^4.17.19",
+                    "prop-types": "^15.5.8",
+                    "react-fast-compare": "^2.0.0",
+                    "victory-core": "^35.11.4"
+                  }
+                }
+              }
+            },
+            "victory-tooltip": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.11.4.tgz",
+              "integrity": "sha512-B+UUqzryurtMghJGiE34tg5eI44vHxyOOcuPIM3IpJLujnNIJXVykBjgQZnFq1CT/63TtDCOlzPkOjSbecPtXQ==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            },
+            "victory-voronoi-container": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.11.4.tgz",
+              "integrity": "sha512-vmwHBm/+nZ9qdRcaNd7r08AVRkus/ER6UA4KAYWkKUe50ZT9NYjDxy0wW/Y7PHQldfL9q/VxAyIE/M6jSFWkEA==",
+              "requires": {
+                "delaunay-find": "0.0.6",
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^35.11.4",
+                "victory-tooltip": "^35.11.4"
+              }
+            },
+            "victory-zoom-container": {
+              "version": "35.11.4",
+              "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.11.4.tgz",
+              "integrity": "sha512-8D4hTdvGZqyZdgWjkz/pDRVy/kijWhptFbK0KWl5J1Tt4YuCGiRC9oxQOpEjlqr8TSyeVnpyuF4QuIp9YOIrAw==",
+              "requires": {
+                "lodash": "^4.17.19",
+                "prop-types": "^15.5.8",
+                "victory-core": "^35.11.4"
+              }
+            }
+          }
+        },
         "@patternfly/react-icons": {
           "version": "3.15.17",
           "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-3.15.17.tgz",
@@ -29905,6 +30066,11 @@
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
           }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -31522,60 +31688,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "@types/d3-array": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
-      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ=="
-    },
-    "@types/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
-    },
-    "@types/d3-ease": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
-    },
-    "@types/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "requires": {
-        "@types/d3-color": "*"
-      }
-    },
-    "@types/d3-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
-    },
-    "@types/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "requires": {
-        "@types/d3-time": "*"
-      }
-    },
-    "@types/d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
-      "requires": {
-        "@types/d3-path": "*"
-      }
-    },
-    "@types/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
-    },
-    "@types/d3-timer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "@types/debounce-promise": {
       "version": "3.1.3",
@@ -34759,81 +34871,82 @@
       }
     },
     "d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
-      "requires": {
-        "internmap": "1 - 2"
-      }
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
     },
     "d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "requires": {
-        "d3-color": "1 - 3"
+        "d3-color": "1"
       }
     },
     "d3-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
-      "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
     },
     "d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
       "requires": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "requires": {
-        "d3-path": "1 - 3"
+        "d3-path": "1"
       }
     },
     "d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
-      "requires": {
-        "d3-array": "2 - 3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "requires": {
-        "d3-time": "1 - 3"
+        "d3-time": "1"
       }
     },
     "d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -37791,11 +37904,6 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
-    },
-    "internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
     },
     "interpret": {
       "version": "2.2.0",
@@ -42548,13 +42656,13 @@
       }
     },
     "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
+        "react-is": "^16.8.1"
       }
     },
     "prop-types-extra": {
@@ -42760,9 +42868,9 @@
       }
     },
     "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-final-form": {
       "version": "6.5.3",
@@ -45857,250 +45965,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "victory-area": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.8.tgz",
-      "integrity": "sha512-aIyMuzUqiDcpTCB7FUOYDJvqiDPiluEXLOw6Lh1vrUYmV7CNqMDOIBtTau2vI41Ao0o0YJdCAcyzBib9e3UYbw==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      }
-    },
-    "victory-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.8.tgz",
-      "integrity": "sha512-tClVJEay1YOJAh9rRyyLx8pei7Sr1/xTz04bJmfzFoAxFoPBtvgfFwXhfZ1YjGIl7m5Wh2CiYMY3figueLzYtg==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-bar": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.8.tgz",
-      "integrity": "sha512-jLLPm3IW8/2uSLPvQD9bxzXnTraUYBIDTkbZPZy7oHP01OVzP1sj+MMHcINCWcUbyUyLZDL3u8CvViXjS273JQ==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      }
-    },
-    "victory-brush-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.8.tgz",
-      "integrity": "sha512-PN5zQ6kjVwZca1qV41WlV6J2IEyQh+2hykRe6c/wERDotVVbSrX3sJVAzUbN+7x2rrK0CL6a/XUI8jDsWTMM2A==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-chart": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.8.tgz",
-      "integrity": "sha512-kC1jL63PAmqUrvZNOfwAXNuaIwz4nvXYUuEPu59WRBCOIGDGRgv2wJ1O7O0xYXqDkI57EtAYf9KUK+miEn/Btg==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-polar-axis": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      }
-    },
-    "victory-core": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.8.tgz",
-      "integrity": "sha512-SkyEszZKGyxjqfptfFWYdI22CvCuE9LhkaDpikzIhT2gcE3SuOBO5fk/740XMYE2ZUsJ4Fu/Vy4+8jZi17y44A==",
-      "requires": {
-        "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.8"
-      }
-    },
-    "victory-create-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.8.tgz",
-      "integrity": "sha512-H2BsdTbJ/RxxcEg5lzk3TDlihtOs7I/5KaIBP3yosPs702i40mL2qndkRkj08QeiZhkaKfQ2GOUvyP+t7DSdmg==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-cursor-container": "^36.6.8",
-        "victory-selection-container": "^36.6.8",
-        "victory-voronoi-container": "^36.6.8",
-        "victory-zoom-container": "^36.6.8"
-      }
-    },
-    "victory-cursor-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.8.tgz",
-      "integrity": "sha512-3WIBRl+7jnZok6syLfW8RK23nliDcoD/JUTN0YZo6bKBqHeFc4+ur3mlwCfghH7sGoxJRYuOJxTd9x2MwM5HQQ==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-group": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.8.tgz",
-      "integrity": "sha512-CiupDIGPPWVgwif3ayd8glSlR41mVbuT0Nl0ay9q42w2fiM32syiJAoifIw47X4tL8ow/DXH+/5Pd8eEyA2trA==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      }
-    },
-    "victory-legend": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.8.tgz",
-      "integrity": "sha512-OnkzB82Mvt5/1LYNsrfZQoXaVvgfp1rCsFRI3imq257Sh/UPy0/eZehCMQs/SVbU0z0EuIpXokhZb3BBdoJgpw==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-line": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.8.tgz",
-      "integrity": "sha512-MozOejQRZPdzFaru5zUfqVB4TEff6nZjtQhOs+F5yyhXjLgM89zGX30r3jK5cjVdAPbTu4KPUrwktvlw+AkPRA==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      }
-    },
-    "victory-pie": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.8.tgz",
-      "integrity": "sha512-dUHWiiKd60dlt7OjFa+YYwanHAkP/T0abzy6O3SFxGre52oeqd8px1EoVhlLKpn4ao8L35koG9mvz6/pGyr8Dw==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      }
-    },
-    "victory-polar-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.8.tgz",
-      "integrity": "sha512-aU+Wp5six21POhI9oXeREnZHljpqcmwFHHnliVGrwgRsuc7TAjfXPWVOX9guEFfh6zQW6IZWWWTTLAN/PIEm9w==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-scatter": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.8.tgz",
-      "integrity": "sha512-GKSNneBxIWLsF3eBSTW5IwT5S4YdsfFl4PVCP3/wTa2myfS5DIS9FufEnJp/FEZGalEXYWxeR47rlWqABxAj5A==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-selection-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.8.tgz",
-      "integrity": "sha512-kudYbSX+o7fr64oeN7+EG/c+lqO22aypxVdCwa6BagAGoqqLR4jXxTqqIdp8tvxCgfCCXxopnTKYr46nubypGw==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-shared-events": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.8.tgz",
-      "integrity": "sha512-hWPOVqMD3Sv6Rl1iyO6ibQrwYF9/eLCnRo0T59/Hsid6On0AJJjL9gv0oEIM5fqz7R7zx9PJmMk877IctEOemw==",
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-stack": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.8.tgz",
-      "integrity": "sha512-Pkux46IqAealOi0KvqQpaJKKKpHCfZ/sh5IeUKYFy+QKWAjiQjG6hFZeHgr2YaS7OfdbvHhoAdvp03KntWzpbw==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      }
-    },
-    "victory-tooltip": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.8.tgz",
-      "integrity": "sha512-9P+QeAGyDpP0trJnQ1NtnbDhpoJB0Ghc2boYEehvL12p0OzolY9/Nq5SDP0tu5i1BBujwFXtnoCDqt+mOH25fA==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      }
-    },
-    "victory-vendor": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.8.tgz",
-      "integrity": "sha512-H3kyQ+2zgjMPvbPqAl7Vwm2FD5dU7/4bCTQakFQnpIsfDljeOMDojRsrmJfwh4oAlNnWhpAf+mbAoLh8u7dwyQ==",
-      "requires": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
-      }
-    },
-    "victory-voronoi-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.8.tgz",
-      "integrity": "sha512-x9/OOZdMm4dh38jNhSfBYT0nG6ribsINU0/WNzIn3QcDXFBInsJ7jRySxYmdmk45OdXfbDRwDMqVHk72sWQyUw==",
-      "requires": {
-        "delaunay-find": "0.0.6",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-tooltip": "^36.6.8"
-      }
-    },
-    "victory-zoom-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.8.tgz",
-      "integrity": "sha512-gxX5iJUaxrFFZ2IGS0sQnUI+3Mhj6bVLqtOlQd3Krld+9f/ieuUbxl+P+eIyhQU/VyHSlirIZeOGOXJeYcU9jQ==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
       }
     },
     "w3c-hr-time": {


### PR DESCRIPTION
Reverts RedHatInsights/insights-chrome#2060

Breaks the download button because the pf charts changed imports in a minor release.

```
WARNING in ./node_modules/@redhat-cloud-services/frontend-components-pdf-generator/dist/esm/index.js 7:144492-144494
export 'getLightThemeColors' (imported as 'Ie') was not found in '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme' (possible exports: __esModule, getAxisTheme, getBulletComparativeErrorMeasureTheme, getBulletComparativeMeasureTheme, getBulletComparativeWarningMeasureTheme, getBulletGroupTitleTheme, getBulletPrimaryDotMeasureTheme, getBulletPrimaryNegativeMeasureTheme, getBulletPrimarySegmentedMeasureTheme, getBulletQualitativeRangeTheme, getBulletTheme, getChartTheme, getCustomTheme, getDonutTheme, getDonutThresholdDynamicTheme, getDonutThresholdStaticTheme, getDonutUtilizationTheme, getTheme, getThemeColors, getThresholdTheme, mergeTheme)
 @ ./src/js/pdf/DownloadButton.js 3:0-97 6:42-63
 @ container entry ./DownloadButton[0]

```