### PR TITLE
Add react-chars override for missing export.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -39,6 +39,8 @@ const commonConfig = ({ dev }) => {
         ...imageNullLoader(),
         // do not consume unfetch from nested dependencies
         unfetch: path.resolve(__dirname, '../src/js/unfetch'),
+        // charts override for the PDF renderer
+        '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme': path.resolve(__dirname, '../src/js/overrides/chart-utils-override.js'),
         '@scalprum/core': path.resolve(__dirname, '../node_modules/@scalprum/core'),
         '@scalprum/react-core': path.resolve(__dirname, '../node_modules/@scalprum/react-core'),
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@formatjs/cli": "4.2.33",
         "@patternfly/patternfly": "4.210.2",
         "@patternfly/quickstarts": "2.3.1",
-        "@patternfly/react-core": "4.236.6",
+        "@patternfly/react-core": "4.250.1",
         "@patternfly/react-icons": "4.86.7",
         "@patternfly/react-tokens": "4.87.7",
         "@redhat-cloud-services/entitlements-client": "1.0.101",
@@ -3540,36 +3540,36 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.236.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.236.6.tgz",
-      "integrity": "sha512-mZIAo2qrHInyrS6Ex98v0ETTwV1vZ8FuiAqqSmcfXo3lz3pTFK52MLOUnYIFPtrDYQ4UAHTX2VKNx88/5/JlAA==",
+      "version": "4.250.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.250.1.tgz",
+      "integrity": "sha512-vAOZPQdZzYXl/vkHnHMIt1eC3nrPDdsuuErPatkNPwmSvilXuXmWP5wxoJ36FbSNRRURkprFwx52zMmWS3iHJA==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.87.6",
-        "@patternfly/react-styles": "^4.86.6",
-        "@patternfly/react-tokens": "^4.88.6",
+        "@patternfly/react-icons": "^4.92.6",
+        "@patternfly/react-styles": "^4.91.6",
+        "@patternfly/react-tokens": "^4.93.6",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-core/node_modules/@patternfly/react-icons": {
-      "version": "4.87.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.87.6.tgz",
-      "integrity": "sha512-z5amUcPDYkdn1kJct0nA9iYgtRS0yH/SVrvfV8NN/A4zH9Vzw0IOb3lEfehnAHk2AY0C7lxxPI1VNktbXMNb9g==",
+      "version": "4.92.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.92.6.tgz",
+      "integrity": "sha512-UdMSDqJ7fCxi/E6vlsFHuDZ3L0+kqBZ4ujRi4mjokrsvzOR4WFdaMhC+7iRy4aPNjT0DpHVjVUUUoWwKID9VqA==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-core/node_modules/@patternfly/react-tokens": {
-      "version": "4.88.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.88.6.tgz",
-      "integrity": "sha512-UGCR8xdAFJWlZiew5Hgc6j/fmVLEIqKd1Fu2Ytw1u5MvGKalRtYvcafgAVYlLLSzR1aou3HJ4b6oTfGfzKcpVg=="
+      "version": "4.93.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
+      "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw=="
     },
     "node_modules/@patternfly/react-core/node_modules/tslib": {
       "version": "2.3.1",
@@ -3601,25 +3601,6 @@
         "@patternfly/react-styles": "^4.91.6",
         "@patternfly/react-tokens": "^4.93.6",
         "lodash": "^4.17.19",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
-    },
-    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
-      "version": "4.250.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.250.1.tgz",
-      "integrity": "sha512-vAOZPQdZzYXl/vkHnHMIt1eC3nrPDdsuuErPatkNPwmSvilXuXmWP5wxoJ36FbSNRRURkprFwx52zMmWS3iHJA==",
-      "peer": true,
-      "dependencies": {
-        "@patternfly/react-icons": "^4.92.6",
-        "@patternfly/react-styles": "^4.91.6",
-        "@patternfly/react-tokens": "^4.93.6",
-        "focus-trap": "6.9.2",
-        "react-dropzone": "9.0.0",
-        "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
@@ -29580,13 +29561,13 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.236.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.236.6.tgz",
-      "integrity": "sha512-mZIAo2qrHInyrS6Ex98v0ETTwV1vZ8FuiAqqSmcfXo3lz3pTFK52MLOUnYIFPtrDYQ4UAHTX2VKNx88/5/JlAA==",
+      "version": "4.250.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.250.1.tgz",
+      "integrity": "sha512-vAOZPQdZzYXl/vkHnHMIt1eC3nrPDdsuuErPatkNPwmSvilXuXmWP5wxoJ36FbSNRRURkprFwx52zMmWS3iHJA==",
       "requires": {
-        "@patternfly/react-icons": "^4.87.6",
-        "@patternfly/react-styles": "^4.86.6",
-        "@patternfly/react-tokens": "^4.88.6",
+        "@patternfly/react-icons": "^4.92.6",
+        "@patternfly/react-styles": "^4.91.6",
+        "@patternfly/react-tokens": "^4.93.6",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -29594,15 +29575,15 @@
       },
       "dependencies": {
         "@patternfly/react-icons": {
-          "version": "4.87.6",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.87.6.tgz",
-          "integrity": "sha512-z5amUcPDYkdn1kJct0nA9iYgtRS0yH/SVrvfV8NN/A4zH9Vzw0IOb3lEfehnAHk2AY0C7lxxPI1VNktbXMNb9g==",
+          "version": "4.92.6",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.92.6.tgz",
+          "integrity": "sha512-UdMSDqJ7fCxi/E6vlsFHuDZ3L0+kqBZ4ujRi4mjokrsvzOR4WFdaMhC+7iRy4aPNjT0DpHVjVUUUoWwKID9VqA==",
           "requires": {}
         },
         "@patternfly/react-tokens": {
-          "version": "4.88.6",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.88.6.tgz",
-          "integrity": "sha512-UGCR8xdAFJWlZiew5Hgc6j/fmVLEIqKd1Fu2Ytw1u5MvGKalRtYvcafgAVYlLLSzR1aou3HJ4b6oTfGfzKcpVg=="
+          "version": "4.93.6",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
+          "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw=="
         },
         "tslib": {
           "version": "2.3.1",
@@ -29636,21 +29617,6 @@
         "tslib": "^2.0.0"
       },
       "dependencies": {
-        "@patternfly/react-core": {
-          "version": "4.250.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.250.1.tgz",
-          "integrity": "sha512-vAOZPQdZzYXl/vkHnHMIt1eC3nrPDdsuuErPatkNPwmSvilXuXmWP5wxoJ36FbSNRRURkprFwx52zMmWS3iHJA==",
-          "peer": true,
-          "requires": {
-            "@patternfly/react-icons": "^4.92.6",
-            "@patternfly/react-styles": "^4.91.6",
-            "@patternfly/react-tokens": "^4.93.6",
-            "focus-trap": "6.9.2",
-            "react-dropzone": "9.0.0",
-            "tippy.js": "5.1.2",
-            "tslib": "^2.0.0"
-          }
-        },
         "@patternfly/react-icons": {
           "version": "4.92.6",
           "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.92.6.tgz",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "@formatjs/cli": "4.2.33",
     "@patternfly/patternfly": "4.210.2",
     "@patternfly/quickstarts": "2.3.1",
-    "@patternfly/react-core": "4.236.6",
+    "@patternfly/react-core": "4.250.1",
     "@patternfly/react-icons": "4.86.7",
     "@patternfly/react-tokens": "4.87.7",
     "@redhat-cloud-services/entitlements-client": "1.0.101",

--- a/src/js/overrides/chart-utils-override.js
+++ b/src/js/overrides/chart-utils-override.js
@@ -1,0 +1,4 @@
+export * from '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme';
+import { getThemeColors as getThemeColorsInternal } from '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme';
+export const getThemeColors = getThemeColorsInternal;
+export const getLightThemeColors = getThemeColorsInternal;


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-22517

The react-chars made a breaking change in a minor release by removing some exports. We need to override the module until we migrate away from the UI PDF generator

We can't release new PDF module as we will never make the peer dependencies work with npm@8