### PR TITLE
Use visibility function in All services

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -160,6 +160,11 @@ const commonConfig = ({ dev }) => {
               host: `http://localhost:${process.env.CONFIG_PORT}`,
             },
           }),
+          ...(process.env.NAV_CONFIG && {
+            '/api/chrome-service/v1/static': {
+              host: `http://localhost:${process.env.NAV_CONFIG}`,
+            },
+          }),
         },
       }),
     },

--- a/src/hooks/useAllServices.ts
+++ b/src/hooks/useAllServices.ts
@@ -10,6 +10,7 @@ import {
 } from '../components/AllServices/allServicesLinks';
 import { requiredBundles } from '../components/AppFilter/useAppFilter';
 import { getChromeStaticPathname, isBeta } from '../utils/common';
+import { evaluateVisibility } from '../utils/isNavItemVisible';
 
 export type AvailableLinks = {
   [key: string]: NavItem;
@@ -154,6 +155,10 @@ const useAllServices = () => {
             .get<BundleNavigation>(`${getChromeStaticPathname('navigation')}/${fragment}-navigation.json?ts=${Date.now()}`)
             .catch(() => axios.get<BundleNavigation>(`${isBeta() ? '/beta' : ''}/config/chrome/${fragment}-navigation.json?ts=${Date.now()}`))
             .then(handleBundleResponse)
+            .then(async (bundleNav) => ({
+              ...bundleNav,
+              links: (await Promise.all(bundleNav.links.map(evaluateVisibility))).filter(({ isHidden }) => !isHidden),
+            }))
             .catch((err) => {
               console.error('Unable to load appfilter bundle', err, fragment);
               return [];

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -110,12 +110,17 @@ export const visibilityFunctions: VisibilityFunctions = {
   }: Omit<AxiosRequestConfig, 'adapter'> & { accessor?: string; matcher?: keyof typeof matcherMapper }) => {
     const data = await window.insights.chrome.auth.getUser();
 
+    const token = await window.insights.chrome.auth.getToken();
     // this will log a bunch of 403s if the account number isn't present
     if (data?.identity.account_number) {
       return instance({
         url,
         method,
         ...options,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...options.headers,
+        },
       })
         .then((response) => matchValue(accessor ? get(response || {}, accessor) : response, matcher))
         .catch(() => {


### PR DESCRIPTION
### Description

Some apps don't want to surface in the all services if user doesn't have correct rights. This PR evaluates each bundle links and filters out those not available.

While testing API request visibility function I've found we are not sending the token to non HCC urls, so I've included it in all api visibility requests.