### PR TITLE
[RHCLOUD-26032] Help drop-down has duplicated data-ouia-component-id

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -44,7 +44,7 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
   const isITLessEnv = ITLess();
   const { pathname } = useLocation();
   const noBreadcrumb = !['/', '/allservices', '/favoritedservices'].includes(pathname);
-  const { lg } = useWindowWidth();
+  const lg = useWindowWidth();
 
   return (
     <Fragment>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,6 +21,7 @@ import { ITLess } from '../../utils/common';
 import SearchInput from '../Search/SearchInput';
 import AllServicesDropdown from '../AllServicesDropdown/AllServicesDropdown';
 import Breadcrumbs, { Breadcrumbsprops } from '../Breadcrumbs/Breadcrumbs';
+import useWindowWidth from '../../hooks/useWindowWidth';
 
 const FeedbackRoute = ({ user }: { user: DeepRequired<ChromeUser> }) => {
   const paths =
@@ -43,20 +44,6 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
   const isITLessEnv = ITLess();
   const { pathname } = useLocation();
   const noBreadcrumb = !['/', '/allservices', '/favoritedservices'].includes(pathname);
-
-  const useWindowWidth = () => {
-    const [lg, setLg] = useState(window.innerWidth >= 1450);
-
-    useEffect(() => {
-      const handleResize = () => {
-        setLg(window.innerWidth >= 1450);
-      };
-      window.addEventListener('resize', handleResize);
-    }, []);
-
-    return { lg };
-  };
-
   const { lg } = useWindowWidth();
 
   return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import Tools from './Tools';
 import UnAuthtedHeader from './UnAuthtedHeader';
@@ -44,6 +44,21 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
   const { pathname } = useLocation();
   const noBreadcrumb = !['/', '/allservices', '/favoritedservices'].includes(pathname);
 
+  const useWindowWidth = () => {
+    const [lg, setLg] = useState(window.innerWidth >= 1450);
+
+    useEffect(() => {
+      const handleResize = () => {
+        setLg(window.innerWidth >= 1450);
+      };
+      window.addEventListener('resize', handleResize);
+    }, []);
+
+    return {lg};
+  };
+
+  const {lg} = useWindowWidth();
+
   return (
     <Fragment>
       <MastheadMain className="pf-u-pl-lg pf-u-pt-0 pf-u-pb-xs">
@@ -58,7 +73,7 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
               widget-type="InsightsToolbar"
               visibility={{ '2xl': 'hidden' }}
             >
-              <HeaderTools />
+              {!lg && <HeaderTools />}
             </ToolbarGroup>
           </ToolbarContent>
         </Toolbar>
@@ -89,7 +104,7 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
               visibility={{ default: 'hidden', '2xl': 'visible' }}
               widget-type="InsightsToolbar"
             >
-              <HeaderTools />
+              {lg && <HeaderTools />}
             </ToolbarGroup>
           </ToolbarContent>
         </Toolbar>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import Tools from './Tools';
 import UnAuthtedHeader from './UnAuthtedHeader';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -54,10 +54,10 @@ export const Header = ({ breadcrumbsProps }: { breadcrumbsProps?: Breadcrumbspro
       window.addEventListener('resize', handleResize);
     }, []);
 
-    return {lg};
+    return { lg };
   };
 
-  const {lg} = useWindowWidth();
+  const { lg } = useWindowWidth();
 
   return (
     <Fragment>

--- a/src/hooks/useWindowWidth.tsx
+++ b/src/hooks/useWindowWidth.tsx
@@ -8,9 +8,10 @@ const useWindowWidth = () => {
       setLg(window.innerWidth >= 1450);
     };
     window.addEventListener('resize', handleResize);
+    () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  return { lg };
+  return lg;
 };
 
 export default useWindowWidth;

--- a/src/hooks/useWindowWidth.tsx
+++ b/src/hooks/useWindowWidth.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+const useWindowWidth = () => {
+    const [lg, setLg] = useState(window.innerWidth >= 1450);
+
+    useEffect(() => {
+      const handleResize = () => {
+        setLg(window.innerWidth >= 1450);
+      };
+      window.addEventListener('resize', handleResize);
+    }, []);
+
+    return { lg };
+}
+
+export default useWindowWidth;

--- a/src/hooks/useWindowWidth.tsx
+++ b/src/hooks/useWindowWidth.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useState } from 'react';
 
 const useWindowWidth = () => {
-    const [lg, setLg] = useState(window.innerWidth >= 1450);
+  const [lg, setLg] = useState(window.innerWidth >= 1450);
 
-    useEffect(() => {
-      const handleResize = () => {
-        setLg(window.innerWidth >= 1450);
-      };
-      window.addEventListener('resize', handleResize);
-    }, []);
+  useEffect(() => {
+    const handleResize = () => {
+      setLg(window.innerWidth >= 1450);
+    };
+    window.addEventListener('resize', handleResize);
+  }, []);
 
-    return { lg };
-}
+  return { lg };
+};
 
 export default useWindowWidth;


### PR DESCRIPTION
- Used hook and event listener to dynamically show `<HeaderTools />` during window resizes. The ouia chrome-help does not duplicate anymore.