### PR TITLE
Upgrade @sentry/browser to version 7.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@scalprum/core": "^0.2.3",
         "@scalprum/react-core": "^0.2.3",
         "@segment/analytics-next": "^1.38.0",
-        "@sentry/browser": "^6.12.0",
+        "@sentry/browser": "^7.14.1",
         "@unleash/proxy-client-react": "^3.0.0",
         "abortcontroller-polyfill": "^1.7.3",
         "axios": "^0.21.4",
@@ -4446,78 +4446,64 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.12.0.tgz",
-      "integrity": "sha512-wsJi1NLOmfwtPNYxEC50dpDcVY7sdYckzwfqz1/zHrede1mtxpqSw+7iP4bHADOJXuF+ObYYTHND0v38GSXznQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.14.2.tgz",
+      "integrity": "sha512-KGAZ+5lK7gIO2CM3/MAQGY8JtNVCWXRi807lAxndJ3E1oIQb9A0x7b+AJNr1+6jlwf6QESblr92MCLKPHDpNbA==",
       "dependencies": {
-        "@sentry/core": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/core": "7.14.2",
+        "@sentry/types": "7.14.2",
+        "@sentry/utils": "7.14.2",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
-      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.14.2.tgz",
+      "integrity": "sha512-AXcH6nROugziO5KsKSQ9TmAXq6HJa8Fn+kDqAL/sNY65w6YYlHifMO2xHkSXVJxGw7vx9DYh/5SF+KnLn6NDNA==",
       "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "7.14.2",
+        "@sentry/types": "7.14.2",
+        "@sentry/utils": "7.14.2",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
-      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.14.2.tgz",
+      "integrity": "sha512-18cuSesTn9VAF0JC107flLmtCRt/6DBn38uz0G9cPThKtTSNwjGvGZ/ag4J1iq+IDjVS5MA6iTncXOsSpVP2Wg==",
       "dependencies": {
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/types": "7.14.2",
+        "@sentry/utils": "7.14.2",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
-      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
-      "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
-      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.14.2.tgz",
+      "integrity": "sha512-JzkOtenArOXmJBAk/FBbxKKX7XC650HqkhGL4ugT/f+RyxfiDZ0X1TAYMrvKIe+qpn5Nh7JUBfR+BARKAiu2wQ==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
-      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.14.2.tgz",
+      "integrity": "sha512-vpZolN+k1IoxWXhKyOVcRl7V1bgww+96gHqTJdcMzOB83x/ofels7L0kqxb03WukKTYcnc7Ep+yBiKi/OYX9og==",
       "dependencies": {
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "7.14.2",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@simonsmith/cypress-image-snapshot": {
@@ -30276,59 +30262,48 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.12.0.tgz",
-      "integrity": "sha512-wsJi1NLOmfwtPNYxEC50dpDcVY7sdYckzwfqz1/zHrede1mtxpqSw+7iP4bHADOJXuF+ObYYTHND0v38GSXznQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.14.2.tgz",
+      "integrity": "sha512-KGAZ+5lK7gIO2CM3/MAQGY8JtNVCWXRi807lAxndJ3E1oIQb9A0x7b+AJNr1+6jlwf6QESblr92MCLKPHDpNbA==",
       "requires": {
-        "@sentry/core": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/core": "7.14.2",
+        "@sentry/types": "7.14.2",
+        "@sentry/utils": "7.14.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
-      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.14.2.tgz",
+      "integrity": "sha512-AXcH6nROugziO5KsKSQ9TmAXq6HJa8Fn+kDqAL/sNY65w6YYlHifMO2xHkSXVJxGw7vx9DYh/5SF+KnLn6NDNA==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "7.14.2",
+        "@sentry/types": "7.14.2",
+        "@sentry/utils": "7.14.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
-      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.14.2.tgz",
+      "integrity": "sha512-18cuSesTn9VAF0JC107flLmtCRt/6DBn38uz0G9cPThKtTSNwjGvGZ/ag4J1iq+IDjVS5MA6iTncXOsSpVP2Wg==",
       "requires": {
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
-      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
-      "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "7.14.2",
+        "@sentry/utils": "7.14.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
-      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.14.2.tgz",
+      "integrity": "sha512-JzkOtenArOXmJBAk/FBbxKKX7XC650HqkhGL4ugT/f+RyxfiDZ0X1TAYMrvKIe+qpn5Nh7JUBfR+BARKAiu2wQ=="
     },
     "@sentry/utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
-      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.14.2.tgz",
+      "integrity": "sha512-vpZolN+k1IoxWXhKyOVcRl7V1bgww+96gHqTJdcMzOB83x/ofels7L0kqxb03WukKTYcnc7Ep+yBiKi/OYX9og==",
       "requires": {
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "7.14.2",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@scalprum/core": "^0.2.3",
     "@scalprum/react-core": "^0.2.3",
     "@segment/analytics-next": "^1.38.0",
-    "@sentry/browser": "^6.12.0",
+    "@sentry/browser": "^7.14.1",
     "@unleash/proxy-client-react": "^3.0.0",
     "abortcontroller-polyfill": "^1.7.3",
     "axios": "^0.21.4",


### PR DESCRIPTION
This upgrades the @sentry/browser npm package in order to enable performance reports in Sentry dashboard.