### PR TITLE
Add shared footer to all services and default layout

### DIFF
--- a/src/components/Header/FavoritesLink.tsx
+++ b/src/components/Header/FavoritesLink.tsx
@@ -8,7 +8,7 @@ const FavoritesLink = () => {
   return (
     <Button
       className="chr-c-button-masthead pf-u-px-lg-on-md disabled"
-      component={(props) => <ChromeLink {...props} href="/FavoritedServices" />}
+      component={(props) => <ChromeLink {...props} href="/favoritedservices" />}
       isDisabled
     >
       <Icon isInline className="ins-m-hide-on-sm">

--- a/src/components/Header/ServicesLink.tsx
+++ b/src/components/Header/ServicesLink.tsx
@@ -6,7 +6,7 @@ import ChromeLink from '../ChromeLink';
 
 const ServicesLink = () => {
   return (
-    <Button className="chr-c-button-masthead pf-u-px-lg-on-md" component={(props) => <ChromeLink {...props} href="/AllServices" />}>
+    <Button className="chr-c-button-masthead pf-u-px-lg-on-md" component={(props) => <ChromeLink {...props} href="/allservices" />}>
       <Icon isInline className="ins-m-hide-on-sm">
         <CloudIcon />
       </Icon>

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -22,6 +22,7 @@ import { createChromeContext } from '../../chrome/create-chrome';
 import LandingNav from '../LandingNav';
 import Navigation from '../Navigation';
 import useHelpTopicManager from '../QuickStart/useHelpTopicManager';
+import Footer from '../Footer/Footer';
 
 const ProductSelection = lazy(() => import('../Stratosphere/ProductSelection'));
 
@@ -140,7 +141,7 @@ const ScalprumRoot = memo(
        */
       <ScalprumProvider {...scalprumProviderProps}>
         <Routes>
-          <Route index path="/" element={<DefaultLayout Sidebar={LandingNav} {...props} />} />
+          <Route index path="/" element={<DefaultLayout Sidebar={LandingNav} Footer={Footer} {...props} />} />
           <Route
             path="/connect/products"
             element={
@@ -153,7 +154,7 @@ const ScalprumRoot = memo(
             path="/allservices"
             element={
               <Suspense fallback={LoadingFallback}>
-                <AllServices />
+                <AllServices Footer={Footer} />
               </Suspense>
             }
           />
@@ -161,7 +162,7 @@ const ScalprumRoot = memo(
             path="/favoritedservices"
             element={
               <Suspense fallback={LoadingFallback}>
-                <FavoritedServices />
+                <FavoritedServices Footer={Footer} />
               </Suspense>
             }
           />

--- a/src/layouts/AllServices.tsx
+++ b/src/layouts/AllServices.tsx
@@ -5,7 +5,6 @@ import { Gallery, Masthead, Page, PageSection, PageSectionVariants, SearchInput,
 
 import { Header } from '../components/Header/Header';
 import RedirectBanner from '../components/Stratosphere/RedirectBanner';
-import Footer from '../components/Footer/Footer';
 import AllServicesSection from '../components/AllServices/AllServicesSection';
 
 import './AllServices.scss';
@@ -13,7 +12,11 @@ import { updateDocumentTitle } from '../utils/common';
 import useAllServices from '../hooks/useAllServices';
 import Messages from '../locales/Messages';
 
-const AllServices = () => {
+export type AllServicesProps = {
+  Footer?: React.FC;
+};
+
+const AllServices = ({ Footer }: AllServicesProps) => {
   const { linkSections, error, ready, filterValue, setFilterValue } = useAllServices();
   const intl = useIntl();
 
@@ -73,7 +76,7 @@ const AllServices = () => {
               </StackItem>
             </Stack>
           </PageSection>
-          <Footer />
+          {Footer && <Footer />}
         </div>
       </Page>
     </div>

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -27,6 +27,7 @@ type ShieldedRootProps = {
   hideNav?: boolean;
   initialized?: boolean;
   Sidebar?: React.FC<NavigationProps>;
+  Footer?: React.FC;
 };
 
 type DefaultLayoutProps = {
@@ -36,12 +37,15 @@ type DefaultLayoutProps = {
   isNavOpen: boolean;
   setIsNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
   Sidebar?: React.FC<NavigationProps>;
+  Footer?: React.FC;
 };
 
-const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccountNumber, hideNav, isNavOpen, setIsNavOpen, Sidebar }) => {
+const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccountNumber, hideNav, isNavOpen, setIsNavOpen, Sidebar, Footer }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const { loaded, schema, noNav } = useNavigation();
+
+  console.log(Footer, 'this is footer!!');
 
   return (
     <Page
@@ -78,13 +82,14 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
         {selectedAccountNumber && <div className="chr-viewing-as">{intl.formatMessage(messages.viewingAsAccount, { selectedAccountNumber })}</div>}
         <RedirectBanner />
         <ChromeRoutes routesProps={{ scopeClass: 'chr-scope__default-layout' }} />
+        {Footer && <Footer />}
       </div>
     </Page>
   );
 };
 
 const ShieldedRoot = memo(
-  ({ hideNav = false, initialized = false, Sidebar }: ShieldedRootProps) => {
+  ({ hideNav = false, initialized = false, Sidebar, Footer }: ShieldedRootProps) => {
     const [isMobileView, setIsMobileView] = useState(window.document.body.clientWidth < 1200);
     const [isNavOpen, setIsNavOpen] = useState(!isMobileView);
     /**
@@ -133,6 +138,7 @@ const ShieldedRoot = memo(
         hasBanner={hasBanner}
         selectedAccountNumber={selectedAccountNumber}
         Sidebar={Sidebar}
+        Footer={Footer}
       />
     );
   },
@@ -143,16 +149,17 @@ ShieldedRoot.displayName = 'ShieldedRoot';
 
 export type RootAppProps = {
   Sidebar?: React.FC<NavigationProps>;
+  Footer?: React.FC;
 };
 
-const DefaultLayoutRoot = ({ Sidebar }: RootAppProps) => {
+const DefaultLayoutRoot = ({ Sidebar, Footer }: RootAppProps) => {
   const ouiaTags = useOuiaTags();
   const initialized = useScalprum(({ initialized }) => initialized);
   const hideNav = useSelector(({ chrome: { user } }: ReduxState) => !user || !Sidebar);
 
   return (
     <div id="chrome-app-render-root" {...ouiaTags}>
-      <ShieldedRoot hideNav={hideNav} initialized={initialized} Sidebar={Sidebar} />
+      <ShieldedRoot hideNav={hideNav} initialized={initialized} Sidebar={Sidebar} Footer={Footer} />
     </div>
   );
 };

--- a/src/layouts/FavoritedServices.tsx
+++ b/src/layouts/FavoritedServices.tsx
@@ -25,14 +25,17 @@ import { Button, Masthead, Page, PageSection, PageSectionVariants, Stack, StackI
 
 import { Header } from '../components/Header/Header';
 import RedirectBanner from '../components/Stratosphere/RedirectBanner';
-import Footer from '../components/Footer/Footer';
 
 import ChromeLink from '../components/ChromeLink';
 // import StarIcon from '@patternfly/react-icons/dist/js/icons/star-icon';
 
 import './FavoritedServices.scss';
 
-const FavoritedServices = () => (
+export type FavoritedServicesProps = {
+  Footer?: React.FC;
+};
+
+const FavoritedServices = ({ Footer }: FavoritedServicesProps) => (
   <div id="chrome-app-render-root">
     <Page
       onPageResize={null} // required to disable PF resize observer that causes re-rendring issue
@@ -64,7 +67,7 @@ const FavoritedServices = () => (
               </TextContent>
             </StackItem>
             <StackItem className="chr-l-stack__item-centered pf-u-mt-md">
-              <Button variant="primary" alt="View all services" component={(props) => <ChromeLink {...props} href="/AllServices" />}>
+              <Button variant="primary" alt="View all services" component={(props) => <ChromeLink {...props} href="/allservices" />}>
                 View all services
               </Button>
             </StackItem>
@@ -111,7 +114,7 @@ const FavoritedServices = () => (
             </StackItem>*/}
           </Stack>
         </PageSection>
-        <Footer />
+        {Footer && <Footer />}
       </div>
     </Page>
   </div>


### PR DESCRIPTION
### Description

We don't want to maintain multiple footers in our project. This PR will use Footer when landing page is rendered, All services and Favorited services.

### Limitations

Needs to go live with https://github.com/RedHatInsights/landing-page-frontend/pull/454

### Jira

https://issues.redhat.com/browse/RHCLOUD-23755