### PR TITLE
Open new tab when clicking on API docs

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -120,8 +120,8 @@ const Tools = () => {
   const aboutMenuDropdownItems = [
     {
       title: `${intl.formatMessage(messages.apiDocumentation)}`,
-      url: `/docs/api`,
-      appId: 'apiDocs',
+      url: `https://developers.redhat.com/api-catalog/`,
+      isHidden: isITLessEnv,
     },
     {
       title: `${intl.formatMessage(messages.openSupportCase)}`,


### PR DESCRIPTION
### Descritpion

We have a brand new API docs site, let's open a new tab whenever user clicks on the API docs from UI with this new API docs.

### JIRA

https://issues.redhat.com/browse/RHCLOUD-26822