### PR TITLE
Eliminate horizontal scrollbar in entire page (Take 2)

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,6 +1,7 @@
 @import '~@patternfly/patternfly/patternfly-addons.scss';
 .chr-c-masthead {
   --pf-c-masthead__content--MinHeight: 48px !important;
+  --pf-c-masthead__main--before--Right: 0;
   .chr-c-brand {
     width: 208px;
   }


### PR DESCRIPTION
Resolves a conflict between Masthead and the Drawer (without hiding the drawer overflow)

Jira: 
https://issues.redhat.com/browse/RHCLOUD-25375
https://issues.redhat.com/browse/RHCLOUD-25926


Old
<img width="1351" alt="Screenshot 2023-05-17 at 1 32 40 PM" src="https://github.com/RedHatInsights/insights-chrome/assets/1287144/08d4ce62-a1a7-46b8-9257-f32e33c39603">

new
<img width="1352" alt="Screenshot 2023-05-17 at 1 30 38 PM" src="https://github.com/RedHatInsights/insights-chrome/assets/1287144/7035c51c-17d1-46c7-a363-a9b32c283849">
