### PR TITLE
Fix Preview alert 'close button' styling

### DIFF
--- a/src/components/Header/HeaderAlert.scss
+++ b/src/components/Header/HeaderAlert.scss
@@ -9,6 +9,9 @@
       padding: unset;
       background-color: unset;
   }
+  .pf-c-button.pf-m-plain {
+    color: var(--pf-global--Color--dark-200);
+  }
 }
 
 .chr-c-alert-preview {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-25759
Override masthead `pf-m-plain` button styling

Old
<img width="430" alt="Screenshot 2023-05-04 at 12 56 08 PM" src="https://user-images.githubusercontent.com/1287144/236273272-0c673b22-9154-4212-8e10-cf3c252b7d8e.png">

New
<img width="427" alt="Screenshot 2023-05-04 at 12 55 50 PM" src="https://user-images.githubusercontent.com/1287144/236273275-5ef9cccd-ed29-4baa-b507-a5cffcf62762.png">
