### PR TITLE
Fix missing header spacing in prod 

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -99,7 +99,11 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
                 <SearchInput />
               </ToolbarGroup>
             ) : null}
-            <ToolbarGroup className="pf-m-icon-button-group" visibility={{ default: 'hidden', '2xl': 'visible' }} widget-type="InsightsToolbar">
+            <ToolbarGroup
+              className="pf-m-icon-button-group pf-u-ml-auto"
+              visibility={{ default: 'hidden', '2xl': 'visible' }}
+              widget-type="InsightsToolbar"
+            >
               <HeaderTools />
             </ToolbarGroup>
           </ToolbarContent>


### PR DESCRIPTION
This issue appear when the search input is hidden (currently in prod env)

### Before
![screenshot-console redhat com-2023 04 25-14_33_24](https://user-images.githubusercontent.com/22619452/234278218-86fc8acd-b9c4-4fde-b7ea-56c88c6ee878.png)

### After
![screenshot-prod foo redhat com_1337-2023 04 25-14_37_01](https://user-images.githubusercontent.com/22619452/234278235-92d038ab-9e9b-4071-a392-3a8a63ebb153.png)
