### PR TITLE
[RHCLOUD-26032] Help drop-down has duplicated data-ouia-component-id

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -99,7 +99,7 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
         <MastheadBrand className="pf-u-flex-shrink-0 pf-u-mr-lg" component={(props) => <ChromeLink {...props} appId="landing" href="/" />}>
           <Logo />
         </MastheadBrand>
-        <Toolbar isFullHeight>
+        <Toolbar isFullHeight style={{ display: 'flex', justifyContent: 'end' }}>
           <ToolbarContent>
             <div>
                 <div ref={ elementRef1 }>
@@ -109,7 +109,7 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
                     widget-type="InsightsToolbar"
                     visibility={{ '2xl': 'hidden' }}
                   >
-                        <HeaderTools />
+                    <HeaderTools />
                   </ToolbarGroup>
               </div>
             </div>
@@ -144,7 +144,7 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
                   visibility={{ default: 'hidden', '2xl': 'visible' }}
                   widget-type="InsightsToolbar"
                 >  
-                      <HeaderTools />   
+                  <HeaderTools />   
                 </ToolbarGroup>
               </div>
             </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,7 +21,6 @@ import { ITLess } from '../../utils/common';
 import SearchInput from '../Search/SearchInput';
 import AllServicesDropdown from '../AllServicesDropdown/AllServicesDropdown';
 import Breadcrumbs, { Breadcrumbsprops } from '../Breadcrumbs/Breadcrumbs';
-import { entries } from 'lodash';
 
 const FeedbackRoute = ({ user }: { user: DeepRequired<ChromeUser> }) => {
   const paths =
@@ -94,17 +93,15 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
         </MastheadBrand>
         <Toolbar isFullHeight style={{ display: 'flex', justifyContent: 'end' }}>
           <ToolbarContent>
-            <div>
-                <div ref={ elementRef1 }>
-                  <ToolbarGroup
-                    alignment={{ default: 'alignRight' }}
-                    className="pf-m-icon-button-group"
-                    widget-type="InsightsToolbar"
-                    visibility={{ '2xl': 'hidden' }}
-                  >
-                    <HeaderTools />
-                  </ToolbarGroup>
-              </div>
+            <div ref={ elementRef1 }>
+              <ToolbarGroup
+                alignment={{ default: 'alignRight' }}
+                className="pf-m-icon-button-group"
+                widget-type="InsightsToolbar"
+                visibility={{ '2xl': 'hidden' }}
+              >
+                <HeaderTools />
+              </ToolbarGroup>
             </div>
           </ToolbarContent>
         </Toolbar>
@@ -130,16 +127,14 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
             <ToolbarGroup className="pf-u-flex-grow-1 pf-u-mr-0 pf-u-mr-md-on-2xl" variant="filter-group">
               <SearchInput />
             </ToolbarGroup>
-            <div>
-              <div ref={ elementRef2 }>
-                <ToolbarGroup
-                  className="pf-m-icon-button-group pf-u-ml-auto"
-                  visibility={{ default: 'hidden', '2xl': 'visible' }}
-                  widget-type="InsightsToolbar"
-                >  
-                  <HeaderTools />   
-                </ToolbarGroup>
-              </div>
+            <div ref={ elementRef2 }>
+              <ToolbarGroup
+                className="pf-m-icon-button-group pf-u-ml-auto"
+                visibility={{ default: 'hidden', '2xl': 'visible' }}
+                widget-type="InsightsToolbar"
+              >  
+                <HeaderTools />   
+              </ToolbarGroup>
             </div>
           </ToolbarContent>
         </Toolbar>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -53,7 +53,6 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
   const [element2Parent, setElement2Parent] = useState<Element | null>(null);
 
   const resizeOperator = () => {
-    console.log(window.innerWidth);
     const windowWidth = window.innerWidth;
     if (windowWidth >= 1450) {
         setIsElement1Visible(false);
@@ -72,23 +71,17 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
   }, []);
 
   useEffect (() => {
-    console.log("element 1 changed")
     if (isElement1Visible && element1Parent) {
-      console.log("element 1 add")
       element1Parent.appendChild(elementRef1.current!);
     } else {
-      console.log("element 1 remove")
       elementRef1.current?.parentElement?.removeChild(elementRef1.current);
     }
   }, [isElement1Visible])
 
   useEffect (() => {
-    console.log("element 2 changed")
     if (isElement2Visible && element2Parent) {
-      console.log("element 2 add")
       element2Parent.appendChild(elementRef2.current!);
     } else {
-      console.log("element 2 remove")
       elementRef2.current?.parentElement?.removeChild(elementRef2.current);
     }
   }, [isElement2Visible])

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -54,13 +54,13 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
   const resizeOperator = () => {
     const windowWidth = window.innerWidth;
     if (windowWidth >= 1450) {
-        setIsElement1Visible(false);
-        setIsElement2Visible(true);
+      setIsElement1Visible(false);
+      setIsElement2Visible(true);
     } else {
-        setIsElement1Visible(true);
-        setIsElement2Visible(false);
+      setIsElement1Visible(true);
+      setIsElement2Visible(false);
     }
-  }
+  };
 
   useEffect(() => {
     setElement1Parent(elementRef1.current!.parentElement);
@@ -69,21 +69,21 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
     window.addEventListener('resize', resizeOperator);
   }, []);
 
-  useEffect (() => {
+  useEffect(() => {
     if (isElement1Visible && element1Parent) {
       element1Parent.appendChild(elementRef1.current!);
     } else {
       elementRef1.current?.parentElement?.removeChild(elementRef1.current);
     }
-  }, [isElement1Visible])
+  }, [isElement1Visible]);
 
-  useEffect (() => {
+  useEffect(() => {
     if (isElement2Visible && element2Parent) {
       element2Parent.appendChild(elementRef2.current!);
     } else {
       elementRef2.current?.parentElement?.removeChild(elementRef2.current);
     }
-  }, [isElement2Visible])
+  }, [isElement2Visible]);
 
   return (
     <Fragment>
@@ -93,7 +93,7 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
         </MastheadBrand>
         <Toolbar isFullHeight style={{ display: 'flex', justifyContent: 'end' }}>
           <ToolbarContent>
-            <div ref={ elementRef1 }>
+            <div ref={elementRef1}>
               <ToolbarGroup
                 alignment={{ default: 'alignRight' }}
                 className="pf-m-icon-button-group"
@@ -127,13 +127,13 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
             <ToolbarGroup className="pf-u-flex-grow-1 pf-u-mr-0 pf-u-mr-md-on-2xl" variant="filter-group">
               <SearchInput />
             </ToolbarGroup>
-            <div ref={ elementRef2 }>
+            <div ref={elementRef2}>
               <ToolbarGroup
                 className="pf-m-icon-button-group pf-u-ml-auto"
                 visibility={{ default: 'hidden', '2xl': 'visible' }}
                 widget-type="InsightsToolbar"
-              >  
-                <HeaderTools />   
+              >
+                <HeaderTools />
               </ToolbarGroup>
             </div>
           </ToolbarContent>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import Tools from './Tools';
 import UnAuthtedHeader from './UnAuthtedHeader';
@@ -21,6 +21,7 @@ import { ITLess } from '../../utils/common';
 import SearchInput from '../Search/SearchInput';
 import AllServicesDropdown from '../AllServicesDropdown/AllServicesDropdown';
 import Breadcrumbs, { Breadcrumbsprops } from '../Breadcrumbs/Breadcrumbs';
+import { entries } from 'lodash';
 
 const FeedbackRoute = ({ user }: { user: DeepRequired<ChromeUser> }) => {
   const paths =
@@ -44,6 +45,54 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
   const { pathname } = useLocation();
   const noBreadcrumb = !['/', '/allservices', '/favoritedservices'].includes(pathname);
 
+  const elementRef1 = useRef<HTMLDivElement>(null);
+  const elementRef2 = useRef<HTMLDivElement>(null);
+  const [isElement1Visible, setIsElement1Visible] = useState(false);
+  const [isElement2Visible, setIsElement2Visible] = useState(false);
+  const [element1Parent, setElement1Parent] = useState<Element | null>(null);
+  const [element2Parent, setElement2Parent] = useState<Element | null>(null);
+
+  const resizeOperator = () => {
+    console.log(window.innerWidth);
+    const windowWidth = window.innerWidth;
+    if (windowWidth >= 1450) {
+        setIsElement1Visible(false);
+        setIsElement2Visible(true);
+    } else {
+        setIsElement1Visible(true);
+        setIsElement2Visible(false);
+    }
+  }
+
+  useEffect(() => {
+    setElement1Parent(elementRef1.current!.parentElement);
+    setElement2Parent(elementRef2.current!.parentElement);
+    resizeOperator();
+    window.addEventListener('resize', resizeOperator);
+  }, []);
+
+  useEffect (() => {
+    console.log("element 1 changed")
+    if (isElement1Visible && element1Parent) {
+      console.log("element 1 add")
+      element1Parent.appendChild(elementRef1.current!);
+    } else {
+      console.log("element 1 remove")
+      elementRef1.current?.parentElement?.removeChild(elementRef1.current);
+    }
+  }, [isElement1Visible])
+
+  useEffect (() => {
+    console.log("element 2 changed")
+    if (isElement2Visible && element2Parent) {
+      console.log("element 2 add")
+      element2Parent.appendChild(elementRef2.current!);
+    } else {
+      console.log("element 2 remove")
+      elementRef2.current?.parentElement?.removeChild(elementRef2.current);
+    }
+  }, [isElement2Visible])
+
   return (
     <Fragment>
       <MastheadMain className="pf-u-pl-lg pf-u-pt-0 pf-u-pb-xs">
@@ -52,14 +101,18 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
         </MastheadBrand>
         <Toolbar isFullHeight>
           <ToolbarContent>
-            <ToolbarGroup
-              alignment={{ default: 'alignRight' }}
-              className="pf-m-icon-button-group"
-              widget-type="InsightsToolbar"
-              visibility={{ '2xl': 'hidden' }}
-            >
-              <HeaderTools />
-            </ToolbarGroup>
+            <div>
+                <div ref={ elementRef1 }>
+                  <ToolbarGroup
+                    alignment={{ default: 'alignRight' }}
+                    className="pf-m-icon-button-group"
+                    widget-type="InsightsToolbar"
+                    visibility={{ '2xl': 'hidden' }}
+                  >
+                        <HeaderTools />
+                  </ToolbarGroup>
+              </div>
+            </div>
           </ToolbarContent>
         </Toolbar>
       </MastheadMain>
@@ -84,13 +137,17 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
             <ToolbarGroup className="pf-u-flex-grow-1 pf-u-mr-0 pf-u-mr-md-on-2xl" variant="filter-group">
               <SearchInput />
             </ToolbarGroup>
-            <ToolbarGroup
-              className="pf-m-icon-button-group pf-u-ml-auto"
-              visibility={{ default: 'hidden', '2xl': 'visible' }}
-              widget-type="InsightsToolbar"
-            >
-              <HeaderTools />
-            </ToolbarGroup>
+            <div>
+              <div ref={ elementRef2 }>
+                <ToolbarGroup
+                  className="pf-m-icon-button-group pf-u-ml-auto"
+                  visibility={{ default: 'hidden', '2xl': 'visible' }}
+                  widget-type="InsightsToolbar"
+                >  
+                      <HeaderTools />   
+                </ToolbarGroup>
+              </div>
+            </div>
           </ToolbarContent>
         </Toolbar>
       </MastheadContent>


### PR DESCRIPTION
Made the following changes:
- Used TypeScript to manually mount and dismount the necessary `<ToolbarGroup>` based on the window size `2xl` or `1450px` so that the ouia `chrome-help` is not shown in the DOM twice.
- Consequently, I had to force a `flexbox` and `justify-content: 'end'` because the `alignRight` property wasn't working anymore for the first reference to the ouia. This is due to the nested `<div>` statements needed to implement the mounting/dismounting script.