### PR TITLE
Add new env var to build script

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,6 +4,7 @@ export COMPONENT="insights-chrome-frontend"
 export IMAGE="quay.io/cloudservices/$COMPONENT"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
+export INCLUDE_CHROME_CONFIG="true"
 cat /etc/redhat-release
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 


### PR DESCRIPTION
This patch just adds the new `INCLUDE_CHROME_CONFIG` env var to the build script. 