### PR TITLE
Add akamaiCacheBustPaths for frontend resource

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -23,6 +23,10 @@ objects:
         paths:
           - /
           - /config/chrome
+      akamaiCacheBustPaths:
+        - /config/chrome/fed-modules.json
+        - /apps/chrome/index.html
+        - /apps/chrome/js/fed-mods.json
 parameters:
   - name: ENV_NAME
     required: true


### PR DESCRIPTION
This patch adds paths for assets we want to cache bust on deploy.

I'm not 100% what branch y'all are using for contributions we want to get to stage-beta, so if this is the wrong branch let me know :)