### PR TITLE
Silently fail if feature flags API throws server error.

### DIFF
--- a/src/components/FeatureFlags/FeatureFlagsProvider.tsx
+++ b/src/components/FeatureFlags/FeatureFlagsProvider.tsx
@@ -1,17 +1,36 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import UnleasFlagProvider, { FlagProvider, UnleashClient } from '@unleash/proxy-client-react';
+import UnleasFlagProvider, { FlagProvider, IFlagProvider, UnleashClient } from '@unleash/proxy-client-react';
 import { useSelector } from 'react-redux';
+import { captureException } from '@sentry/react';
 import { ReduxState } from '../../redux/store';
 import { ChromeUser } from '@redhat-cloud-services/types';
 
-const config = {
+const config: IFlagProvider['config'] = {
   url: `${document.location.origin}/api/featureflags/v0`,
   clientKey: 'proxy-123',
   appName: 'web',
   headerName: 'X-Unleash-Auth',
   refreshInterval: 60000,
-  metrcisInterval: 120000,
+  metricsInterval: 120000,
+  fetch: (url: URL, headers: RequestInit) => {
+    /**
+     * The default fetch handler in the client does not handle 500 errors and does not set the error flag or calls the on('error') listener.
+     * So we need a little bit of cheating to unblock the flagError and flagsReady variables
+     */
+    return window.fetch(url, headers).catch((err) => {
+      captureException(err);
+      // set the error flag
+      localStorage.setItem(UNLEASH_ERROR_KEY, 'true');
+      return {
+        headers: {
+          get: () => '',
+        },
+        json: () => Promise.resolve({ toggles: [] }),
+        ok: true,
+      };
+    });
+  },
 };
 
 export const UNLEASH_ERROR_KEY = 'chrome:feature-flags:error';

--- a/src/utils/useNavigation.ts
+++ b/src/utils/useNavigation.ts
@@ -43,7 +43,7 @@ const appendQSSearch = (currentSearch: string, activeQuickStartID: string) => {
 };
 
 const useNavigation = () => {
-  const { flagsReady } = useFlagsStatus();
+  const { flagsReady, flagsError } = useFlagsStatus();
   const isBetaEnv = isBeta();
   const dispatch = useDispatch();
   const location = useLocation();
@@ -103,7 +103,7 @@ const useNavigation = () => {
     let observer: MutationObserver | undefined;
     // reset no nav flag
     setNoNav(false);
-    if (currentNamespace && flagsReady) {
+    if (currentNamespace && (flagsReady || flagsError)) {
       axios
         .get(`${window.location.origin}${isBetaEnv ? '/beta' : ''}/config/chrome/${currentNamespace}-navigation.json?ts=${Date.now()}`)
         .then(async (response) => {
@@ -137,7 +137,7 @@ const useNavigation = () => {
         observer.disconnect();
       }
     };
-  }, [currentNamespace, flagsReady]);
+  }, [currentNamespace, flagsReady, flagsError]);
 
   return {
     loaded: !!schema,


### PR DESCRIPTION
Fixes infinite nav loading if feature flags API returns 500 status response.

The build-in error handler of the unleash client is not triggered on 500 for some reason. This will act as if the API returned no toggles but will not block the UI features. The user just won't have any feature flags.