### PR TITLE
Push bundle link only if bundle has ID

### DIFF
--- a/src/hooks/useAllServices.ts
+++ b/src/hooks/useAllServices.ts
@@ -67,7 +67,7 @@ const handleBundleResponse = (bundle: Omit<BundleNavigation, 'id' | 'title'> & P
     return [...acc, rest];
   }, []);
   const bundleFirstLink = getFirstChildRoute(bundle.navItems);
-  if (bundleFirstLink) {
+  if (bundleFirstLink && bundle.id) {
     const bundleLink: NavItem = {
       ...bundleFirstLink,
       title: bundle.title,
@@ -89,10 +89,10 @@ const parseBundlesToObject = (items: NavItem[]): AvailableLinks =>
       };
     }
 
-    return curr.href
+    return curr.id
       ? {
           ...acc,
-          [curr.href]: curr,
+          [curr.id]: curr,
         }
       : acc;
   }, {});


### PR DESCRIPTION
### Description

There's a bug that some items are missing from all services if first child route of nested items is used in all services navigation. This PR fixes it by not including items without ID in bundle's first link.

### JIRA

RHCLOUD-25758