### PR TITLE
Print sentry debug info, adjust tracesSampleRate

### DIFF
--- a/src/utils/debugFunctions.ts
+++ b/src/utils/debugFunctions.ts
@@ -21,6 +21,7 @@ const debugFunctions = {
   darkMode: () => functionBuilder('chrome:darkmode', true),
   segmentDev: () => functionBuilder('chrome:analytics:dev', true),
   intlDebug: () => functionBuilder('chrome:intl:debug', true),
+  sentryDebug: () => functionBuilder('chrome:sentry:debug', true),
 };
 
 export default debugFunctions;

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -73,7 +73,8 @@ function initSentry() {
     maxBreadcrumbs: 50,
     attachStacktrace: true,
     integrations: [new BrowserTracing()],
-    tracesSampleRate: 0.007,
+    tracesSampleRate: 0.2,
+    debug: !!window.localStorage.getItem('chrome:sentry:debug'),
   });
 }
 


### PR DESCRIPTION
This increases the value for `tracesSampleRate` to accept more transactions. Also, I propose to enable debug information in console. 

This is due to some unexpected behavior we experience in production: less we set the value, more transactions start to come. Documentation states the opposite behavior to be expected, and we were asked by Sentry support to set the higher value with the 1/10 precision. The debug info must not cause any safety concerns: https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#debug.
