### PR TITLE
fix: remove nav title when breadcrumbs are enabled

### DIFF
--- a/src/components/Navigation/Navigation.test.js
+++ b/src/components/Navigation/Navigation.test.js
@@ -12,6 +12,7 @@ jest.mock('@unleash/proxy-client-react', () => {
     __esModule: true,
     ...actual,
     // unblock navigation loading
+    useFlag: () => false,
     useFlagsStatus: () => ({ flagsReady: true }),
   };
 });

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -10,6 +10,7 @@ import { getUrl, isBeta } from '../../utils/common';
 import NavLoader from './Loader';
 import ChromeNavItem from './ChromeNavItem';
 import type { Navigation as NavigationSchema } from '../../@types/types';
+import { useFlag } from '@unleash/proxy-client-react';
 
 export type NavigationProps = { loaded: boolean; schema: NavigationSchema };
 
@@ -21,6 +22,7 @@ const Navigation: React.FC<NavigationProps> = ({ loaded, schema }) => {
     undefined,
   ]);
   const showBundleCatalog = localStorage.getItem('chrome:experimental:quickstarts') === 'true';
+  const breadcrumbsDisabled = !useFlag('platform.chrome.bredcrumbs.enabled');
 
   const onLinkClick = (origEvent: React.MouseEvent<HTMLAnchorElement, MouseEvent>, href: string) => {
     if (!showBetaModal && !isBeta()) {
@@ -39,7 +41,7 @@ const Navigation: React.FC<NavigationProps> = ({ loaded, schema }) => {
 
   return (
     <Fragment>
-      <div className="chr-c-app-title">{schema?.title}</div>
+      {breadcrumbsDisabled && <div className="chr-c-app-title">{schema?.title}</div>}
       <Nav aria-label="Insights Global Navigation" data-ouia-safe="true" ouiaId="SideNavigation">
         <NavList>
           <PageContextConsumer>


### PR DESCRIPTION
For [RHCLOUD-25205](https://issues.redhat.com/browse/RHCLOUD-25205)

<img width="1512" alt="Screenshot 2023-04-14 at 2 14 05 PM" src="https://user-images.githubusercontent.com/115492521/232128107-0232ed2a-04b9-400d-8438-780c096195f1.png">
