### PR TITLE
Block entitlements and permission calls by org_id not account_number

### DIFF
--- a/src/jwt/user.ts
+++ b/src/jwt/user.ts
@@ -189,7 +189,7 @@ export default async (token: SSOParsedToken): Promise<ChromeUser | void> => {
       cogToken = await getTokenWithAuthorizationCode();
     }
     try {
-      if (user.identity.account_number) {
+      if (user.identity.org_id) {
         data = isITLessEnv
           ? ((await servicesApi(cogToken).servicesGet()) as unknown as typeof data)
           : ((await servicesApi(token.jti).servicesGet()) as unknown as typeof data);


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-25254

### Changes
- block entitlements and permission calls by org_id not account_number