### PR TITLE
Rename preview flag in redirects and use feature flag for integrations

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -27,7 +27,6 @@ import { ReduxState } from '../../redux/store';
 import BellIcon from '@patternfly/react-icons/dist/dynamic/icons/bell-icon';
 import { toggleNotificationsDrawer } from '../../redux/actions';
 import useWindowWidth from '../../hooks/useWindowWidth';
-import { usePreviewFlag } from '../../utils/usePreviewFlag';
 
 const isITLessEnv = ITLess();
 
@@ -81,7 +80,7 @@ const Tools = () => {
     isRhosakEntitled: false,
     isDemoAcc: false,
   });
-  const enableIntegrations = usePreviewFlag('platform.sources.integrations');
+  const enableIntegrations = useFlag('platform.sources.integrations');
   const { xs } = useWindowWidth();
   const user = useSelector(({ chrome: { user } }: ReduxState) => user!);
   const unreadNotifications = useSelector(({ chrome: { notifications } }: ReduxState) => notifications.data.some((item) => !item.read));

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -5,7 +5,7 @@ import ChromeRoute from '../ChromeRoute';
 import NotFoundRoute from '../NotFoundRoute';
 import LoadingFallback from '../../utils/loading-fallback';
 import { ReduxState } from '../../redux/store';
-import { usePreviewFlag } from '../../utils/usePreviewFlag';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const INTEGRATION_SOURCES = 'platform.sources.integrations';
 
@@ -23,7 +23,7 @@ const redirects = [
   {
     path: '/settings',
     to: '/settings/integrations',
-    previewFlag: {
+    featureFlag: {
       value: true,
       name: INTEGRATION_SOURCES,
     },
@@ -31,7 +31,7 @@ const redirects = [
   {
     path: '/settings',
     to: '/settings/sources',
-    previewFlag: {
+    featureFlag: {
       value: false,
       name: INTEGRATION_SOURCES,
     },
@@ -67,8 +67,8 @@ export type RoutesProps = {
 };
 
 const ChromeRoutes = ({ routesProps }: RoutesProps) => {
-  const enableIntegrations = usePreviewFlag(INTEGRATION_SOURCES);
-  const previewFlags = useMemo<Record<string, boolean>>(() => ({ INTEGRATION_SOURCES: enableIntegrations }), [enableIntegrations]);
+  const enableIntegrations = useFlag(INTEGRATION_SOURCES);
+  const featureFlags = useMemo<Record<string, boolean>>(() => ({ INTEGRATION_SOURCES: enableIntegrations }), [enableIntegrations]);
   const moduleRoutes = useSelector(({ chrome: { moduleRoutes } }: ReduxState) => moduleRoutes);
   const showBundleCatalog = localStorage.getItem('chrome:experimental:quickstarts') === 'true';
 
@@ -84,10 +84,10 @@ const ChromeRoutes = ({ routesProps }: RoutesProps) => {
           }
         />
       )}
-      {redirects.map(({ path, to, previewFlag }) => {
-        if (previewFlag) {
-          const found = Object.keys(previewFlags).find((item) => item === previewFlag.name);
-          if (previewFlags[found as string] !== previewFlag.value) {
+      {redirects.map(({ path, to, featureFlag }) => {
+        if (featureFlag) {
+          const found = Object.keys(featureFlags).find((item) => item === featureFlag.name);
+          if (featureFlags[found as string] !== featureFlag.value) {
             return null;
           }
         }


### PR DESCRIPTION
### Description

Since we want to release integrations + sources on monday 30th Oct let's prepare the redirects as well. This PR also includes renaming of preview flag o feature flag in routes as it makes more sence that way.

### TODO

Merge on 30th Oct.