### PR TITLE
Allow 'fake' services to be favorited

### DIFF
--- a/src/hooks/useAllServices.ts
+++ b/src/hooks/useAllServices.ts
@@ -270,8 +270,10 @@ const useAllServices = () => {
     servicesLinks,
     error,
     ready,
+    availableSections,
     filterValue,
     setFilterValue,
+    findNavItems,
   };
 };
 

--- a/src/hooks/useFavoritedServices.ts
+++ b/src/hooks/useFavoritedServices.ts
@@ -2,13 +2,15 @@ import { ServiceTileProps } from '../components/FavoriteServices/ServiceTile';
 import useAllServices from './useAllServices';
 import { useEffect, useMemo, useState } from 'react';
 import fetchNavigationFiles, { extractNavItemGroups } from '../utils/fetchNavigationFiles';
-import { Navigation } from '../@types/types';
+import { NavItem, Navigation } from '../@types/types';
 import { findNavLeafPath } from '../utils/common';
 import useFavoritePagesWrapper from './useFavoritePagesWrapper';
+import { AllServicesGroup } from '../components/AllServices/allServicesLinks';
 
 const useFavoritedServices = () => {
   const { favoritePages } = useFavoritePagesWrapper();
-  const { allLinks } = useAllServices();
+  const { allLinks, availableSections } = useAllServices();
+  const [fakeBundle, setFakeBundle] = useState<Navigation | undefined>(undefined);
   const [bundles, setBundles] = useState<Navigation[]>([]);
 
   useEffect(() => {
@@ -18,11 +20,32 @@ const useFavoritedServices = () => {
         console.error('Unable to fetch favorite services', error);
       });
   }, []);
+
+  useEffect(() => {
+    if (availableSections.length !== 0 && !fakeBundle) {
+      const navItems = availableSections
+        .reduce<NavItem[]>((acc, curr) => {
+          const fakeLink = curr.links.filter((link) => (link as AllServicesGroup).isGroup !== true);
+          return [...acc, fakeLink as NavItem];
+        }, [])
+        .flat();
+      setFakeBundle({
+        navItems: navItems,
+      } as Navigation);
+    }
+  }, [availableSections, fakeBundle]);
+
   const linksWithFragments = useMemo(() => {
+    // push items with unique hrefs from our fake bundle for leaf creation
+    fakeBundle?.navItems.forEach((item) => {
+      if (!allLinks.some((link) => link.href === item.href)) {
+        allLinks.push(item);
+      }
+    });
     return allLinks.map((link) => {
       let linkLeaf: ReturnType<typeof findNavLeafPath> | undefined;
       // use every to exit early if match was found
-      bundles.every((bundle) => {
+      [...bundles, fakeBundle || []].every((bundle) => {
         const leaf = findNavLeafPath(extractNavItemGroups(bundle), (item) => item?.href === link.href);
         if (leaf.activeItem) {
           linkLeaf = leaf;
@@ -35,7 +58,7 @@ const useFavoritedServices = () => {
         linkLeaf,
       };
     });
-  }, [allLinks, bundles]);
+  }, [allLinks, bundles, fakeBundle]);
 
   // extract human friendly data from the all services data set
   const favoriteServices = favoritePages.reduce<ServiceTileProps[]>((acc, curr) => {


### PR DESCRIPTION
For [RHCLOUD-25323](https://issues.redhat.com/browse/RHCLOUD-25323). Previously 'Create Cluster' could be favorited from the 'Containers' menu, but would not show up under a user's favorite services.

<img width="881" alt="image" src="https://github.com/RedHatInsights/insights-chrome/assets/115492521/49b993f1-acd7-473b-9d22-a99d7a4e6812">

