### PR TITLE
Fix streams link on All services page

### DIFF
--- a/src/layouts/AllServices.tsx
+++ b/src/layouts/AllServices.tsx
@@ -84,7 +84,7 @@ const AllServices = () => (
                         <ChromeLink href="/application-services/service-registry">Service Registry</ChromeLink>
                       </Text>
                       <Text component={TextVariants.p}>
-                        <ChromeLink href="/application-services/streams/overview">Streams for Apache Kafka</ChromeLink>
+                        <ChromeLink href="/application-services/streams/kafkas">Streams for Apache Kafka</ChromeLink>
                       </Text>
                     </TextContent>
                   </CardBody>


### PR DESCRIPTION
### Description

The link on all services page for streams for Apache Kafka is incorrect. Instead of `/application-services/streams/overview` it should be `/application-services/streams/kafkas`.

### Jira

https://issues.redhat.com/browse/RHCLOUD-23684