### PR TITLE
Adding a placeholder Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,9 @@ pipeline {
     }
     stages {
         stage('Initial Setup') {
-            sh 'echo Placeholder Jenkinsfile'
+            step {
+                sh 'echo Placeholder Jenkinsfile'
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent { label 'insights' }
+    options {
+        timestamps()
+    }
+    stages {
+        stage('Initial Setup') {
+            sh 'echo Placeholder Jenkinsfile'
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     }
     stages {
         stage('Initial Setup') {
-            step {
+            steps {
                 sh 'echo Placeholder Jenkinsfile'
             }
         }


### PR DESCRIPTION
When I add the job to app-interface for the Jenkinsfile pipeline, every other opened PR will fail since they do not have a Jenkinsfile. Adding a placeholder that doesn't do anything will solve this issue. 