### PR TITLE
Make feedback modal open support case with product

### DIFF
--- a/src/components/Feedback/FeedbackModal.tsx
+++ b/src/components/Feedback/FeedbackModal.tsx
@@ -22,8 +22,10 @@ import FeedbackSuccess from './FeedbackSuccess';
 import messages from '../../locales/Messages';
 import FeedbackError from './FeedbackError';
 
-import './Feedback.scss';
 import InternalChromeContext from '../../utils/internalChromeContext';
+import LibtJWTContext from '../LibJWTContext';
+import { createSupportCase } from '../../utils/createCase';
+import './Feedback.scss';
 
 export type FeedbackModalProps = {
   user: DeepRequired<ChromeUser>;
@@ -46,6 +48,7 @@ const FeedbackModal = memo(({ user }: FeedbackModalProps) => {
   const dispatch = useDispatch();
   const [modalPage, setModalPage] = useState<FeedbackPages>('feedbackHome');
   const { getEnvironment } = useContext(InternalChromeContext);
+  const libjwt = useContext(LibtJWTContext);
   const env = getEnvironment();
   const isAvailable = env === 'prod' || env === 'stage';
   const setIsModalOpen = (isOpen: boolean) => dispatch(toggleFeedbackModal(isOpen));
@@ -73,13 +76,7 @@ const FeedbackModal = memo(({ user }: FeedbackModalProps) => {
                 <CardBody>{intl.formatMessage(messages.describeBugUrgentCases)}</CardBody>
               </Card>
               <br />
-              <Card
-                isSelectableRaised
-                isCompact
-                onClick={() => {
-                  window.open('https://access.redhat.com/support/cases/#/case/new/open-case?caseCreate=true', '_blank');
-                }}
-              >
+              <Card isSelectableRaised isCompact onClick={() => createSupportCase(user.identity, libjwt)}>
                 <CardTitle className="chr-c-feedback-card-title">
                   <Text>
                     {intl.formatMessage(messages.openSupportCase)} <ExternalLinkAltIcon />


### PR DESCRIPTION
[RHCLOUD-28371](https://issues.redhat.com/browse/RHCLOUD-28371)

When opening a support case from the feedback modal, the product and hash should be now passed according to active app