### PR TITLE
Fix fetch headers spread syntax in case of arrays

### DIFF
--- a/src/utils/iqeEnablement.test.js
+++ b/src/utils/iqeEnablement.test.js
@@ -1,0 +1,20 @@
+import iqeEnablement from './iqeEnablement';
+
+describe('iqeEnablement', () => {
+  test('should correctly spread headers object', async () => {
+    const result = iqeEnablement.spreadAdditionalHeaders({ headers: { one: 'ONE', two: 'Two' } });
+
+    expect(result).toEqual({ one: 'ONE', two: 'Two' });
+  });
+
+  test('should correctly spread headers from array of arrays', async () => {
+    const result = iqeEnablement.spreadAdditionalHeaders({
+      headers: [
+        ['one', 'ONE'],
+        ['two', 'Two'],
+      ],
+    });
+
+    expect(result).toEqual({ one: 'ONE', two: 'Two' });
+  });
+});


### PR DESCRIPTION
Headers can be passed to fetch in various ways, but the current spread mechanism works only for `Object`s and fails with the [`Array` of `Array`s](https://developer.mozilla.org/en-US/docs/Web/API/Headers#examples) usage.

This is an attempt to fix the issue, but I'm struggling in testing this out, anyone can help?
cc. @riccardo-forina @edewit