### PR TITLE
Fix breadcrumb nav links

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -1,5 +1,5 @@
 .chr-c-breadcrumbs {
-  background-color: var(--pf-global--BackgroundColor--dark-300);
+  background-color: var(--pf-global--BackgroundColor--dark-300) !important;
   &__alignment {
     display: flex;
     align-items: center;

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,7 +1,7 @@
 .chr-c-masthead {
   overflow: visible;
   // required for the second row of the masthead
-  padding: 0;
+  padding: 0 !important;
   .chr-c-dropdown-item__stack {
     white-space: nowrap;
     * { color: var(--pf-c-dropdown__menu-item--disabled--Color); }


### PR DESCRIPTION
For [RHCLOUD-25204](https://issues.redhat.com/browse/RHCLOUD-25204). Breadcrumbs were breaking the masthead (see the padding being added to the masthead as well as the breadcrumbs background changing in the before pic below):

Before
![masthead-before](https://user-images.githubusercontent.com/115492521/232806614-afe75125-8202-4145-ba88-80716e719bb9.gif)

After
![masthead-after](https://user-images.githubusercontent.com/115492521/232806974-0cbfc3f3-7ff0-4736-bd1d-d4041320eb54.gif)
