### PR TITLE
add patternfly/react-table and react-icons as shared packages

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -40,6 +40,8 @@ const plugins = (dev = false, beta = false) => {
         { 'react-redux': { requiredVersion: deps['react-redux'] } },
         { '@openshift/dynamic-plugin-sdk': { singleton: true, requiredVersion: deps['@openshift/dynamic-plugin-sdk'] } },
         { '@patternfly/react-core': { requiredVersion: deps['@patternfly/react-core'] } },
+        { '@patternfly/react-icons': { requiredVersion: deps['@patternfly/react-icons'] } },
+        { '@patternfly/react-table': { requiredVersion: deps['@patternfly/react-table'] } },
         { '@patternfly/quickstarts': { singleton: true, requiredVersion: deps['@patternfly/quickstarts'] } },
         { '@redhat-cloud-services/chrome': { singleton: true, requiredVersion: deps['@redhat-cloud-services/chrome'] } },
         { '@scalprum/react-core': { singleton: true, requiredVersion: deps['@scalprum/react-core'] } },


### PR DESCRIPTION
This PR adds `@patternfly/react-icons`,` @patternfly/react-table` packages to the list of shared libraries in the default scope. With this in place, dependant apps, will not load their local copy of the package, but use the shared one as both the fallback module and the main instance in the shared scope. This PR should be looked at together with this demo [Patch PR](https://github.com/RedHatInsights/patchman-ui/pull/966). 

**The bundle size decreased from 3.56 mb to 1.28 mb.**

Before the change: 
![before the standalone packages](https://user-images.githubusercontent.com/59481011/220382853-1559c68b-7438-45b7-aadc-1a609a8f494f.png)

After the change:
![After standalone packages](https://user-images.githubusercontent.com/59481011/220382956-6e585c42-d750-4144-8a23-ed9dc0c978f9.png)

The actual bundle size loaded into browser has decreased from 23 mb to 12 mb

Before the change: 
![browser before standalone packages](https://user-images.githubusercontent.com/59481011/220383099-6e06608c-6b90-470b-8bf2-d09eb4f20034.png)

After the change:
![brwoser afer standalone packages](https://user-images.githubusercontent.com/59481011/220383200-958b20b8-8606-4654-ba02-ccb045095d74.png)


