### PR TITLE
Do not encode search API query params.

### DIFF
--- a/src/components/Search/SearchDescription.scss
+++ b/src/components/Search/SearchDescription.scss
@@ -4,8 +4,9 @@
       .bundle {
         color: var(--pf-global--palette--black-700);
       }
-      span.hl {
+      mark {
         color: var(--pf-global--primary-color--100);
+        background-color: transparent;
       }
     }
   }

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -34,7 +34,6 @@ const REPLACE_TAG = 'REPLACE_TAG';
 const BASE_SEARCH = new URLSearchParams();
 BASE_SEARCH.append('q', `${REPLACE_TAG}~2`); // add query replacement tag and enable fuzzy search with ~1
 BASE_SEARCH.append('fq', 'documentKind:ModuleDefinition'); // search for ModuleDefinition documents
-BASE_SEARCH.append('fl', 'allTitle, bundle_title, bundle, abstract, href, relative_uri, id'); // list of valid rows
 BASE_SEARCH.append('rows', '10'); // request 10 results
 BASE_SEARCH.append('hl', 'true'); // enable highlight
 BASE_SEARCH.append('hl.method', 'original'); // choose highlight method
@@ -43,12 +42,11 @@ BASE_SEARCH.append('hl.fl', 'allTitle'); // highlight title
 BASE_SEARCH.append('hl.fl', 'bundle_title'); // highlight bundle title
 BASE_SEARCH.append('hl.fl', 'bundle'); // highlight bundle id
 BASE_SEARCH.append('hl.snippets', '3'); // enable up to 3 highlights in a single string
-BASE_SEARCH.append('hl.simple.pre', '<span class="hl">'); // specify HL opening/closing tags
-BASE_SEARCH.append('hl.simple.post', '</span>');
 BASE_SEARCH.append('hl.mergeContiguous', 'true'); // Use only one highlight atrribute to simply tag replacement.
 
 const BASE_URL = new URL('https://access.stage.redhat.com/hydra/rest/search/platform/console/');
-BASE_URL.search = BASE_SEARCH.toString();
+// search API stopped receiving encoded search string
+BASE_URL.search = decodeURIComponent(BASE_SEARCH.toString());
 const SEARCH_QUERY = BASE_URL.toString();
 
 const getMaxMenuHeight = (menuElement?: HTMLDivElement | null) => {

--- a/src/components/Search/SearchTitle.scss
+++ b/src/components/Search/SearchTitle.scss
@@ -1,7 +1,8 @@
 .chr-c-search {
   &__title {
-    span.hl {
+    mark {
       color: var(--pf-global--primary-color--100);
+      background-color: transparent;
     }
   }
 }


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-25116


### Why

The search API can no longer parse encoded query strings (don't know why I am trying to find out). Encoded search params were causing the search API requests to fail.

### Changes
- stop encoding search query params
- use the default `mark` tag for highlights (the custom mark tags suddenly started to return encoded tags)