### PR TITLE
Add missing aria label to feedback modal.

### DIFF
--- a/src/js/App/Feedback/FeedbackModal.tsx
+++ b/src/js/App/Feedback/FeedbackModal.tsx
@@ -103,7 +103,7 @@ const FeedbackModal = ({ user }: FeedbackModalProps) => {
         <OutlinedCommentsIcon />
         {intl.formatMessage(messages.feedback)}
       </Button>
-      <Modal isOpen={isOpen} className="chr-c-feedback-modal" variant={ModalVariant.medium} onClose={handleCloseModal}>
+      <Modal aria-label="Feedback modal" isOpen={isOpen} className="chr-c-feedback-modal" variant={ModalVariant.medium} onClose={handleCloseModal}>
         <Grid>
           <GridItem span={8} rowSpan={12}>
             <ModalDescription modalPage={modalPage} />


### PR DESCRIPTION
Fixes console error:

```
Modal: Specify at least one of: title, aria-label, aria-labelledby. 
    at Modal (https://console.stage.redhat.com/beta/apps/chrome/js/vendors-node_modules_patternfly_react-core_dist_esm_index_js.8a87bb00baaede7656a9.js:11290:9)
    at FeedbackModal (https://console.stage.redhat.com/beta/apps/chrome/js/src_js_bootstrap_js-src_js_unfetch_index_js-node_modules_redhat-cloud-services_frontend-compo-d86d1e.8a87bb00baaede7656a9.js:4734:26)
    at Route (https://console.stage.redhat.com/beta/apps/chrome/js/vendors-node_modules_react-router_esm_react-router_js.8a87bb00baaede7656a9.js:1104:29)
    at FeedbackRoute (https://console.stage.redhat.com/beta/apps/chrome/js/src_js_bootstrap_js-src_js_unfetch_index_js-node_modules_redhat-cloud-services_frontend-compo-d86d1e.8a87bb00baaede7656a9.js:1227:19)
    at div
```