### PR TITLE
Remove cookie from ws:/ and wss:/ paths

### DIFF
--- a/src/jwt/jwt.ts
+++ b/src/jwt/jwt.ts
@@ -457,8 +457,6 @@ export async function setCookie(token?: string) {
     if (cookieName) {
       setCookieWrapper(`${cookieName}=${tok};` + `path=/wss;` + `secure=true;` + `expires=${getCookieExpires(tokExpires)}`);
       setCookieWrapper(`${cookieName}=${tok};` + `path=/ws;` + `secure=true;` + `expires=${getCookieExpires(tokExpires)}`);
-      setCookieWrapper(`${cookieName}=${tok};` + `path=wss://;` + `secure=true;` + `expires=${getCookieExpires(tokExpires)}`);
-      setCookieWrapper(`${cookieName}=${tok};` + `path=ws://;` + `secure=true;` + `expires=${getCookieExpires(tokExpires)}`);
       setCookieWrapper(`${cookieName}=${tok};` + `path=/api/tasks/v1;` + `secure=true;` + `expires=${getCookieExpires(tokExpires)}`);
       setCookieWrapper(`${cookieName}=${tok};` + `path=/api/automation-hub;` + `secure=true;` + `expires=${getCookieExpires(decodeToken(tok).exp)}`);
       setCookieWrapper(`${cookieName}=${tok};` + `path=/api/remediations/v1;` + `secure=true;` + `expires=${getCookieExpires(tokExpires)}`);


### PR DESCRIPTION
### Description

When cookie is set for `ws:/` or `wss:/` it's automatically enabled for any request. This breaks some APIs as they are confused which token parse (either cooki or auth token). This PR removes these 2 endpoints since we are using `/ws` and `/wss` paths anyway for sending tokens to websocket connections.

### JIRA

RHCLOUD-27537