### PR TITLE
chore: Reduce sample rate for sentry transactions

### DIFF
--- a/src/js/sentry.ts
+++ b/src/js/sentry.ts
@@ -73,7 +73,7 @@ function initSentry() {
     maxBreadcrumbs: 50,
     attachStacktrace: true,
     integrations: [new BrowserTracing()],
-    tracesSampleRate: 0.5, // send only every second transaction to Sentry
+    tracesSampleRate: 0.1,
   });
 }
 


### PR DESCRIPTION
This PR changes the `sampleRate` to 0.1 for sentry transactions. The reason is that we are possibly exceeding our plan limits very fast for transactions. Transactions are counted independently to errors.