### PR TITLE
Add dev.foo.redhat.com to list of available prod sso

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -41,7 +41,7 @@ export const DEFAULT_SSO_ROUTES = {
     portal: 'https://ephem.outsrights.cc/beta/apps/chrome/index.html',
   },
   dev: {
-    url: ['console.dev.redhat.com'],
+    url: ['dev.foo.redhat.com', 'console.dev.redhat.com'],
     sso: 'https://sso.redhat.com/auth',
     portal: 'https://access.redhat.com',
   },


### PR DESCRIPTION
### Description

Some teams need to use dev environment on dev.foo.redhat.com. It should connect to prod SSO, but download static files from https://console.dev.redhat.com/

### JIRA

https://issues.redhat.com/browse/RHCLOUD-24316