### PR TITLE
Use longer fragment matching to get better breadcrumbs links results.

### DIFF
--- a/src/hooks/useBreadcrumbsLinks.ts
+++ b/src/hooks/useBreadcrumbsLinks.ts
@@ -37,13 +37,14 @@ const useBreadcrumbsLinks = () => {
         const groupFragments: Required<NavItem, 'href'>[] = navItems.map((item, index) => ({
           ...item,
           /**
-           * Must be +3 because:
+           * Use the longer fragment value. If fragments are shorter than 3, fallback to value 3.
+           * Must be +3 for fallback because:
            * - first fragment is always empty "" (+1),
            * - second fragment is always bundle (+1),
            * - slice is exclusive and the matched index is not included (+1)
            * Even the root level link should always include the bundle.
            *  */
-          href: fallbackMatchFragments.slice(0, index + 3).join('/') || `/${bundleId}`,
+          href: fallbackMatchFragments.slice(0, Math.max(index + 3, index + appFragments.length)).join('/') || `/${bundleId}`,
         }));
         segments.push(...groupFragments, activeItem);
       }


### PR DESCRIPTION
Improves breadcrumb fragment HREFs when URL fragments do not match the nav levels (there is more fragments in URL than there is levels in left nav)