### PR TITLE
Gate custom react router dom behind a check

### DIFF
--- a/src/chrome/update-shared-scope.ts
+++ b/src/chrome/update-shared-scope.ts
@@ -1,14 +1,21 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { getSharedScope, initSharedScope } from '@scalprum/core';
-import { LinkProps, NavLinkProps, NavigateOptions, NavigateProps, To } from 'react-router-dom';
+import { LinkProps, NavLinkProps, NavigateOptions, NavigateProps, Path, To } from 'react-router-dom';
+
+const hacApps = ['/application-pipeline', '/stonesoup', '/app-studio'];
 
 const updateSharedScope = () => {
   const calculateTo = (to: To) => {
     if (window.location.pathname.includes('/hac')) {
       // FIXME: Create a global dynamic plugin solution to scope plugin nested routes
-      if (typeof to === 'string' && !to.startsWith('/hac') && to.startsWith('/')) {
+      if (typeof to === 'string' && !to.startsWith('/hac') && to.startsWith('/') && hacApps.some((item) => to.startsWith(item))) {
         return `/hac${to}`;
-      } else if (typeof to !== 'string' && to.pathname && !to.pathname.startsWith('/hac')) {
+      } else if (
+        typeof to !== 'string' &&
+        to.pathname &&
+        !to.pathname.startsWith('/hac') &&
+        hacApps.some((item) => (to as Partial<Path>)?.pathname?.startsWith(item))
+      ) {
         return {
           ...to,
           pathname: `/hac${to.pathname}`,


### PR DESCRIPTION
### Description

When user is on hac application and clicks on anything in services drawer, and then navigates back with browser, they land on broken URL, because we are pushing in history stack non existent URL prepended with /hac.

This PR fixes such issue, by adding if statement to check if the requested URL contains hac application.

### JIRA

RHCLOUD-25258
