### PR TITLE
fix: Clone response before accessing the body

### DIFF
--- a/src/js/chrome/iqeEnablement.ts
+++ b/src/js/chrome/iqeEnablement.ts
@@ -83,20 +83,17 @@ function init(store: Store) {
     }
     return prom
       .then(async (res) => {
+        const resCloned = res.clone();
         if (!res.ok) {
           try {
-            const isJson = res?.headers?.get('content-type')?.includes('application/json');
-            const data = isJson ? await res.json() : await res.text();
+            const isJson = resCloned?.headers?.get('content-type')?.includes('application/json');
+            const data = isJson ? await resCloned.json() : await resCloned.text();
             const gatewayError = get3scaleError(data);
             if (gatewayError) {
               store.dispatch(setGatewayError(gatewayError));
             }
 
-            return {
-              ...res,
-              headers: res.headers,
-              ...(isJson ? { json: () => Promise.resolve(data) } : { text: () => Promise.resolve(data) }),
-            };
+            return res;
           } catch (error) {
             console.error('unable to check unauthotized response', error);
             return res;


### PR DESCRIPTION
This 1) makes the window.fetch polyfill explicitly clone the response body from the API request, 2) and eventually return the instance of Response object. This ensures the polyfill returns an instance of Response, and also lets further consumers to access the response body (libraries, Insights applications code).