### PR TITLE
Add notifications drawer to the page layout

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -71,4 +71,11 @@
     // make sure its under the wrapped items on small screens
     grid-row: 3;
   }
+
+  .pf-c-toolbar__item .pf-c-notification-badge {
+    &.pf-m-unread {
+      --pf-c-notification-badge--after--BackgroundColor: var(--pf-global--palette--red-100);
+      &:hover {--pf-c-notification-badge--after--BackgroundColor: var(--pf-global--palette--red-200)}
+    }
+  }
 }

--- a/src/components/Header/HeaderTests/__snapshots__/Tools.test.js.snap
+++ b/src/components/Header/HeaderTests/__snapshots__/Tools.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Tools should render correctly 1`] = `
 <div
-  class="pf-c-toolbar__item"
+  class="pf-c-toolbar__item pf-m-spacer-md"
 >
   <label
     class="pf-c-switch pf-m-reverse chr-c-beta-switcher"

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -1,22 +1,24 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React, { memo, useContext, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { AlertActionLink, AlertVariant, Button, Divider, DropdownItem, Switch, ToolbarItem } from '@patternfly/react-core';
+import { AlertActionLink, AlertVariant, Button, Divider, DropdownItem, NotificationBadge, Switch, ToolbarItem } from '@patternfly/react-core';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import RedhatIcon from '@patternfly/react-icons/dist/js/icons/redhat-icon';
 import UserToggle from './UserToggle';
 import ToolbarToggle, { ToolbarToggleDropdownItem } from './ToolbarToggle';
 import HeaderAlert from './HeaderAlert';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import cookie from 'js-cookie';
-import { ITLess, getRouterBasename, getSection, isBeta } from '../../utils/common';
+import { ITLess, getRouterBasename, getSection, isBeta, isNotificationsEnabled, isProd } from '../../utils/common';
 import { useIntl } from 'react-intl';
 import { useFlag } from '@unleash/proxy-client-react';
 import messages from '../../locales/Messages';
 import { createSupportCase } from '../../utils/createCase';
 import LibtJWTContext from '../LibJWTContext';
 import { ReduxState } from '../../redux/store';
+import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
+import { toggleNotificationsDrawer } from '../../redux/actions';
 
 const isITLessEnv = ITLess();
 
@@ -68,6 +70,9 @@ const Tools = () => {
     isDemoAcc: false,
   });
   const user = useSelector(({ chrome: { user } }: ReduxState) => user!);
+  const unreadNotifications = useSelector(({ chrome: { notifications } }: ReduxState) => notifications?.data?.filter((isRead) => isRead) || []);
+  const isDrawerExpanded = useSelector(({ chrome: { notifications } }: ReduxState) => notifications?.isExpanded);
+  const dispatch = useDispatch();
   const libjwt = useContext(LibtJWTContext);
   const intl = useIntl();
   const location = useLocation();
@@ -209,9 +214,28 @@ const Tools = () => {
 
   return (
     <>
-      <ToolbarItem>
+      <ToolbarItem
+        {...(isNotificationsEnabled() && {
+          spacer: {
+            default: 'spacerMd',
+          },
+        })}
+      >
         <BetaSwitcher />
       </ToolbarItem>
+      {isNotificationsEnabled() && (
+        <ToolbarItem>
+          <NotificationBadge
+            className="chr-c-notification-badge"
+            variant={unreadNotifications.length === 0 ? 'read' : 'unread'}
+            onClick={() => dispatch(toggleNotificationsDrawer())}
+            aria-label="Notifications"
+            isExpanded={isDrawerExpanded}
+          >
+            <BellIcon />
+          </NotificationBadge>
+        </ToolbarItem>
+      )}
       {localStorage.getItem('chrome:darkmode') === 'true' && (
         <ToolbarItem>
           <ThemeToggle />

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -10,7 +10,7 @@ import ToolbarToggle, { ToolbarToggleDropdownItem } from './ToolbarToggle';
 import HeaderAlert from './HeaderAlert';
 import { useDispatch, useSelector } from 'react-redux';
 import cookie from 'js-cookie';
-import { ITLess, getRouterBasename, getSection, isBeta, isNotificationsEnabled, isProd } from '../../utils/common';
+import { ITLess, getRouterBasename, getSection, isBeta } from '../../utils/common';
 import { useIntl } from 'react-intl';
 import { useFlag } from '@unleash/proxy-client-react';
 import messages from '../../locales/Messages';
@@ -84,6 +84,7 @@ const Tools = () => {
 
   const enableAuthDropdownOption = useFlag('platform.chrome.dropdown.authfactor');
   const previewEnabled = useFlag('platform.chrome.preview');
+  const isNotificationsEnabled = useFlag('platform.chrome.notifications-drawer');
 
   /* list out the items for the settings menu */
   const settingsMenuDropdownItems = [
@@ -215,7 +216,7 @@ const Tools = () => {
   return (
     <>
       <ToolbarItem
-        {...(isNotificationsEnabled() && {
+        {...(isNotificationsEnabled && {
           spacer: {
             default: 'spacerMd',
           },
@@ -223,7 +224,7 @@ const Tools = () => {
       >
         <BetaSwitcher />
       </ToolbarItem>
-      {isNotificationsEnabled() && (
+      {isNotificationsEnabled && (
         <ToolbarItem>
           <NotificationBadge
             className="chr-c-notification-badge"

--- a/src/components/NotificationsDrawer/DrawerPanelContent.tsx
+++ b/src/components/NotificationsDrawer/DrawerPanelContent.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  NotificationDrawer,
+  NotificationDrawerHeader,
+  Text,
+  Title,
+} from '@patternfly/react-core';
+import { useDispatch, useSelector } from 'react-redux';
+import { toggleNotificationsDrawer } from '../../redux/actions';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
+import BellSlashIcon from '@patternfly/react-icons/dist/esm/icons/bell-slash-icon';
+import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-square-alt-icon';
+import { ReduxState } from '../../redux/store';
+
+export type DrawerPanelProps = {
+  innerRef: React.Ref<unknown>;
+};
+
+const EmptyNotifications = () => (
+  <EmptyState>
+    <EmptyStateIcon icon={BellSlashIcon} />
+    <Title headingLevel="h4" size="lg">
+      No notifications found
+    </Title>
+    <EmptyStateBody>
+      <Button
+        component="a"
+        variant="link"
+        icon={<ExternalLinkSquareAltIcon />}
+        iconPosition="right"
+        href="./user-preferences/notifications"
+        target="_blank"
+      >
+        Check your User Preferences
+      </Button>
+      <Text>Contact your Organization Administrator</Text>
+    </EmptyStateBody>
+  </EmptyState>
+);
+
+const DrawerPanelBase = ({ innerRef }: DrawerPanelProps) => {
+  const dispatch = useDispatch();
+  const notifications = useSelector(({ chrome: { notifications } }: ReduxState) => notifications?.data || []);
+  return (
+    <NotificationDrawer ref={innerRef}>
+      <NotificationDrawerHeader onClose={() => dispatch(toggleNotificationsDrawer())}>
+        <Button variant="plain" aria-label="Filter">
+          <FilterIcon />
+        </Button>
+        <Button variant="plain" aria-label="Mark as read">
+          <EllipsisVIcon />
+        </Button>
+      </NotificationDrawerHeader>
+      {notifications.length === 0 ? <EmptyNotifications /> : 'TODO'}
+    </NotificationDrawer>
+  );
+};
+
+const DrawerPanel = React.forwardRef((props, innerRef) => <DrawerPanelBase innerRef={innerRef} {...props} />);
+
+export default DrawerPanel;

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -25,7 +25,7 @@ import { NavigationProps } from '../components/Navigation';
 import MastheadMenuToggle from '../components/Header/MastheadMenuToggle';
 import { getUrl } from '../hooks/useBundle';
 import useEnableSummitFeature from '../hooks/useEnableSummitFeature';
-import { isNotificationsEnabled } from '../utils/common';
+import { useFlag } from '@unleash/proxy-client-react';
 
 type ShieldedRootProps = {
   hideNav?: boolean;
@@ -54,6 +54,7 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
     const tabbableElement = drawerPanelRef.current?.querySelector('a, button') as HTMLAnchorElement | HTMLButtonElement;
     tabbableElement.focus();
   };
+  const isNotificationsEnabled = useFlag('platform.chrome.notifications-drawer');
   return (
     <Page
       className={classnames('chr-c-page', { 'chr-c-page__hasBanner': hasBanner, 'chr-c-page__account-banner': selectedAccountNumber })}
@@ -70,7 +71,7 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
           />
         </Masthead>
       }
-      {...(isNotificationsEnabled() && {
+      {...(isNotificationsEnabled && {
         onNotificationDrawerExpand: focusDrawer,
         notificationDrawer: <DrawerPanel ref={drawerPanelRef} />,
         isNotificationDrawerExpanded: isDrawerExpanded,

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -15,6 +15,8 @@ import { useIntl } from 'react-intl';
 import messages from '../locales/Messages';
 import { CROSS_ACCESS_ACCOUNT_NUMBER } from '../utils/consts';
 
+import DrawerPanel from '../components/NotificationsDrawer/DrawerPanelContent';
+
 import '../components/Navigation/Navigation.scss';
 import './DefaultLayout.scss';
 import { ReduxState } from '../redux/store';
@@ -23,6 +25,7 @@ import { NavigationProps } from '../components/Navigation';
 import MastheadMenuToggle from '../components/Header/MastheadMenuToggle';
 import { getUrl } from '../hooks/useBundle';
 import useEnableSummitFeature from '../hooks/useEnableSummitFeature';
+import { isNotificationsEnabled } from '../utils/common';
 
 type ShieldedRootProps = {
   hideNav?: boolean;
@@ -45,7 +48,12 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
   const intl = useIntl();
   const { loaded, schema, noNav } = useNavigation();
   const enableSummitFeature = useEnableSummitFeature();
-
+  const isDrawerExpanded = useSelector(({ chrome: { notifications } }: ReduxState) => notifications?.isExpanded);
+  const drawerPanelRef = useRef<HTMLDivElement>();
+  const focusDrawer = () => {
+    const tabbableElement = drawerPanelRef.current?.querySelector('a, button') as HTMLAnchorElement | HTMLButtonElement;
+    tabbableElement.focus();
+  };
   return (
     <Page
       className={classnames('chr-c-page', { 'chr-c-page__hasBanner': hasBanner, 'chr-c-page__account-banner': selectedAccountNumber })}
@@ -62,6 +70,11 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
           />
         </Masthead>
       }
+      {...(isNotificationsEnabled() && {
+        onNotificationDrawerExpand: focusDrawer,
+        notificationDrawer: <DrawerPanel ref={drawerPanelRef} />,
+        isNotificationDrawerExpanded: isDrawerExpanded,
+      })}
       sidebar={
         (noNav || hideNav) && Sidebar
           ? undefined

--- a/src/redux/action-types.ts
+++ b/src/redux/action-types.ts
@@ -39,3 +39,5 @@ export const DISABLE_QUICKSTARTS = '@@chrome/disable-quickstarts';
 export const CLEAR_QUICKSTARTS = '@@chrome/clear-quickstarts';
 
 export const SET_GATEWAY_ERROR = '@@chrome/set-gateway-error';
+
+export const TOGGLE_NOTIFICATIONS_DRAWER = '@@chrome/toggle-notifications-drawer';

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -202,3 +202,7 @@ export const setGatewayError = (error?: ThreeScaleError) => ({
   type: actionTypes.SET_GATEWAY_ERROR,
   payload: error,
 });
+
+export const toggleNotificationsDrawer = () => ({
+  type: actionTypes.TOGGLE_NOTIFICATIONS_DRAWER,
+});

--- a/src/redux/chromeReducers.ts
+++ b/src/redux/chromeReducers.ts
@@ -332,3 +332,13 @@ export function setGatewayError(state: ChromeState, { payload }: { payload?: Thr
     gatewayError: payload,
   };
 }
+
+export function toggleNotificationsReducer(state: ChromeState) {
+  return {
+    ...state,
+    notifications: {
+      ...state.notifications,
+      isExpanded: !state.notifications?.isExpanded,
+    },
+  };
+}

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -24,6 +24,7 @@ import {
   toggleDebuggerButton,
   toggleDebuggerModal,
   toggleFeedbackModal,
+  toggleNotificationsReducer,
 } from './chromeReducers';
 import {
   globalFilterDefaultState,
@@ -66,6 +67,7 @@ import {
   TOGGLE_DEBUGGER_BUTTON,
   TOGGLE_DEBUGGER_MODAL,
   TOGGLE_FEEDBACK_MODAL,
+  TOGGLE_NOTIFICATIONS_DRAWER,
   UPDATE_ACCESS_REQUESTS_NOTIFICATIONS,
   UPDATE_DOCUMENT_TITLE_REDUCER,
   USER_LOGIN,
@@ -97,6 +99,7 @@ const reducers = {
   [MARK_ACTIVE_PRODUCT]: markActiveProduct,
   [SET_GATEWAY_ERROR]: setGatewayError,
   [CLEAR_QUICKSTARTS]: clearQuickstartsReducer,
+  [TOGGLE_NOTIFICATIONS_DRAWER]: toggleNotificationsReducer,
 };
 
 const globalFilter = {
@@ -151,6 +154,11 @@ export default function (): {
         modules: {},
         scalprumConfig: {},
         moduleRoutes: [],
+        notifications: {
+          data: [],
+          isExpanded: false,
+          count: 0,
+        },
       },
       action
     ) => applyReducerHash(reducers)(state, action),

--- a/src/redux/store.d.ts
+++ b/src/redux/store.d.ts
@@ -11,6 +11,14 @@ export type InternalNavigation = {
 
 export type AccessRequest = { request_id: string; created: string; seen: boolean };
 
+export type Notifications = {
+  isExpanded: boolean;
+  data: Array<{
+    isRead: boolean;
+  }>;
+  count: number;
+};
+
 export type ChromeState = {
   contextSwitcherOpen: boolean;
   activeApp?: string;
@@ -53,6 +61,7 @@ export type ChromeState = {
   };
   documentTitle?: string;
   gatewayError?: ThreeScaleError;
+  notifications?: Notifications;
 };
 
 export type GlobalFilterWorkloads = {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -190,6 +190,10 @@ export function isBeta(pathname?: string) {
   return ['beta', 'preview'].includes(previewFragment);
 }
 
+export function isNotificationsEnabled() {
+  return !isProd(); // let's show the notif drawer in stage for now, once it's populated add || isBeta()
+}
+
 export function getRouterBasename(pathname?: string) {
   const previewFragment = (pathname ?? window.location.pathname).split('/')[1];
   return isBeta(pathname) ? `/${previewFragment}` : '/';

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -190,10 +190,6 @@ export function isBeta(pathname?: string) {
   return ['beta', 'preview'].includes(previewFragment);
 }
 
-export function isNotificationsEnabled() {
-  return !isProd(); // let's show the notif drawer in stage for now, once it's populated add || isBeta()
-}
-
 export function getRouterBasename(pathname?: string) {
   const previewFragment = (pathname ?? window.location.pathname).split('/')[1];
   return isBeta(pathname) ? `/${previewFragment}` : '/';


### PR DESCRIPTION
### Description

We want to show notifications drawer to the user. This PR adds the notification drawer to page layout gated behind environment gate.

### JIRA

RHCLOUD-24694

### Screenshot

Be default PF shows blank background (if all notifications are read), if any notification is unread we're showing red square (this is slightly different from PF where they are using blue).

![Screenshot from 2023-05-19 10-39-23](https://github.com/RedHatInsights/insights-chrome/assets/3439771/43993479-3bd8-4884-9654-f9c10d74bb61)
