### PR TITLE
Use Jenkins env for current branch variable.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -5,7 +5,6 @@ export IMAGE="quay.io/cloudservices/$COMPONENT"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 export INCLUDE_CHROME_CONFIG="true"
-export CHROME_CONFIG_BRANCH="prod-beta"
 cat /etc/redhat-release
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
@@ -14,6 +13,17 @@ COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-fronten
 # ---------------------------
 
 set -ex
+
+
+# get correct config build per build
+ENV_BRANCH=$(sed "s/origin\///" <<< "$GIT_BRANCH")
+if [[ $ENV_BRANCH == "master" ]]
+then
+  export CHROME_CONFIG_BRANCH="prod-beta"
+else
+  export CHROME_CONFIG_BRANCH=$(sed "s/master/prod/" <<< "$ENV_BRANCH")
+fi
+
 # source is preferred to | bash -s in this case to avoid a subshell
 source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
 BUILD_RESULTS=$?


### PR DESCRIPTION
@karelhala this will replace the static env variables we included for the hotfix. We can then proceed with moving to use chrome service as a source of CSC for the rest of the environments.