### PR TITLE
add segment prod & dev keys for stone soup

### DIFF
--- a/src/analytics/SegmentProvider.tsx
+++ b/src/analytics/SegmentProvider.tsx
@@ -49,10 +49,12 @@ const getAPIKey = (env: SegmentEnvs = 'dev', module: SegmentModules, moduleAPIKe
   {
     prod: {
       acs: '9NmgZh57uEaOW9ePKqeKjjUKE8MEqaVU',
+      hacCore: 'cLLG3VVakAECyGRAUnmjRkSqGJkYlRWI',
       openshift: 'z3Ic4EtzJtHrhXfpKgViJmf2QurSxXb9',
     },
     dev: {
       acs: 'CA5jdEouFKAxwGq7X9i1b7UySMKshj1j',
+      hacCore: '5SuWCF4fRqTzMD8HVsk2r1LEYsYVsHCC',
       openshift: 'A8iCO9n9Ax9ObvHBgz4hMC9htKB0AdKj',
     },
   }[env]?.[module] ||


### PR DESCRIPTION
Adding new segment keys for stone soup. Stone soup is based on dynamic plugins therefore the module ID comes in as `hacCore`. 

Since stone soup is the only app using hac-core right now, this is ok. In future we may need to revisit how the module ID is obtained for separate dynamic plugin applications.

fyi @karelhala 