### PR TITLE
Replace cookie preference with previous element

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,25 @@
 import { Button, Modal, ModalVariant, PageSection, Text, TextContent, TextList, TextListItem, TextVariants } from '@patternfly/react-core';
-import React, { useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 
 import './Footer.scss';
 
-const Footer = () => {
+export type FooterProps = {
+  setCookieElement: Dispatch<SetStateAction<HTMLAnchorElement | null>>;
+  cookieElement: Element | null;
+};
+
+const Footer = ({ setCookieElement, cookieElement }: FooterProps) => {
+  const cookieRef = useRef<HTMLAnchorElement>(null);
+  useEffect(() => {
+    if (cookieRef.current) {
+      if (cookieElement) {
+        cookieRef.current.replaceWith(cookieElement);
+      } else {
+        setCookieElement(cookieRef.current);
+      }
+    }
+  }, [cookieRef.current]);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -42,7 +58,7 @@ const Footer = () => {
                 <a href="https://www.redhat.com/en/about/all-policies-guidelines">All Policies and Guidelines</a>
               </li>
               <li>
-                <a id="teconsent"></a>
+                <a id="teconsent" ref={cookieRef}></a>
               </li>
             </ul>
           </div>
@@ -78,6 +94,11 @@ const Footer = () => {
       </Modal>
     </React.Fragment>
   );
+};
+
+Footer.propTypes = {
+  setCookieElement: PropTypes.func,
+  cookieElement: PropTypes.element,
 };
 
 export default Footer;

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { Suspense, lazy, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ScalprumProvider, ScalprumProviderProps } from '@scalprum/react-core';
 import { shallowEqual, useSelector, useStore } from 'react-redux';
 import { Route, Routes } from 'react-router-dom';
@@ -40,6 +40,7 @@ export type ScalprumRootProps = {
 const ScalprumRoot = memo(
   ({ config, helpTopicsAPI, quickstartsAPI, ...props }: ScalprumRootProps) => {
     const { setFilteredHelpTopics } = useContext(HelpTopicContext);
+    const [cookieElement, setCookieElement] = useState<HTMLAnchorElement | null>(null);
     const internalFilteredTopics = useRef<HelpTopic[]>([]);
     const { analytics } = useContext(SegmentContext);
 
@@ -141,7 +142,13 @@ const ScalprumRoot = memo(
        */
       <ScalprumProvider {...scalprumProviderProps}>
         <Routes>
-          <Route index path="/" element={<DefaultLayout Sidebar={LandingNav} Footer={Footer} {...props} />} />
+          <Route
+            index
+            path="/"
+            element={
+              <DefaultLayout Sidebar={LandingNav} Footer={<Footer setCookieElement={setCookieElement} cookieElement={cookieElement} />} {...props} />
+            }
+          />
           <Route
             path="/connect/products"
             element={
@@ -154,7 +161,7 @@ const ScalprumRoot = memo(
             path="/allservices"
             element={
               <Suspense fallback={LoadingFallback}>
-                <AllServices Footer={Footer} />
+                <AllServices Footer={<Footer setCookieElement={setCookieElement} cookieElement={cookieElement} />} />
               </Suspense>
             }
           />
@@ -162,7 +169,7 @@ const ScalprumRoot = memo(
             path="/favoritedservices"
             element={
               <Suspense fallback={LoadingFallback}>
-                <FavoritedServices Footer={Footer} />
+                <FavoritedServices Footer={<Footer setCookieElement={setCookieElement} cookieElement={cookieElement} />} />
               </Suspense>
             }
           />

--- a/src/layouts/AllServices.tsx
+++ b/src/layouts/AllServices.tsx
@@ -13,7 +13,7 @@ import useAllServices from '../hooks/useAllServices';
 import Messages from '../locales/Messages';
 
 export type AllServicesProps = {
-  Footer?: React.FC;
+  Footer?: React.ReactNode;
 };
 
 const AllServices = ({ Footer }: AllServicesProps) => {
@@ -76,7 +76,7 @@ const AllServices = ({ Footer }: AllServicesProps) => {
               </StackItem>
             </Stack>
           </PageSection>
-          {Footer && <Footer />}
+          {Footer}
         </div>
       </Page>
     </div>

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -27,7 +27,7 @@ type ShieldedRootProps = {
   hideNav?: boolean;
   initialized?: boolean;
   Sidebar?: React.FC<NavigationProps>;
-  Footer?: React.FC;
+  Footer?: React.ReactNode;
 };
 
 type DefaultLayoutProps = {
@@ -37,7 +37,7 @@ type DefaultLayoutProps = {
   isNavOpen: boolean;
   setIsNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
   Sidebar?: React.FC<NavigationProps>;
-  Footer?: React.FC;
+  Footer?: React.ReactNode;
 };
 
 const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccountNumber, hideNav, isNavOpen, setIsNavOpen, Sidebar, Footer }) => {
@@ -80,7 +80,7 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
         {selectedAccountNumber && <div className="chr-viewing-as">{intl.formatMessage(messages.viewingAsAccount, { selectedAccountNumber })}</div>}
         <RedirectBanner />
         <ChromeRoutes routesProps={{ scopeClass: 'chr-scope__default-layout' }} />
-        {Footer && <Footer />}
+        {Footer}
       </div>
     </Page>
   );
@@ -147,7 +147,7 @@ ShieldedRoot.displayName = 'ShieldedRoot';
 
 export type RootAppProps = {
   Sidebar?: React.FC<NavigationProps>;
-  Footer?: React.FC;
+  Footer?: React.ReactNode;
 };
 
 const DefaultLayoutRoot = ({ Sidebar, Footer }: RootAppProps) => {

--- a/src/layouts/FavoritedServices.tsx
+++ b/src/layouts/FavoritedServices.tsx
@@ -32,7 +32,7 @@ import ChromeLink from '../components/ChromeLink';
 import './FavoritedServices.scss';
 
 export type FavoritedServicesProps = {
-  Footer?: React.FC;
+  Footer?: React.ReactNode;
 };
 
 const FavoritedServices = ({ Footer }: FavoritedServicesProps) => (
@@ -114,7 +114,7 @@ const FavoritedServices = ({ Footer }: FavoritedServicesProps) => (
             </StackItem>*/}
           </Stack>
         </PageSection>
-        {Footer && <Footer />}
+        {Footer}
       </div>
     </Page>
   </div>


### PR DESCRIPTION
### Description

When navigating between landing page and All services (or favrotied services), information about cookie preference gets lost. That's because we are using 3rd party script to change the element. However whenever user changes views it gets removed because the script doesn't run for the second time. This PR fixes this issue in super hacky way. In the initial render the cookie element is not set, once the element gets rendered store it in parent component and whenever we render the footer again use that element.