### PR TITLE
Decrease sample rate to meet transaction quotas

### DIFF
--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -73,7 +73,7 @@ function initSentry() {
     maxBreadcrumbs: 50,
     attachStacktrace: true,
     integrations: [new BrowserTracing()],
-    tracesSampleRate: 0.1,
+    tracesSampleRate: 0.007,
   });
 }
 


### PR DESCRIPTION
This reduces `tracesSampleRate` to 0.007 to accommodate the current month quotas for the Insights project.