### PR TITLE
Expose getBundleData in chrome API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.6",
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.29",
-        "@redhat-cloud-services/types": "^0.0.20",
+        "@redhat-cloud-services/types": "^0.0.21",
         "@simonsmith/cypress-image-snapshot": "^6.0.1",
         "@swc/core": "^1.3.37",
         "@swc/jest": "^0.2.24",
@@ -3991,9 +3991,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/types": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.20.tgz",
-      "integrity": "sha512-Jb3/3jR5vqxiAeIKL6c6r0RxWmOwQeUaQkxqGdi0s5MhdhPzbay+nnvGSfOpCe/J05LF7EH+aiMpz8vKWb5nAA==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.21.tgz",
+      "integrity": "sha512-s+NPzkBEtAiUuWdqWwVtK7XnSLySGeAoBpRh/sULQzw/qRKH4RNcjeHxhxpjyTAJb1n1OG2auATukUvHFfJcHw==",
       "dev": true
     },
     "node_modules/@remix-run/router": {
@@ -35853,9 +35853,9 @@
       }
     },
     "@redhat-cloud-services/types": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.20.tgz",
-      "integrity": "sha512-Jb3/3jR5vqxiAeIKL6c6r0RxWmOwQeUaQkxqGdi0s5MhdhPzbay+nnvGSfOpCe/J05LF7EH+aiMpz8vKWb5nAA==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.21.tgz",
+      "integrity": "sha512-s+NPzkBEtAiUuWdqWwVtK7XnSLySGeAoBpRh/sULQzw/qRKH4RNcjeHxhxpjyTAJb1n1OG2auATukUvHFfJcHw==",
       "dev": true
     },
     "@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.6",
     "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.29",
-    "@redhat-cloud-services/types": "^0.0.20",
+    "@redhat-cloud-services/types": "^0.0.21",
     "@simonsmith/cypress-image-snapshot": "^6.0.1",
     "@swc/core": "^1.3.37",
     "@swc/jest": "^0.2.24",

--- a/src/chrome/create-chrome.ts
+++ b/src/chrome/create-chrome.ts
@@ -33,6 +33,7 @@ import { STORE_INITIAL_HASH } from '../redux/action-types';
 import { ChromeModule, FlagTagsFilter } from '../@types/types';
 import { createFedrampAuthObject } from '../cognito';
 import { getTokenWithAuthorizationCode } from '../cognito/auth';
+import useBundle from '../hooks/useBundle';
 
 export type CreateChromeContextConfig = {
   useGlobalFilter: (callback: (selectedTags?: FlagTagsFilter) => any) => ReturnType<typeof callback>;
@@ -103,6 +104,7 @@ export const createChromeContext = ({
     isProd,
     forceDemo: () => Cookies.set('cs_demo', 'true'),
     getBundle: () => getUrl('bundle'),
+    getBundleData: useBundle,
     getApp: () => getUrl('app'),
     getEnvironment: () => getEnv(),
     getEnvironmentDetails: () => getEnvDetails(),


### PR DESCRIPTION
requires: https://github.com/RedHatInsights/frontend-components/pull/1735
jira: https://issues.redhat.com/browse/RHCLOUD-25098

#### Note
We can use the `useBundle` "hook" because it's not a hook but a simple function and it's not dependence on any react internals.
