### PR TITLE
Update Favorite card description styling

### DIFF
--- a/src/components/FavoriteServices/ServiceTile.tsx
+++ b/src/components/FavoriteServices/ServiceTile.tsx
@@ -21,7 +21,7 @@ const ServiceTile = ({ name, pathname, description, isExternal }: ServiceTilePro
   return (
     <ChromeLink isExternal={isExternal} href={pathname} className="chr-c-favorite-service__tile">
       <Card className="chr-c-link-favorite-card" isFlat isFullHeight isSelectableRaised>
-        <CardBody>
+        <CardBody className="pf-u-p-md">
           <Split>
             <SplitItem className="pf-m-fill">{name}</SplitItem>
             <SplitItem>
@@ -43,7 +43,11 @@ const ServiceTile = ({ name, pathname, description, isExternal }: ServiceTilePro
           </Split>
           <TextContent>
             <Text component="small">{bundle}</Text>
-            {description ? <Text component="p">{description}</Text> : null}
+            {description ? (
+              <Text component="small" className="pf-u-color-100">
+                {description}
+              </Text>
+            ) : null}
           </TextContent>
         </CardBody>
       </Card>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-25320
- Use small variant for Favorites service description
- Update card body padding

Old
<img width="1183" alt="Screenshot 2023-04-24 at 11 42 10 AM" src="https://user-images.githubusercontent.com/1287144/234047569-7bdf2cc1-3fcc-45e8-af3f-52636d536c2c.png">
New
<img width="1174" alt="Screenshot 2023-04-24 at 11 59 16 AM" src="https://user-images.githubusercontent.com/1287144/234052175-3bd7ced7-c74e-47a5-95d0-808395ed938a.png">

