### PR TITLE
fix: Clone response before accessing the body

### DIFF
--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -83,20 +83,17 @@ function init(store: Store) {
     }
     return prom
       .then(async (res) => {
+        const resCloned = res.clone();
         if (!res.ok) {
           try {
-            const isJson = res?.headers?.get('content-type')?.includes('application/json');
-            const data = isJson ? await res.json() : await res.text();
+            const isJson = resCloned?.headers?.get('content-type')?.includes('application/json');
+            const data = isJson ? await resCloned.json() : await resCloned.text();
             const gatewayError = get3scaleError(data);
             if (gatewayError) {
               store.dispatch(setGatewayError(gatewayError));
             }
 
-            return {
-              ...res,
-              headers: res.headers,
-              ...(isJson ? { json: () => Promise.resolve(data) } : { text: () => Promise.resolve(data) }),
-            };
+            return res;
           } catch (error) {
             console.error('unable to check unauthotized response', error);
             return res;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPADVISOR-57.

## Description

It is expected that `window.fetch` returns an object which complies with [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) interface, and that the response body is accessible only once (https://github.com/whatwg/fetch/issues/196#issuecomment-171935172). However, the current implementation of `fetch` polyfill violates this contract, and, specifically, causes a bug in OCP Advisor, where rtk-query library cannot read the response properly.  

This makes the window.fetch polyfill 1) explicitly [clone](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone) the response body from the API request, 2) and eventually return the instance of Response object. This lets further consumers to access the response body (libraries, Insights applications code) in case of the response with error code.