### PR TITLE
Lock react-charts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@formatjs/cli": "4.2.33",
         "@patternfly/patternfly": "4.210.2",
         "@patternfly/quickstarts": "2.3.1",
+        "@patternfly/react-charts": "6.3.9",
         "@patternfly/react-core": "4.236.6",
         "@patternfly/react-icons": "4.86.7",
         "@patternfly/react-tokens": "4.87.7",
@@ -3498,46 +3499,51 @@
       "integrity": "sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw=="
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "6.94.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.7.tgz",
-      "integrity": "sha512-ZiZMBGxAiTkYTf6p1Jv3GSgv6bxFbn0WtcYuerfB3gOeRi5JUDysciJai6MT/TFuLQmf3bNy3CJ0/b/x/rER2w==",
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
+      "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
       "dependencies": {
-        "@patternfly/react-styles": "^4.91.6",
-        "@patternfly/react-tokens": "^4.93.6",
+        "@patternfly/patternfly": "4.10.31",
+        "@patternfly/react-styles": "^4.3.4",
+        "@patternfly/react-tokens": "^4.4.4",
         "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0",
-        "victory-area": "^36.6.7",
-        "victory-axis": "^36.6.7",
-        "victory-bar": "^36.6.7",
-        "victory-chart": "^36.6.7",
-        "victory-core": "^36.6.7",
-        "victory-create-container": "^36.6.7",
-        "victory-cursor-container": "^36.6.7",
-        "victory-group": "^36.6.7",
-        "victory-legend": "^36.6.7",
-        "victory-line": "^36.6.7",
-        "victory-pie": "^36.6.7",
-        "victory-scatter": "^36.6.7",
-        "victory-stack": "^36.6.7",
-        "victory-tooltip": "^36.6.7",
-        "victory-voronoi-container": "^36.6.7",
-        "victory-zoom-container": "^36.6.7"
+        "lodash": "^4.17.15",
+        "tslib": "^1.11.1",
+        "victory": "^34.3.9",
+        "victory-area": "^34.3.8",
+        "victory-axis": "^34.3.8",
+        "victory-bar": "^34.3.8",
+        "victory-chart": "^34.3.9",
+        "victory-core": "^34.3.8",
+        "victory-create-container": "^34.3.8",
+        "victory-group": "^34.3.9",
+        "victory-legend": "^34.3.8",
+        "victory-line": "^34.3.8",
+        "victory-pie": "^34.3.8",
+        "victory-scatter": "^34.3.8",
+        "victory-stack": "^34.3.9",
+        "victory-tooltip": "^34.3.8",
+        "victory-voronoi-container": "^34.3.8",
+        "victory-zoom-container": "^34.3.8"
       },
       "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
+      }
+    },
+    "node_modules/@patternfly/react-charts/node_modules/@patternfly/patternfly": {
+      "version": "4.10.31",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
+      "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A==",
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
       }
     },
     "node_modules/@patternfly/react-charts/node_modules/@patternfly/react-tokens": {
       "version": "4.93.6",
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
       "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw=="
-    },
-    "node_modules/@patternfly/react-charts/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@patternfly/react-core": {
       "version": "4.236.6",
@@ -7664,60 +7670,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
-      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ=="
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
-    },
     "node_modules/@types/debounce-promise": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.3.tgz",
@@ -11617,114 +11569,87 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-color": "1"
       }
     },
     "node_modules/d3-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
-      "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
     },
     "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
       "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "node_modules/d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-path": "1"
       }
     },
     "node_modules/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-time": "1"
       }
     },
     "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -11967,9 +11892,9 @@
       "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "node_modules/delaunay-find": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
-      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+      "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
       "dependencies": {
         "delaunator": "^4.0.0"
       }
@@ -15360,12 +15285,9 @@
       }
     },
     "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "node_modules/interpret": {
       "version": "2.2.0",
@@ -21828,9 +21750,9 @@
       }
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "node_modules/react-final-form": {
       "version": "6.5.3",
@@ -25663,308 +25585,338 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "node_modules/victory-area": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.8.tgz",
-      "integrity": "sha512-aIyMuzUqiDcpTCB7FUOYDJvqiDPiluEXLOw6Lh1vrUYmV7CNqMDOIBtTau2vI41Ao0o0YJdCAcyzBib9e3UYbw==",
+    "node_modules/victory": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
+      "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "victory-area": "^34.3.12",
+        "victory-axis": "^34.3.12",
+        "victory-bar": "^34.3.12",
+        "victory-box-plot": "^34.3.12",
+        "victory-brush-container": "^34.3.12",
+        "victory-brush-line": "^34.3.12",
+        "victory-candlestick": "^34.3.12",
+        "victory-chart": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-create-container": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-errorbar": "^34.3.12",
+        "victory-group": "^34.3.12",
+        "victory-histogram": "^34.3.12",
+        "victory-legend": "^34.3.12",
+        "victory-line": "^34.3.12",
+        "victory-pie": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-scatter": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-shared-events": "^34.3.12",
+        "victory-stack": "^34.3.12",
+        "victory-tooltip": "^34.3.12",
+        "victory-voronoi": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+      "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.8.tgz",
-      "integrity": "sha512-tClVJEay1YOJAh9rRyyLx8pei7Sr1/xTz04bJmfzFoAxFoPBtvgfFwXhfZ1YjGIl7m5Wh2CiYMY3figueLzYtg==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+      "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-bar": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.8.tgz",
-      "integrity": "sha512-jLLPm3IW8/2uSLPvQD9bxzXnTraUYBIDTkbZPZy7oHP01OVzP1sj+MMHcINCWcUbyUyLZDL3u8CvViXjS273JQ==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+      "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
+      "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-brush-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.8.tgz",
-      "integrity": "sha512-PN5zQ6kjVwZca1qV41WlV6J2IEyQh+2hykRe6c/wERDotVVbSrX3sJVAzUbN+7x2rrK0CL6a/XUI8jDsWTMM2A==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+      "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
+      "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
+      "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-chart": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.8.tgz",
-      "integrity": "sha512-kC1jL63PAmqUrvZNOfwAXNuaIwz4nvXYUuEPu59WRBCOIGDGRgv2wJ1O7O0xYXqDkI57EtAYf9KUK+miEn/Btg==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+      "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-polar-axis": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
       }
     },
     "node_modules/victory-core": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.8.tgz",
-      "integrity": "sha512-SkyEszZKGyxjqfptfFWYdI22CvCuE9LhkaDpikzIhT2gcE3SuOBO5fk/740XMYE2ZUsJ4Fu/Vy4+8jZi17y44A==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
       "dependencies": {
-        "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
       }
     },
     "node_modules/victory-create-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.8.tgz",
-      "integrity": "sha512-H2BsdTbJ/RxxcEg5lzk3TDlihtOs7I/5KaIBP3yosPs702i40mL2qndkRkj08QeiZhkaKfQ2GOUvyP+t7DSdmg==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+      "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-cursor-container": "^36.6.8",
-        "victory-selection-container": "^36.6.8",
-        "victory-voronoi-container": "^36.6.8",
-        "victory-zoom-container": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "victory-brush-container": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
       }
     },
     "node_modules/victory-cursor-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.8.tgz",
-      "integrity": "sha512-3WIBRl+7jnZok6syLfW8RK23nliDcoD/JUTN0YZo6bKBqHeFc4+ur3mlwCfghH7sGoxJRYuOJxTd9x2MwM5HQQ==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+      "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
+      "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-group": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.8.tgz",
-      "integrity": "sha512-CiupDIGPPWVgwif3ayd8glSlR41mVbuT0Nl0ay9q42w2fiM32syiJAoifIw47X4tL8ow/DXH+/5Pd8eEyA2trA==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+      "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
+      "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
+      "dependencies": {
+        "d3-array": "^2.4.0",
+        "d3-scale": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-bar": "^34.3.12",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
       }
     },
     "node_modules/victory-legend": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.8.tgz",
-      "integrity": "sha512-OnkzB82Mvt5/1LYNsrfZQoXaVvgfp1rCsFRI3imq257Sh/UPy0/eZehCMQs/SVbU0z0EuIpXokhZb3BBdoJgpw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+      "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-line": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.8.tgz",
-      "integrity": "sha512-MozOejQRZPdzFaru5zUfqVB4TEff6nZjtQhOs+F5yyhXjLgM89zGX30r3jK5cjVdAPbTu4KPUrwktvlw+AkPRA==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+      "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-pie": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.8.tgz",
-      "integrity": "sha512-dUHWiiKd60dlt7OjFa+YYwanHAkP/T0abzy6O3SFxGre52oeqd8px1EoVhlLKpn4ao8L35koG9mvz6/pGyr8Dw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+      "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-polar-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.8.tgz",
-      "integrity": "sha512-aU+Wp5six21POhI9oXeREnZHljpqcmwFHHnliVGrwgRsuc7TAjfXPWVOX9guEFfh6zQW6IZWWWTTLAN/PIEm9w==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+      "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-scatter": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.8.tgz",
-      "integrity": "sha512-GKSNneBxIWLsF3eBSTW5IwT5S4YdsfFl4PVCP3/wTa2myfS5DIS9FufEnJp/FEZGalEXYWxeR47rlWqABxAj5A==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+      "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-selection-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.8.tgz",
-      "integrity": "sha512-kudYbSX+o7fr64oeN7+EG/c+lqO22aypxVdCwa6BagAGoqqLR4jXxTqqIdp8tvxCgfCCXxopnTKYr46nubypGw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+      "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-shared-events": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.8.tgz",
-      "integrity": "sha512-hWPOVqMD3Sv6Rl1iyO6ibQrwYF9/eLCnRo0T59/Hsid6On0AJJjL9gv0oEIM5fqz7R7zx9PJmMk877IctEOemw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+      "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
       "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-stack": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.8.tgz",
-      "integrity": "sha512-Pkux46IqAealOi0KvqQpaJKKKpHCfZ/sh5IeUKYFy+QKWAjiQjG6hFZeHgr2YaS7OfdbvHhoAdvp03KntWzpbw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+      "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
       }
     },
     "node_modules/victory-tooltip": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.8.tgz",
-      "integrity": "sha512-9P+QeAGyDpP0trJnQ1NtnbDhpoJB0Ghc2boYEehvL12p0OzolY9/Nq5SDP0tu5i1BBujwFXtnoCDqt+mOH25fA==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+      "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
-    "node_modules/victory-vendor": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.8.tgz",
-      "integrity": "sha512-H3kyQ+2zgjMPvbPqAl7Vwm2FD5dU7/4bCTQakFQnpIsfDljeOMDojRsrmJfwh4oAlNnWhpAf+mbAoLh8u7dwyQ==",
+    "node_modules/victory-voronoi": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
+      "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
       "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-voronoi-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.8.tgz",
-      "integrity": "sha512-x9/OOZdMm4dh38jNhSfBYT0nG6ribsINU0/WNzIn3QcDXFBInsJ7jRySxYmdmk45OdXfbDRwDMqVHk72sWQyUw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+      "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
       "dependencies": {
-        "delaunay-find": "0.0.6",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-tooltip": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "delaunay-find": "0.0.5",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-tooltip": "^34.3.12"
       }
     },
     "node_modules/victory-zoom-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.8.tgz",
-      "integrity": "sha512-gxX5iJUaxrFFZ2IGS0sQnUI+3Mhj6bVLqtOlQd3Krld+9f/ieuUbxl+P+eIyhQU/VyHSlirIZeOGOXJeYcU9jQ==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+      "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -29540,42 +29492,43 @@
       }
     },
     "@patternfly/react-charts": {
-      "version": "6.94.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.7.tgz",
-      "integrity": "sha512-ZiZMBGxAiTkYTf6p1Jv3GSgv6bxFbn0WtcYuerfB3gOeRi5JUDysciJai6MT/TFuLQmf3bNy3CJ0/b/x/rER2w==",
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
+      "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
       "requires": {
-        "@patternfly/react-styles": "^4.91.6",
-        "@patternfly/react-tokens": "^4.93.6",
+        "@patternfly/patternfly": "4.10.31",
+        "@patternfly/react-styles": "^4.3.4",
+        "@patternfly/react-tokens": "^4.4.4",
         "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0",
-        "victory-area": "^36.6.7",
-        "victory-axis": "^36.6.7",
-        "victory-bar": "^36.6.7",
-        "victory-chart": "^36.6.7",
-        "victory-core": "^36.6.7",
-        "victory-create-container": "^36.6.7",
-        "victory-cursor-container": "^36.6.7",
-        "victory-group": "^36.6.7",
-        "victory-legend": "^36.6.7",
-        "victory-line": "^36.6.7",
-        "victory-pie": "^36.6.7",
-        "victory-scatter": "^36.6.7",
-        "victory-stack": "^36.6.7",
-        "victory-tooltip": "^36.6.7",
-        "victory-voronoi-container": "^36.6.7",
-        "victory-zoom-container": "^36.6.7"
+        "lodash": "^4.17.15",
+        "tslib": "^1.11.1",
+        "victory": "^34.3.9",
+        "victory-area": "^34.3.8",
+        "victory-axis": "^34.3.8",
+        "victory-bar": "^34.3.8",
+        "victory-chart": "^34.3.9",
+        "victory-core": "^34.3.8",
+        "victory-create-container": "^34.3.8",
+        "victory-group": "^34.3.9",
+        "victory-legend": "^34.3.8",
+        "victory-line": "^34.3.8",
+        "victory-pie": "^34.3.8",
+        "victory-scatter": "^34.3.8",
+        "victory-stack": "^34.3.9",
+        "victory-tooltip": "^34.3.8",
+        "victory-voronoi-container": "^34.3.8",
+        "victory-zoom-container": "^34.3.8"
       },
       "dependencies": {
+        "@patternfly/patternfly": {
+          "version": "4.10.31",
+          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
+          "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A=="
+        },
         "@patternfly/react-tokens": {
           "version": "4.93.6",
           "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
           "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -31599,60 +31552,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "@types/d3-array": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
-      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ=="
-    },
-    "@types/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
-    },
-    "@types/d3-ease": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
-    },
-    "@types/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "requires": {
-        "@types/d3-color": "*"
-      }
-    },
-    "@types/d3-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
-    },
-    "@types/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "requires": {
-        "@types/d3-time": "*"
-      }
-    },
-    "@types/d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
-      "requires": {
-        "@types/d3-path": "*"
-      }
-    },
-    "@types/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
-    },
-    "@types/d3-timer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "@types/debounce-promise": {
       "version": "3.1.3",
@@ -34786,81 +34685,87 @@
       }
     },
     "d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
-      "requires": {
-        "internmap": "1 - 2"
-      }
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
     },
     "d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "requires": {
-        "d3-color": "1 - 3"
+        "d3-color": "1"
       }
     },
     "d3-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
-      "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
     },
     "d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
       "requires": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "d3-shape": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
-      "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "requires": {
-        "d3-path": "1 - 3"
+        "d3-path": "1"
       }
     },
     "d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
-      "requires": {
-        "d3-array": "2 - 3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "requires": {
-        "d3-time": "1 - 3"
+        "d3-time": "1"
       }
     },
     "d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -35054,9 +34959,9 @@
       "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "delaunay-find": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
-      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+      "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
       "requires": {
         "delaunator": "^4.0.0"
       }
@@ -37793,9 +37698,9 @@
       }
     },
     "internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "interpret": {
       "version": "2.2.0",
@@ -42720,9 +42625,9 @@
       }
     },
     "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-final-form": {
       "version": "6.5.3",
@@ -45796,248 +45701,340 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "victory-area": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.8.tgz",
-      "integrity": "sha512-aIyMuzUqiDcpTCB7FUOYDJvqiDPiluEXLOw6Lh1vrUYmV7CNqMDOIBtTau2vI41Ao0o0YJdCAcyzBib9e3UYbw==",
+    "victory": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
+      "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
+        "victory-area": "^34.3.12",
+        "victory-axis": "^34.3.12",
+        "victory-bar": "^34.3.12",
+        "victory-box-plot": "^34.3.12",
+        "victory-brush-container": "^34.3.12",
+        "victory-brush-line": "^34.3.12",
+        "victory-candlestick": "^34.3.12",
+        "victory-chart": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-create-container": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-errorbar": "^34.3.12",
+        "victory-group": "^34.3.12",
+        "victory-histogram": "^34.3.12",
+        "victory-legend": "^34.3.12",
+        "victory-line": "^34.3.12",
+        "victory-pie": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-scatter": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-shared-events": "^34.3.12",
+        "victory-stack": "^34.3.12",
+        "victory-tooltip": "^34.3.12",
+        "victory-voronoi": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
+      }
+    },
+    "victory-area": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+      "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.8.tgz",
-      "integrity": "sha512-tClVJEay1YOJAh9rRyyLx8pei7Sr1/xTz04bJmfzFoAxFoPBtvgfFwXhfZ1YjGIl7m5Wh2CiYMY3figueLzYtg==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+      "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-bar": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.8.tgz",
-      "integrity": "sha512-jLLPm3IW8/2uSLPvQD9bxzXnTraUYBIDTkbZPZy7oHP01OVzP1sj+MMHcINCWcUbyUyLZDL3u8CvViXjS273JQ==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+      "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "victory-box-plot": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
+      "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-brush-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.8.tgz",
-      "integrity": "sha512-PN5zQ6kjVwZca1qV41WlV6J2IEyQh+2hykRe6c/wERDotVVbSrX3sJVAzUbN+7x2rrK0CL6a/XUI8jDsWTMM2A==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+      "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "victory-brush-line": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
+      "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "victory-candlestick": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
+      "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-chart": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.8.tgz",
-      "integrity": "sha512-kC1jL63PAmqUrvZNOfwAXNuaIwz4nvXYUuEPu59WRBCOIGDGRgv2wJ1O7O0xYXqDkI57EtAYf9KUK+miEn/Btg==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+      "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-polar-axis": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
       }
     },
     "victory-core": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.8.tgz",
-      "integrity": "sha512-SkyEszZKGyxjqfptfFWYdI22CvCuE9LhkaDpikzIhT2gcE3SuOBO5fk/740XMYE2ZUsJ4Fu/Vy4+8jZi17y44A==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
       "requires": {
-        "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.8"
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
       }
     },
     "victory-create-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.8.tgz",
-      "integrity": "sha512-H2BsdTbJ/RxxcEg5lzk3TDlihtOs7I/5KaIBP3yosPs702i40mL2qndkRkj08QeiZhkaKfQ2GOUvyP+t7DSdmg==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+      "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
       "requires": {
-        "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.8",
-        "victory-core": "^36.6.8",
-        "victory-cursor-container": "^36.6.8",
-        "victory-selection-container": "^36.6.8",
-        "victory-voronoi-container": "^36.6.8",
-        "victory-zoom-container": "^36.6.8"
+        "lodash": "^4.17.15",
+        "victory-brush-container": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
       }
     },
     "victory-cursor-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.8.tgz",
-      "integrity": "sha512-3WIBRl+7jnZok6syLfW8RK23nliDcoD/JUTN0YZo6bKBqHeFc4+ur3mlwCfghH7sGoxJRYuOJxTd9x2MwM5HQQ==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+      "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "victory-errorbar": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
+      "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-group": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.8.tgz",
-      "integrity": "sha512-CiupDIGPPWVgwif3ayd8glSlR41mVbuT0Nl0ay9q42w2fiM32syiJAoifIw47X4tL8ow/DXH+/5Pd8eEyA2trA==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+      "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "victory-histogram": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
+      "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
+      "requires": {
+        "d3-array": "^2.4.0",
+        "d3-scale": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-bar": "^34.3.12",
+        "victory-core": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        }
       }
     },
     "victory-legend": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.8.tgz",
-      "integrity": "sha512-OnkzB82Mvt5/1LYNsrfZQoXaVvgfp1rCsFRI3imq257Sh/UPy0/eZehCMQs/SVbU0z0EuIpXokhZb3BBdoJgpw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+      "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-line": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.8.tgz",
-      "integrity": "sha512-MozOejQRZPdzFaru5zUfqVB4TEff6nZjtQhOs+F5yyhXjLgM89zGX30r3jK5cjVdAPbTu4KPUrwktvlw+AkPRA==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+      "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-pie": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.8.tgz",
-      "integrity": "sha512-dUHWiiKd60dlt7OjFa+YYwanHAkP/T0abzy6O3SFxGre52oeqd8px1EoVhlLKpn4ao8L35koG9mvz6/pGyr8Dw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+      "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8",
-        "victory-vendor": "^36.6.8"
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-polar-axis": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.8.tgz",
-      "integrity": "sha512-aU+Wp5six21POhI9oXeREnZHljpqcmwFHHnliVGrwgRsuc7TAjfXPWVOX9guEFfh6zQW6IZWWWTTLAN/PIEm9w==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+      "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-scatter": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.8.tgz",
-      "integrity": "sha512-GKSNneBxIWLsF3eBSTW5IwT5S4YdsfFl4PVCP3/wTa2myfS5DIS9FufEnJp/FEZGalEXYWxeR47rlWqABxAj5A==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+      "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-selection-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.8.tgz",
-      "integrity": "sha512-kudYbSX+o7fr64oeN7+EG/c+lqO22aypxVdCwa6BagAGoqqLR4jXxTqqIdp8tvxCgfCCXxopnTKYr46nubypGw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+      "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-shared-events": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.8.tgz",
-      "integrity": "sha512-hWPOVqMD3Sv6Rl1iyO6ibQrwYF9/eLCnRo0T59/Hsid6On0AJJjL9gv0oEIM5fqz7R7zx9PJmMk877IctEOemw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+      "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
       "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-stack": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.8.tgz",
-      "integrity": "sha512-Pkux46IqAealOi0KvqQpaJKKKpHCfZ/sh5IeUKYFy+QKWAjiQjG6hFZeHgr2YaS7OfdbvHhoAdvp03KntWzpbw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+      "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-shared-events": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
       }
     },
     "victory-tooltip": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.8.tgz",
-      "integrity": "sha512-9P+QeAGyDpP0trJnQ1NtnbDhpoJB0Ghc2boYEehvL12p0OzolY9/Nq5SDP0tu5i1BBujwFXtnoCDqt+mOH25fA==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+      "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
-    "victory-vendor": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.8.tgz",
-      "integrity": "sha512-H3kyQ+2zgjMPvbPqAl7Vwm2FD5dU7/4bCTQakFQnpIsfDljeOMDojRsrmJfwh4oAlNnWhpAf+mbAoLh8u7dwyQ==",
+    "victory-voronoi": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
+      "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
       "requires": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "victory-voronoi-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.8.tgz",
-      "integrity": "sha512-x9/OOZdMm4dh38jNhSfBYT0nG6ribsINU0/WNzIn3QcDXFBInsJ7jRySxYmdmk45OdXfbDRwDMqVHk72sWQyUw==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+      "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
       "requires": {
-        "delaunay-find": "0.0.6",
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.8",
-        "victory-tooltip": "^36.6.8"
+        "delaunay-find": "0.0.5",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-tooltip": "^34.3.12"
       }
     },
     "victory-zoom-container": {
-      "version": "36.6.8",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.8.tgz",
-      "integrity": "sha512-gxX5iJUaxrFFZ2IGS0sQnUI+3Mhj6bVLqtOlQd3Krld+9f/ieuUbxl+P+eIyhQU/VyHSlirIZeOGOXJeYcU9jQ==",
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+      "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
       "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.8"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "@patternfly/patternfly": "4.210.2",
     "@patternfly/quickstarts": "2.3.1",
     "@patternfly/react-core": "4.236.6",
+    "@patternfly/react-charts": "6.3.9",
     "@patternfly/react-icons": "4.86.7",
     "@patternfly/react-tokens": "4.87.7",
     "@redhat-cloud-services/entitlements-client": "1.0.101",


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-22517

The react-chars made a breaking change in a minor release by removing some exports. We need to lock the version of the charts until we migrate away from the UI PDF generator