### PR TITLE
Match services links using router matchPath.

### DIFF
--- a/src/components/AllServices/allServicesLinks.ts
+++ b/src/components/AllServices/allServicesLinks.ts
@@ -59,7 +59,7 @@ const allServicesLinks: AllServicesSection[] = [
         title: 'Automation Analytics',
       },
       {
-        href: '/ansible/automation-hub/',
+        href: '/ansible/automation-hub',
         title: 'Automation Hub',
       },
       {
@@ -218,7 +218,7 @@ const allServicesLinks: AllServicesSection[] = [
             title: 'Advisor',
           },
           {
-            href: '/openshift/insights/vulnerability/',
+            href: '/openshift/insights/vulnerability',
             title: 'Vulnerability',
           },
         ],
@@ -279,7 +279,7 @@ const allServicesLinks: AllServicesSection[] = [
             title: 'Advanced Cluster Security',
           },
           {
-            href: '/openshift/insights/vulnerability/',
+            href: '/openshift/insights/vulnerability',
             title: 'Vulnerability',
           },
         ],
@@ -293,7 +293,7 @@ const allServicesLinks: AllServicesSection[] = [
             title: 'Advisor',
           },
           {
-            href: '/insights/compliance/',
+            href: '/insights/compliance',
             title: 'Compliance',
           },
           {
@@ -301,7 +301,7 @@ const allServicesLinks: AllServicesSection[] = [
             title: 'Edge',
           },
           {
-            href: '/insights/malware/',
+            href: '/insights/malware',
             title: 'Malware',
           },
           {


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-24276

### Changes
- enable links based on router path matching rather than strict JS equality

A nested route like `/foo/bar/baz` does not equal `/foo/bar` but will match using the `matchPath` function
```js
// before
'/foo/bar' === '/foo/bar/baz' // false
// now
matchPath('/foo/bar/*', '/foo/bar/baz') // true
```