### PR TITLE
Fix caddyfile catchall routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -59,8 +59,18 @@
         }
     }
 
+    handle /preview* {
+        root * /opt/app-root/src/build/preview
+        file_server
+        try_files {path} {path}/ /index.html
+    }
+    handle /beta* {
+        root * /opt/app-root/src/build/beta
+        file_server
+        try_files {path} {path}/ /index.html
+    }
     handle * {
-        root * /opt/app-root/src/build
+        root * /opt/app-root/src/build/stable
         file_server
         try_files {path} {path}/ /index.html
     }


### PR DESCRIPTION
We had a subtle error in our catchall routes. The way it was setup if we didn't get an explicit path to a valid file it would try to serve from /opt/app-root/src/build which is no longer a valid location to serve from. So, we ended up with the wrong index.html getting served out. This should fix that and handle preview/beta as well.