### PR TITLE
Add option to append filtered help topics.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.24",
-        "@redhat-cloud-services/types": "^0.0.16",
+        "@redhat-cloud-services/types": "^0.0.17",
         "@simonsmith/cypress-image-snapshot": "^5.0.4",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.0.0",
@@ -4153,9 +4153,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/types": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.16.tgz",
-      "integrity": "sha512-JtIAPT1ZJzgwUvttWjtxe3ufMhUJ0upapJ7yi/MLKFhC46B5X2ht7hgbgIeCv5Nf7QLc8TDsSUXqqr9L93Ek5A==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
+      "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg==",
       "dev": true
     },
     "node_modules/@remix-run/router": {
@@ -30239,9 +30239,9 @@
       }
     },
     "@redhat-cloud-services/types": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.16.tgz",
-      "integrity": "sha512-JtIAPT1ZJzgwUvttWjtxe3ufMhUJ0upapJ7yi/MLKFhC46B5X2ht7hgbgIeCv5Nf7QLc8TDsSUXqqr9L93Ek5A==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
+      "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg==",
       "dev": true
     },
     "@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
     "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.24",
-    "@redhat-cloud-services/types": "^0.0.16",
+    "@redhat-cloud-services/types": "^0.0.17",
     "@simonsmith/cypress-image-snapshot": "^5.0.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.0.0",

--- a/src/chrome/create-chrome.ts
+++ b/src/chrome/create-chrome.ts
@@ -91,8 +91,7 @@ export const createChromeContext = ({
     ...actions,
     auth: createAuthObject(libJwt, getUser, store, modulesConfig),
     initialized: true,
-    // FIXME: Remove typecasting after types package update
-    isProd: isProd as unknown as boolean,
+    isProd,
     forceDemo: () => Cookies.set('cs_demo', 'true'),
     getBundle: () => getUrl('bundle'),
     getApp: () => getUrl('app'),

--- a/src/utils/createCase.ts
+++ b/src/utils/createCase.ts
@@ -3,7 +3,7 @@ import logger from '../jwt/logger';
 import URI from 'urijs';
 const log = logger('createCase.js');
 
-import { getEnvDetails, getUrl, isBeta } from './common';
+import { getEnvDetails, getUrl, isBeta, isProd } from './common';
 import { HYDRA_ENDPOINT } from './consts';
 import { spinUpStore } from '../redux/redux-config';
 import { ChromeUser } from '@redhat-cloud-services/types';
@@ -119,7 +119,7 @@ export async function createSupportCase(
 }
 
 function createSupportSentry(session: string, fields?: any) {
-  if (window.insights.chrome.isProd) {
+  if (isProd()) {
     log('Capturing support case information in Sentry');
     // this should capture the app information anyway, so no need to pass extra data
     Sentry.captureException(new Error('Support case created'), {


### PR DESCRIPTION
By using object argument, developers can now choose to append new help topics to a list, instead of replacing it.

```js
// will append
enableTopics({names: ['foo', 'bar'], append: true})
// will replace
enableTopics('foo', 'bar')
```