### PR TITLE
Revert "Wait for visibility functions to be initialized. (#2553)"

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -80,7 +80,7 @@ const useInitialize = () => {
 
     await initializeJWT(libJwt, chromeInstance.current);
     const getUser = createGetUser(libJwt);
-    await initializeVisibilityFunctions({
+    initializeVisibilityFunctions({
       getUser,
       getToken: () => libJwt!.initPromise.then(() => libJwt!.jwt.getUserInfo().then(() => libJwt!.jwt.getEncodedToken())),
       getUserPermissions: createGetUserPermissions(libJwt, getUser),


### PR DESCRIPTION
This reverts commit 4ff72514c938855ff3cd4b28b700a3b13c161584.

We originally delivered this as a fix to: https://issues.redhat.com/browse/RHCLOUD-26532

However it did not fix the issue and is causing errors in the console: https://issues.redhat.com/browse/RHCLOUD-26702

FWIW - `initializeVisibilityFunctions` is not async - see https://github.com/RedHatInsights/insights-chrome/blob/master/src/utils/VisibilitySingleton.ts#L22. I suspect the issue is deeper in the promise logic and I'd like to revert this in aiding in debugging on stage-preview as the original issue (26532) is not reproducible locally.