### PR TITLE
Add check not to append Auth header if already present

### DIFF
--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -107,7 +107,7 @@ function init(store: Store, libJwt?: () => LibJWT | undefined) {
     const tid = Math.random().toString(36);
     const request: Request = new Request(input, init);
 
-    if (checkOrigin(input) && libJwt?.()?.jwt.isAuthenticated()) {
+    if (checkOrigin(input) && libJwt?.()?.jwt.isAuthenticated() && !request.headers.has('Authorization')) {
       request.headers.append('Authorization', `Bearer ${libJwt?.()?.jwt.getEncodedToken()}`);
     }
 


### PR DESCRIPTION
### Description

There's currently an issue if requestor already sets Auth header for `fetch` request it duplicates it and that breaks the auth flow. This PR checks if `Auth` header is alredy set and if so do not re-set it.