### PR TITLE
[RHINENG-663] - Add subtitle property in AllServices

### DIFF
--- a/src/components/AllServices/allServicesLinks.ts
+++ b/src/components/AllServices/allServicesLinks.ts
@@ -3,6 +3,7 @@ import AllServicesIcons from './AllServicesIcons';
 export type AllServicesLink = {
   href: string;
   title: string;
+  subtitle?: string;
   description?: string;
   isExternal?: boolean;
   prod?: boolean;

--- a/src/components/AllServicesDropdown/AllServicesGalleryLink.tsx
+++ b/src/components/AllServicesDropdown/AllServicesGalleryLink.tsx
@@ -12,7 +12,7 @@ import { AllServicesDropdownContext } from './common';
 
 export type AllServicesGalleryLinkProps = AllServicesLinkProps;
 
-const AllServicesGalleryLink = ({ href, title, description, isExternal }: AllServicesGalleryLinkProps) => {
+const AllServicesGalleryLink = ({ href, title, description, isExternal, subtitle }: AllServicesGalleryLinkProps) => {
   const bundle = bundleMapping[href.split('/')[1]];
   const { favoritePage, unfavoritePage, favoritePages } = useFavoritePagesWrapper();
   const { onLinkClick } = useContext(AllServicesDropdownContext);
@@ -68,8 +68,12 @@ const AllServicesGalleryLink = ({ href, title, description, isExternal }: AllSer
             </SplitItem>
           </Split>
           <TextContent>
-            {/* do not show bundle if the card title matches bundle title */}
-            <Text component="small">{bundle !== title ? bundle : null}</Text>
+            {/* 
+              if subtitle is not set use bundle
+
+              do not show bundle if the card title matches bundle title
+            */}
+            <Text component="small">{subtitle || (bundle !== title ? bundle : null)}</Text>
             <Text component="small" className="pf-u-color-100">
               {description ?? ''}
             </Text>


### PR DESCRIPTION
[RHINENG-663](https://issues.redhat.com/browse/RHINENG-663)

Is it possible to use the `product` field for the subtitle here?
![image](https://github.com/RedHatInsights/insights-chrome/assets/20592948/f03792a0-bd5d-4bab-9f18-6cea501aeb13)
At first I tried changing the bundle names, but that would not work for some ansible items

https://github.com/RedHatInsights/chrome-service-backend/pull/228 depends on this PR