### PR TITLE
Fix "Open support case" in masthead

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -131,33 +131,33 @@ const Tools = () => {
   /* list out the items for the about menu */
   const aboutMenuDropdownItems = [
     {
-      title: `${intl.formatMessage(messages.apiDocumentation)}`,
+      title: intl.formatMessage(messages.apiDocumentation),
       onClick: () => window.open('https://developers.redhat.com/api-catalog/', '_blank'),
       isHidden: isITLessEnv,
     },
     {
-      title: `${intl.formatMessage(messages.openSupportCase)}`,
+      title: intl.formatMessage(messages.openSupportCase),
       onClick: () => createSupportCase(user.identity, libjwt),
       isDisabled: window.location.href.includes('/application-services') && !isRhosakEntitled,
       isHidden: isITLessEnv,
     },
     {
-      title: `${intl.formatMessage(messages.statusPage)}`,
+      title: intl.formatMessage(messages.statusPage),
       onClick: () => window.open('https://status.redhat.com/', '_blank'),
       isHidden: isITLessEnv,
     },
     {
-      title: `${intl.formatMessage(messages.supportOptions)}`,
+      title: intl.formatMessage(messages.supportOptions),
       url: isITLessEnv ? 'https://redhatgov.servicenowservices.com/css' : 'https://access.redhat.com/support',
     },
     {
-      title: `${intl.formatMessage(messages.insightsRhelDocumentation)}`,
+      title: intl.formatMessage(messages.insightsRhelDocumentation),
       onClick: () => window.open('https://access.redhat.com/documentation/en-us/red_hat_insights', '_blank'),
       isHidden: getSection() !== 'insights' || isITLessEnv,
     },
 
     {
-      title: `${intl.formatMessage(messages.demoMode)}`,
+      title: intl.formatMessage(messages.demoMode),
       onClick: () => cookie.set('cs_demo', 'true') && window.location.reload(),
       isHidden: !isDemoAcc,
     },

--- a/src/utils/createCase.ts
+++ b/src/utils/createCase.ts
@@ -77,7 +77,9 @@ export async function createSupportCase(
   }
 ) {
   const currentProduct = registerProduct() || 'Other';
-  const { src_hash, app_name } = await getProductData();
+  const productData = await getProductData();
+  // a temporary fallback to getUrl() until all apps are redeployed, which will fix getProductData() - remove after some time
+  const { src_hash, app_name } = { src_hash: productData?.src_hash, app_name: productData?.app_name ?? getUrl('app') };
   const portalUrl = `${getEnvDetails()?.portal}`;
   const caseUrl = `${portalUrl}${HYDRA_ENDPOINT}`;
 


### PR DESCRIPTION
Part of [RHCLOUD-28362](https://issues.redhat.com/browse/RHCLOUD-28362)

Added a fallback adding app_name from the `url` if the current product name and hash are not retrieved because of missing `app.info.json` file