### PR TITLE
Use Auth bearer token when making api requests

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -48,7 +48,7 @@ export const createAuthObject = (libjwt: LibJWT, getUser: () => Promise<ChromeUs
   getUser,
   qe: {
     ...qe,
-    init: () => qe.init(store),
+    init: () => qe.init(store, () => libjwt),
   },
   logout: (bounce?: boolean) => libjwt.jwt.logoutAllTabs(bounce),
   login: () => libjwt.jwt.login(),

--- a/src/jwt/jwt.ts
+++ b/src/jwt/jwt.ts
@@ -369,7 +369,7 @@ export function setCookie(token?: string) {
     if (cookieName) {
       setCookieWrapper(`${cookieName}=${token};` + `path=/wss;` + `secure=true;` + `expires=${getCookieExpires(decodeToken(token).exp)}`);
       setCookieWrapper(`${cookieName}=${token};` + `path=/ws;` + `secure=true;` + `expires=${getCookieExpires(decodeToken(token).exp)}`);
-      setCookieWrapper(`${cookieName}=${token};` + `path=/api;` + `secure=true;` + `expires=${getCookieExpires(decodeToken(token).exp)}`);
+      setCookieWrapper(`${cookieName}=${token};` + `path=/foo;` + `secure=true;` + `expires=${getCookieExpires(decodeToken(token).exp)}`);
     }
   }
 }

--- a/src/jwt/jwt.unit.test.ts
+++ b/src/jwt/jwt.unit.test.ts
@@ -52,7 +52,7 @@ describe('JWT', () => {
   describe('setCookie', () => {
     test('sets a cookie that expires on the same second the JWT expires', () => {
       jwt.setCookie(encodedToken);
-      expect(window.document.cookie).toEqual(`cs_jwt=${encodedToken};` + `path=/api;` + `secure=true;` + `expires=Wed, 24 Apr 2019 17:13:47 GMT`);
+      expect(window.document.cookie).toEqual(`cs_jwt=${encodedToken};` + `path=/foo;` + `secure=true;` + `expires=Wed, 24 Apr 2019 17:13:47 GMT`);
     });
   });
 

--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable prefer-rest-params */
 import type { Store } from 'redux';
-import { crossAccountBouncer } from '../auth';
+import { LibJWT, crossAccountBouncer } from '../auth';
 import { setGatewayError } from '../redux/actions';
 import { get3scaleError } from './responseInterceptors';
 // TODO: Refactor this file to use modern JS
@@ -11,7 +11,7 @@ let fetchResults: Record<string, unknown> = {};
 
 const DENINED_CROSS_CHECK = 'Access denied from RBAC on cross-access check';
 
-function init(store: Store) {
+function init(store: Store, libJwt: () => LibJWT | undefined) {
   const open = window.XMLHttpRequest.prototype.open;
   const send = window.XMLHttpRequest.prototype.send;
   const oldFetch = window.fetch;
@@ -35,6 +35,10 @@ function init(store: Store) {
 
   // must use function here because arrows dont "this" like functions
   window.XMLHttpRequest.prototype.send = function sendReplacement() {
+    if (libJwt?.()?.jwt.isAuthenticated()) {
+      // There is potentially a problem if app sets its own Auth header
+      this.setRequestHeader('Authorization', `Bearer ${libJwt?.()?.jwt.getEncodedToken()}`);
+    }
     // eslint-disable-line func-names
     if (iqeEnabled) {
       xhrResults.push(this);
@@ -65,6 +69,8 @@ function init(store: Store) {
       {
         ...(options || {}),
         headers: {
+          // If app wants to set its own Auth header it can do so
+          ...(libJwt?.()?.jwt.isAuthenticated() && { Authorization: `Bearer ${libJwt?.()?.jwt.getEncodedToken()}` }),
           ...((options && options.headers) || {}),
         },
       },
@@ -109,9 +115,7 @@ function init(store: Store) {
 }
 
 const qe = {
-  init: (store: Store) => {
-    init(store);
-  },
+  init,
   hasPendingAjax: () => {
     const xhrRemoved = xhrResults.filter((result) => result.readyState === 4 || result.readyState === 0);
     xhrResults = xhrResults.filter((result) => result.readyState !== 4 && result.readyState !== 0);


### PR DESCRIPTION
### Description

We don't want to send cookie to server requests anymore. Let's use auth header when making any fetch or xhtml requests.

### JIRA

RHCLOUD-18110