### PR TITLE
Distribute visibility functions via webpack scope.

### DIFF
--- a/src/chrome/create-chrome.test.js
+++ b/src/chrome/create-chrome.test.js
@@ -1,6 +1,14 @@
 import { initializeVisibilityFunctions } from '../utils/VisibilitySingleton';
 import { createChromeContext } from './create-chrome';
 
+jest.mock('@scalprum/core', () => {
+  return {
+    __esModule: true,
+    initSharedScope: jest.fn(),
+    getSharedScope: jest.fn().mockReturnValue({}),
+  };
+});
+
 jest.mock('../jwt/jwt');
 jest.mock('../auth/fetchPermissions');
 

--- a/src/utils/VisibilitySingleton.test.ts
+++ b/src/utils/VisibilitySingleton.test.ts
@@ -2,6 +2,14 @@
 import { ChromeUser, VisibilityFunctions } from '@redhat-cloud-services/types';
 import { getVisibilityFunctions, initializeVisibilityFunctions } from './VisibilitySingleton';
 
+jest.mock('@scalprum/core', () => {
+  return {
+    __esModule: true,
+    initSharedScope: jest.fn(),
+    getSharedScope: jest.fn().mockReturnValue({}),
+  };
+});
+
 const userMock: ChromeUser = {
   identity: {
     // eslint-disable-next-line camelcase

--- a/src/utils/useNavigation.test.js
+++ b/src/utils/useNavigation.test.js
@@ -19,6 +19,14 @@ jest.mock('axios', () => {
   };
 });
 
+jest.mock('@scalprum/core', () => {
+  return {
+    __esModule: true,
+    initSharedScope: jest.fn(),
+    getSharedScope: jest.fn().mockReturnValue({}),
+  };
+});
+
 import * as axios from 'axios';
 import FlagProvider, { UnleashClient } from '@unleash/proxy-client-react';
 import { initializeVisibilityFunctions } from './VisibilitySingleton';


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-26532

### Changes
- access visibility functions through webpack shared scope in Chrome and its remote modules

### How to locally reproduce the issue
- run the Chrome dev server but disable the single runtime chunk config and remove the react refresh plugin

### What was broken
- the remote modules had separate JS chunk containing the visibility function initialization and `get` method. Therefore when chrome initialize the visibility functions in its bootstrap, it did not initialize the remote chunk and we got this error:

```
Uncaught (in promise) Error: Visibility functions were not initialized! Call the initialized function first.
```

Using the webpack shared scope will ensure that the visibility functions ensures that the visibility functions instance will be accessible from multiple chunks but it only has to be initialized in one.