### PR TITLE
Fix last visited titles

### DIFF
--- a/src/components/AllServices/AllServicesLink.tsx
+++ b/src/components/AllServices/AllServicesLink.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Text, TextVariants } from '@patternfly/react-core';
 import classNames from 'classnames';
 import useFavoritePages from '@redhat-cloud-services/chrome/useFavoritePages';
+import { matchPath } from 'react-router-dom';
 
 import StarHalfAltIcon from '@patternfly/react-icons/dist/js/icons/star-half-alt-icon';
 import StarIcon from '@patternfly/react-icons/dist/js/icons/star-icon';
@@ -9,10 +10,17 @@ import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-
 
 import ChromeLink from '../ChromeLink';
 import type { AllServicesLink as AllServicesLinkType } from './allServicesLinks';
+import { shallowEqual, useSelector } from 'react-redux';
+import { ReduxState } from '../../redux/store';
 
 export type AllServicesLinkProps = AllServicesLinkType;
 
 const AllServicesLink = ({ href, title, isExternal }: AllServicesLinkProps) => {
+  // Find service appId
+  const appId = useSelector(
+    ({ chrome: { moduleRoutes } }: ReduxState) => moduleRoutes.find(({ path }) => matchPath(path, href) || matchPath(`${path}/*`, href))?.scope,
+    shallowEqual
+  );
   const { favoritePage, unfavoritePage, favoritePages } = useFavoritePages();
 
   const handleFavouriteToggle = (pathname: string, favorite?: boolean) => {
@@ -26,7 +34,7 @@ const AllServicesLink = ({ href, title, isExternal }: AllServicesLinkProps) => {
   const isFavorite = !!favoritePages.find(({ pathname, favorite }) => pathname === href && favorite);
   return (
     <Text className="chr-c-allservices__link-wrapper" component={TextVariants.p}>
-      <ChromeLink isExternal={isExternal} href={href}>
+      <ChromeLink appId={appId} isExternal={isExternal} href={href}>
         {title}
         {isExternal && <ExternalLinkAltIcon />}
       </ChromeLink>

--- a/src/components/ChromeLink/ChromeLink.tsx
+++ b/src/components/ChromeLink/ChromeLink.tsx
@@ -7,6 +7,7 @@ import { appNavClick } from '../../redux/actions';
 import NavContext, { OnLinkClick } from '../Navigation/navContext';
 import { ReduxState } from '../../redux/store';
 import { NavDOMEvent, RouteDefinition } from '../../@types/types';
+import { updateDocumentTitle } from '../../utils/common';
 
 interface RefreshLinkProps extends React.HTMLAttributes<HTMLAnchorElement> {
   isExternal?: boolean;
@@ -30,6 +31,7 @@ const LinkWrapper: React.FC<LinkWrapperProps> = memo(({ href, isBeta, onLinkClic
   const linkRef = useRef<HTMLAnchorElement | null>(null);
   const moduleRoutes = useSelector<ReduxState, RouteDefinition[]>(({ chrome: { moduleRoutes } }) => moduleRoutes);
   const moduleEntry = useMemo(() => moduleRoutes.find((route) => href.includes(route.path)), [href, appId]);
+  const defaultTitle = useSelector(({ chrome: { modules } }: ReduxState) => appId && modules?.[appId]?.defaultDocumentTitle);
   const preloadTimeout = useRef<NodeJS.Timeout>();
   let actionId = href.split('/').slice(2).join('/');
   if (actionId.includes('/')) {
@@ -56,6 +58,10 @@ const LinkWrapper: React.FC<LinkWrapperProps> = memo(({ href, isBeta, onLinkClic
   };
   const dispatch = useDispatch();
   const onClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    if (defaultTitle || appId) {
+      updateDocumentTitle(defaultTitle || appId);
+    }
+
     if (event.ctrlKey || event.shiftKey) {
       return false;
     }

--- a/src/components/ChromeRoute/ChromeRoute.tsx
+++ b/src/components/ChromeRoute/ChromeRoute.tsx
@@ -27,17 +27,19 @@ const ChromeRoute = memo(
     const { setActiveHelpTopicByName } = useContext(HelpTopicContext);
     const user = useSelector(({ chrome: { user } }: ReduxState) => user);
     const gatewayError = useSelector(({ chrome: { gatewayError } }: ReduxState) => gatewayError);
-    /**
-     * If default title was not set, use module scope (appId)
-     */
+    const activeModule = useSelector(({ chrome: { activeModule } }: ReduxState) => activeModule);
     const defaultTitle = useSelector(({ chrome: { modules } }: ReduxState) => modules?.[scope]?.defaultDocumentTitle || scope);
     useEffect(() => {
       batch(() => {
+        // Only trigger update on a first application render before any active module has been selected
+        // should be triggered only once per session
+        if (!activeModule) {
+          /**
+           * Default document title update. If application won't update its title chrome sets a title using module config
+           */
+          dispatch(updateDocumentTitle(defaultTitle));
+        }
         dispatch(changeActiveModule(scope));
-        /**
-         * Default document title update. If application won't update its title chrome sets a title using module config
-         */
-        dispatch(updateDocumentTitle(defaultTitle));
       });
       /**
        * update pendo metadata on application change

--- a/src/components/Feedback/FeedbackModal.tsx
+++ b/src/components/Feedback/FeedbackModal.tsx
@@ -1,5 +1,4 @@
 import React, { memo, useState } from 'react';
-import useLastVisited from '@redhat-cloud-services/chrome/useLastVisited';
 import {
   Button,
   Card,
@@ -56,9 +55,6 @@ const FeedbackModal = memo(({ user }: FeedbackModalProps) => {
   const handleCloseModal = () => {
     setIsModalOpen(false), setModalPage('feedbackHome');
   };
-  const lastVisited = useLastVisited();
-  console.log({ lastVisited });
-  console.log('Render of a feedback modal');
 
   const ModalDescription = ({ modalPage }: { modalPage: FeedbackPages }) => {
     switch (modalPage) {


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-23849

### Changes
- trigger chrome route title update only on the first chrome module render (user lands directly on a specific URL)
- update document title on ChromeLink click

We should probably start enforcing the `defaultDocumentTitle` prop on modules to have "pretty" titles even before the module is initialized