### PR TITLE
Remove s from Edge link

### DIFF
--- a/src/layouts/AllServices.tsx
+++ b/src/layouts/AllServices.tsx
@@ -313,7 +313,7 @@ const AllServices = () => (
                         <ChromeLink href="/insights/compliance/">Compliance</ChromeLink>
                       </Text>
                       <Text component={TextVariants.p}>
-                        <ChromeLink href="/edge/fleet-managements">Edge</ChromeLink>
+                        <ChromeLink href="/edge/fleet-management">Edge</ChromeLink>
                       </Text>
                       <Text component={TextVariants.p}>
                         <ChromeLink href="/insights/malware/">Malware</ChromeLink>


### PR DESCRIPTION
The link for Edge is currently "/edge/fleet-managements" but should be "/edge/fleet-management" without the s