### PR TITLE
Put /apps/ in routes in Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -22,10 +22,10 @@
     }
     
     @beta_match {
-        path_regexp /beta/chrome(.*)
+        path_regexp /beta/apps/chrome(.*)
     }
     handle @beta_match {
-        uri strip_prefix /beta/chrome
+        uri strip_prefix /beta/apps/chrome
         file_server * {
             root /opt/app-root/src/build 
             index opt/app-root/src/build/index.html
@@ -34,10 +34,10 @@
     }
 
     @preview_match {
-        path_regexp /preview/chrome(.*)
+        path_regexp /preview/apps/chrome(.*)
     }
     handle @preview_match {
-        uri strip_prefix /preview/chrome
+        uri strip_prefix /preview/apps/chrome
         file_server * {
             root /opt/app-root/src/build 
             index opt/app-root/src/build/index.html
@@ -51,6 +51,7 @@
     handle @config_match {
         uri strip_prefix /config
         uri strip_prefix /beta/config
+        uri strip_prefix /preview/config
         file_server * {
             root /opt/app-root/src/build 
             index opt/app-root/src/build/index.html


### PR DESCRIPTION
When I sent up my last MR I didn't have `/apps/` in in the beta and preview routes. This doesn't match the other frontends.