### PR TITLE
Load navigation chunks on console.dev

### DIFF
--- a/cypress/component/helptopics/HelpTopicManager.cy.tsx
+++ b/cypress/component/helptopics/HelpTopicManager.cy.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect } from 'react';
 import { Provider } from 'react-redux';
-import { Store } from 'redux';
+import { AnyAction, Store } from 'redux';
 import ReducerRegistry from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { IntlProvider } from 'react-intl';
@@ -64,7 +64,7 @@ const TestComponent = () => {
 };
 
 describe('HelpTopicManager', () => {
-  let store;
+  let store: Store<any, AnyAction>;
   beforeEach(() => {
     const reduxRegistry = new ReducerRegistry({
       ...chromeInitialState,

--- a/src/components/FeatureFlags/FeatureFlagsProvider.tsx
+++ b/src/components/FeatureFlags/FeatureFlagsProvider.tsx
@@ -25,7 +25,8 @@ const config: IFlagProvider['config'] = {
         // prevent the request from falling back to default error behavior
         //add warning level
         if (resp.status >= 400) {
-          return Sentry.captureMessage(`Feature loading error server error! ${resp.status}: ${resp.statusText}.`, 'warning');
+          Sentry.captureMessage(`Feature loading error server error! ${resp.status}: ${resp.statusText}.`, 'warning');
+          throw new Error(`Feature loading error server error! ${resp.status}: ${resp.statusText}.`);
         }
 
         const contentType = resp.headers.get('content-type');


### PR DESCRIPTION
### Description

console.dev.redhat.com recently stopped working because navigation chunks were not loaded. This PR disables unleash check for console.dev origin.