### PR TITLE
Use jotai for `activeModule` state managment 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "classnames": "^2.3.2",
         "commander": "^10.0.0",
         "history": "^5.3.0",
+        "jotai": "^2.5.1",
         "js-cookie": "^3.0.1",
         "js-yaml": "^4.1.0",
         "localforage": "^1.10.0",
@@ -4252,28 +4253,38 @@
       }
     },
     "node_modules/@patternfly/react-component-groups": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-1.0.17.tgz",
-      "integrity": "sha512-SeTnlmEyk9q/TxnLs2WCNuEhpD9iKdgArW+OnW6O/rm/VDtPAeJ7O+SYT0JeZDqtNzMvAb9D02GE06k+5urchQ==",
+      "version": "5.0.0-prerelease.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.0.0-prerelease.6.tgz",
+      "integrity": "sha512-xqcq3BUuk5ISpBuYDhUBalAz7SV3T5KNhM7pI4RG66Av7S7l5qRGjWJr83beLSb5rN3lbQEDhFGBWkBBuZjShw==",
       "dependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "react-jss": "^10.9.2"
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-table": "^5.1.1",
+        "clsx": "^2.0.0",
+        "react-jss": "^10.10.0"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
+    "node_modules/@patternfly/react-component-groups/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@patternfly/react-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
-      "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.1.tgz",
+      "integrity": "sha512-9DbgQMXYmF8A4aCNLKXwIN1H07SIPoPaVLvx+yiDuJfDx4Qi0T+H7j5cx0VfDfxuCpqea3POJWqBQn1HnwS4wQ==",
       "dependencies": {
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
-        "focus-trap": "7.4.3",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
+        "focus-trap": "7.5.2",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.5.0"
       },
@@ -4283,29 +4294,28 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.1.tgz",
+      "integrity": "sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
-      "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.1.1.tgz",
+      "integrity": "sha512-swO9X+WixYYDsMVsEJp1V8QUfhEQY91QfFm4phfYP4jc2TQ2opIFYdUIHkc+yrZwBhrgb/pPUUfemyqAoSbZcA=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.0.tgz",
-      "integrity": "sha512-Q3MBo9+ZmBvLJzVHxmV9f/4qQAz5Si743zVLHRwjh+tjbn/DrcbxJdT8Uxa3NGKkpvszzgi/LPeXipJOHOELug==",
-      "peer": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.1.1.tgz",
+      "integrity": "sha512-9tAtHj16hemJ6YRBWIm2O+QRNoFWYQt8ZLQ1G0KBwpg2t2G2CbGsS2RG+BamO4IVE6IPo3Yoo39p4UCNRiGVpA==",
       "dependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "@patternfly/react-styles": "^5.0.0",
-        "@patternfly/react-tokens": "^5.0.0",
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
         "lodash": "^4.17.19",
         "tslib": "^2.5.0"
       },
@@ -4315,9 +4325,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
-      "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.1.1.tgz",
+      "integrity": "sha512-cHuNkzNA9IY9aDwfjSEkitQoVEvRhOJRKhH0yIRlRByEkbdoV9jJZ9xj20hNShE+bxmNuom+MCTQSkpkN1bV8A=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
@@ -4489,15 +4499,15 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.0.10.tgz",
-      "integrity": "sha512-xYgHwtpkPYXXByMizbraIm+M9WXS65FDwA4wIJq/hzOAiVv4WtORVCRn3Ysul3wAKlXLB9Q+M6kzxXXcbc+v4g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.1.0.tgz",
+      "integrity": "sha512-IsQf/DK5nA+ARFdq25o5Ndi2EAE5cgkDA80GjK3CluTvV+0ve5wRCtD/nCnVbRs9i/CbSAu8YTCvLA6tCTUKyA==",
       "dependencies": {
-        "@patternfly/react-component-groups": "^1.0.17",
+        "@patternfly/react-component-groups": "^5.0.0-prerelease.5",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
         "@redhat-cloud-services/types": "^0.0.24",
-        "@scalprum/core": "^0.5.1",
-        "@scalprum/react-core": "^0.5.1",
+        "@scalprum/core": "^0.5.4",
+        "@scalprum/react-core": "^0.5.4",
         "sanitize-html": "^2.7.2"
       },
       "peerDependencies": {
@@ -4599,12 +4609,12 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-4.0.2.tgz",
-      "integrity": "sha512-xivlLFmlAhn+WNwaKuHXXQhSeVW+EkuApAErhvYanC5SZ32H9cIzp4aF61ZoLv7A1pjTSu/QcZ+BxvfTKCNrUQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-4.1.0.tgz",
+      "integrity": "sha512-bEoAeZMVY+UuSriSeruZ1pIesiPEjScrVFJQ5Wq/w3UFc79oXSYOgpRElxblPUH/LbKqp7inbzqRm2FxMcVxYg==",
       "dependencies": {
-        "@redhat-cloud-services/frontend-components": "^4.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
+        "@redhat-cloud-services/frontend-components": "^4.0.9",
+        "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
         "redux-promise-middleware": "6.1.3"
       },
       "peerDependencies": {
@@ -15050,11 +15060,11 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
       "dependencies": {
-        "tabbable": "^6.1.2"
+        "tabbable": "^6.2.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -20310,9 +20320,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
@@ -20320,6 +20330,26 @@
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.5.1.tgz",
+      "integrity": "sha512-vanPCCSuHczUXNbVh/iUunuMfrWRL4FdBtAbTRmrfqezJcKb8ybBTg8iivyYuUHapjcDETyJe1E4inlo26bVHA==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-cookie": {
@@ -28436,16 +28466,16 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.1.0.tgz",
+      "integrity": "sha512-U7TF/OYYzAg+OoiT/B8opvN48UHt0QYMi4aD3PjRFpybQ+o6czQF8Ig3SKCCMJdxpBrCalIJ4O00FBof27Fu9Q==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",
-        "joi": "^17.7.0",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       },
       "bin": {
         "wait-on": "bin/wait-on"
@@ -32370,57 +32400,65 @@
       }
     },
     "@patternfly/react-component-groups": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-1.0.17.tgz",
-      "integrity": "sha512-SeTnlmEyk9q/TxnLs2WCNuEhpD9iKdgArW+OnW6O/rm/VDtPAeJ7O+SYT0JeZDqtNzMvAb9D02GE06k+5urchQ==",
+      "version": "5.0.0-prerelease.6",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.0.0-prerelease.6.tgz",
+      "integrity": "sha512-xqcq3BUuk5ISpBuYDhUBalAz7SV3T5KNhM7pI4RG66Av7S7l5qRGjWJr83beLSb5rN3lbQEDhFGBWkBBuZjShw==",
       "requires": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "react-jss": "^10.9.2"
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-table": "^5.1.1",
+        "clsx": "^2.0.0",
+        "react-jss": "^10.10.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+        }
       }
     },
     "@patternfly/react-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
-      "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.1.tgz",
+      "integrity": "sha512-9DbgQMXYmF8A4aCNLKXwIN1H07SIPoPaVLvx+yiDuJfDx4Qi0T+H7j5cx0VfDfxuCpqea3POJWqBQn1HnwS4wQ==",
       "requires": {
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
-        "focus-trap": "7.4.3",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
+        "focus-trap": "7.5.2",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.5.0"
       }
     },
     "@patternfly/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.1.tgz",
+      "integrity": "sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
-      "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.1.1.tgz",
+      "integrity": "sha512-swO9X+WixYYDsMVsEJp1V8QUfhEQY91QfFm4phfYP4jc2TQ2opIFYdUIHkc+yrZwBhrgb/pPUUfemyqAoSbZcA=="
     },
     "@patternfly/react-table": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.0.tgz",
-      "integrity": "sha512-Q3MBo9+ZmBvLJzVHxmV9f/4qQAz5Si743zVLHRwjh+tjbn/DrcbxJdT8Uxa3NGKkpvszzgi/LPeXipJOHOELug==",
-      "peer": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.1.1.tgz",
+      "integrity": "sha512-9tAtHj16hemJ6YRBWIm2O+QRNoFWYQt8ZLQ1G0KBwpg2t2G2CbGsS2RG+BamO4IVE6IPo3Yoo39p4UCNRiGVpA==",
       "requires": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "@patternfly/react-styles": "^5.0.0",
-        "@patternfly/react-tokens": "^5.0.0",
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
         "lodash": "^4.17.19",
         "tslib": "^2.5.0"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
-      "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.1.1.tgz",
+      "integrity": "sha512-cHuNkzNA9IY9aDwfjSEkitQoVEvRhOJRKhH0yIRlRByEkbdoV9jJZ9xj20hNShE+bxmNuom+MCTQSkpkN1bV8A=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
@@ -32548,15 +32586,15 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.0.10.tgz",
-      "integrity": "sha512-xYgHwtpkPYXXByMizbraIm+M9WXS65FDwA4wIJq/hzOAiVv4WtORVCRn3Ysul3wAKlXLB9Q+M6kzxXXcbc+v4g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.1.0.tgz",
+      "integrity": "sha512-IsQf/DK5nA+ARFdq25o5Ndi2EAE5cgkDA80GjK3CluTvV+0ve5wRCtD/nCnVbRs9i/CbSAu8YTCvLA6tCTUKyA==",
       "requires": {
-        "@patternfly/react-component-groups": "^1.0.17",
+        "@patternfly/react-component-groups": "^5.0.0-prerelease.5",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
         "@redhat-cloud-services/types": "^0.0.24",
-        "@scalprum/core": "^0.5.1",
-        "@scalprum/react-core": "^0.5.1",
+        "@scalprum/core": "^0.5.4",
+        "@scalprum/react-core": "^0.5.4",
         "sanitize-html": "^2.7.2"
       },
       "dependencies": {
@@ -32630,12 +32668,12 @@
       }
     },
     "@redhat-cloud-services/frontend-components-notifications": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-4.0.2.tgz",
-      "integrity": "sha512-xivlLFmlAhn+WNwaKuHXXQhSeVW+EkuApAErhvYanC5SZ32H9cIzp4aF61ZoLv7A1pjTSu/QcZ+BxvfTKCNrUQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-4.1.0.tgz",
+      "integrity": "sha512-bEoAeZMVY+UuSriSeruZ1pIesiPEjScrVFJQ5Wq/w3UFc79oXSYOgpRElxblPUH/LbKqp7inbzqRm2FxMcVxYg==",
       "requires": {
-        "@redhat-cloud-services/frontend-components": "^4.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
+        "@redhat-cloud-services/frontend-components": "^4.0.9",
+        "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
         "redux-promise-middleware": "6.1.3"
       }
     },
@@ -39552,11 +39590,11 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
       "requires": {
-        "tabbable": "^6.1.2"
+        "tabbable": "^6.2.0"
       }
     },
     "follow-redirects": {
@@ -43451,9 +43489,9 @@
       }
     },
     "joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
@@ -43462,6 +43500,12 @@
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "jotai": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.5.1.tgz",
+      "integrity": "sha512-vanPCCSuHczUXNbVh/iUunuMfrWRL4FdBtAbTRmrfqezJcKb8ybBTg8iivyYuUHapjcDETyJe1E4inlo26bVHA==",
+      "requires": {}
     },
     "js-cookie": {
       "version": "3.0.5",
@@ -49853,16 +49897,16 @@
       }
     },
     "wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.1.0.tgz",
+      "integrity": "sha512-U7TF/OYYzAg+OoiT/B8opvN48UHt0QYMi4aD3PjRFpybQ+o6czQF8Ig3SKCCMJdxpBrCalIJ4O00FBof27Fu9Q==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2",
-        "joi": "^17.7.0",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       }
     },
     "walkdir": {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "classnames": "^2.3.2",
     "commander": "^10.0.0",
     "history": "^5.3.0",
+    "jotai": "^2.5.1",
     "js-cookie": "^3.0.1",
     "js-yaml": "^4.1.0",
     "localforage": "^1.10.0",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider, useSelector } from 'react-redux';
 import { IntlProvider, ReactIntlErrorCode } from 'react-intl';
+import { Provider as JotaiProvider } from 'jotai';
 
 import { spinUpStore } from './redux/redux-config';
 import RootApp from './components/RootApp';
@@ -11,6 +12,7 @@ import { ReduxState } from './redux/store';
 import OIDCProvider from './auth/OIDCConnector/OIDCProvider';
 import messages from './locales/data.json';
 import ErrorBoundary from './components/ErrorComponents/ErrorBoundary';
+import chromeStore from './state/chromeStore';
 
 const isITLessEnv = ITLess();
 const language: keyof typeof messages = 'en';
@@ -46,26 +48,28 @@ const entry = document.getElementById('chrome-entry');
 if (entry) {
   const reactRoot = createRoot(entry);
   reactRoot.render(
-    <Provider store={spinUpStore()?.store}>
-      <AuthProvider>
-        <IntlProvider
-          locale={language}
-          messages={messages[language]}
-          onError={(error) => {
-            if (
-              (getEnv() === 'stage' && !window.location.origin.includes('foo')) ||
-              localStorage.getItem('chrome:intl:debug') === 'true' ||
-              !(error.code === ReactIntlErrorCode.MISSING_TRANSLATION)
-            ) {
-              console.error(error);
-            }
-          }}
-        >
-          <ErrorBoundary>
-            <App />
-          </ErrorBoundary>
-        </IntlProvider>
-      </AuthProvider>
-    </Provider>
+    <JotaiProvider store={chromeStore}>
+      <Provider store={spinUpStore()?.store}>
+        <AuthProvider>
+          <IntlProvider
+            locale={language}
+            messages={messages[language]}
+            onError={(error) => {
+              if (
+                (getEnv() === 'stage' && !window.location.origin.includes('foo')) ||
+                localStorage.getItem('chrome:intl:debug') === 'true' ||
+                !(error.code === ReactIntlErrorCode.MISSING_TRANSLATION)
+              ) {
+                console.error(error);
+              }
+            }}
+          >
+            <ErrorBoundary>
+              <App />
+            </ErrorBoundary>
+          </IntlProvider>
+        </AuthProvider>
+      </Provider>
+    </JotaiProvider>
   );
 }

--- a/src/components/ChromeRoute/ChromeRoute.tsx
+++ b/src/components/ChromeRoute/ChromeRoute.tsx
@@ -2,7 +2,7 @@ import { ScalprumComponent } from '@scalprum/react-core';
 import React, { memo, useContext, useEffect } from 'react';
 import LoadingFallback from '../../utils/loading-fallback';
 import { batch, useDispatch, useSelector } from 'react-redux';
-import { changeActiveModule, toggleGlobalFilter, updateDocumentTitle } from '../../redux/actions';
+import { toggleGlobalFilter, updateDocumentTitle } from '../../redux/actions';
 import ErrorComponent from '../ErrorComponents/DefaultErrorComponent';
 import { getPendoConf } from '../../analytics';
 import classNames from 'classnames';
@@ -12,6 +12,8 @@ import { ReduxState } from '../../redux/store';
 import { DeepRequired } from 'utility-types';
 import { ChromeUser } from '@redhat-cloud-services/types';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
+import { useAtom } from 'jotai';
+import { activeModuleAtom } from '../../state/atoms';
 
 export type ChromeRouteProps = {
   scope: string;
@@ -29,8 +31,9 @@ const ChromeRoute = memo(
     const { setActiveHelpTopicByName } = useContext(HelpTopicContext);
     const { user } = useContext(ChromeAuthContext);
     const gatewayError = useSelector(({ chrome: { gatewayError } }: ReduxState) => gatewayError);
-    const activeModule = useSelector(({ chrome: { activeModule } }: ReduxState) => activeModule);
     const defaultTitle = useSelector(({ chrome: { modules } }: ReduxState) => modules?.[scope]?.defaultDocumentTitle || scope);
+
+    const [activeModule, setActiveModule] = useAtom(activeModuleAtom);
 
     useEffect(() => {
       batch(() => {
@@ -42,7 +45,7 @@ const ChromeRoute = memo(
            */
           dispatch(updateDocumentTitle(defaultTitle || 'Hybrid Cloud Console'));
         }
-        dispatch(changeActiveModule(scope));
+        setActiveModule(scope);
       });
       /**
        * update pendo metadata on application change

--- a/src/components/ErrorComponents/DefaultErrorComponent.tsx
+++ b/src/components/ErrorComponents/DefaultErrorComponent.tsx
@@ -12,12 +12,12 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/dynamic/icons/ex
 import { chunkLoadErrorRefreshKey } from '../../utils/common';
 import { useIntl } from 'react-intl';
 import messages from '../../locales/Messages';
-import { useSelector } from 'react-redux';
-import { ReduxState } from '../../redux/store';
 import './ErrorComponent.scss';
 import { get3scaleError } from '../../utils/responseInterceptors';
 import GatewayErrorComponent from './GatewayErrorComponent';
 import { getUrl } from '../../hooks/useBundle';
+import { useAtomValue } from 'jotai';
+import { activeModuleAtom } from '../../state/atoms';
 
 export type DefaultErrorComponentProps = {
   error?: any | Error;
@@ -30,7 +30,7 @@ const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
   const intl = useIntl();
   const [sentryId, setSentryId] = useState<string | undefined>();
 
-  const activeModule = useSelector(({ chrome: { activeModule } }: ReduxState) => activeModule);
+  const activeModule = useAtomValue(activeModuleAtom);
   const exceptionMessage = (props.error as Error)?.message ? (props.error as Error).message : 'Unhandled UI runtime error';
   useEffect(() => {
     const sentryId =

--- a/src/components/ErrorComponents/GatewayErrorComponent.tsx
+++ b/src/components/ErrorComponents/GatewayErrorComponent.tsx
@@ -9,6 +9,8 @@ import { Text, TextContent } from '@patternfly/react-core/dist/dynamic/component
 import { useIntl } from 'react-intl';
 import Messages from '../../locales/Messages';
 import { ThreeScaleError } from '../../utils/responseInterceptors';
+import { useAtomValue } from 'jotai';
+import { activeModuleAtom } from '../../state/atoms';
 
 export type GatewayErrorComponentProps = {
   error: ThreeScaleError;
@@ -48,8 +50,10 @@ const Description = ({ detail, complianceError }: DescriptionProps) => {
 };
 
 const GatewayErrorComponent = ({ error }: GatewayErrorComponentProps) => {
+  const activeModule = useAtomValue(activeModuleAtom);
+  const activeProduct = useSelector((state: ReduxState) => state.chrome.activeProduct);
   // get active product, fallback to module name if product is not defined
-  const serviceName = useSelector((state: ReduxState) => state.chrome.activeProduct || state.chrome.activeModule);
+  const serviceName = activeProduct || activeModule;
   return <NotAuthorized description={<Description complianceError={error.complianceError} detail={error.detail} />} serviceName={serviceName} />;
 };
 

--- a/src/components/Header/HeaderTests/ToolbarToggle.test.js
+++ b/src/components/Header/HeaderTests/ToolbarToggle.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import ToolbarToggle from '../ToolbarToggle';
 
 describe('ToolbarToggle', () => {
@@ -34,7 +34,7 @@ describe('ToolbarToggle', () => {
     const toggleButton = container.querySelector('#foo');
     expect(toggleButton).toBeTruthy();
     await act(async () => {
-      fireEvent.click(toggleButton);
+      await fireEvent.click(toggleButton);
     });
     expect(container.querySelector('div')).toMatchSnapshot();
   });
@@ -42,27 +42,45 @@ describe('ToolbarToggle', () => {
   it('should open/close menu correctly', async () => {
     const { container } = render(<ToolbarToggle {...toolbarToggleProps} />);
     const toggleButton = container.querySelector('#foo');
-    expect(toggleButton).toBeTruthy();
+    const expectedTexts = toolbarToggleProps.dropdownItems.filter((item) => !item.isHidden);
+    expect(toggleButton).toBeInTheDocument();
     await act(async () => {
-      fireEvent.click(toggleButton);
+      await fireEvent.click(toggleButton);
     });
-    expect(container.querySelectorAll('.pf-v5-c-menu__list-item')).toHaveLength(2);
+
+    // wait for async actions on toggle to complete
     await act(async () => {
-      fireEvent.click(toggleButton);
+      await Promise.resolve();
     });
-    expect(container.querySelectorAll('.pf-v5-c-menu__list-item')).toHaveLength(0);
+
+    for (const item of expectedTexts) {
+      expect(screen.getByText(item.title)).toBeInTheDocument();
+    }
+    // closes button
+    await act(async () => {
+      await fireEvent.click(toggleButton);
+    });
+
+    // wait for async actions on toggle to complete
+    await act(async () => {
+      await Promise.resolve();
+    });
+    for (const item of expectedTexts) {
+      expect(screen.queryByText(item.title)).not.toBeInTheDocument();
+    }
+    // expect(container.querySelectorAll('.pf-v5-c-menu__list-item')).toHaveLength(0);
   });
 
   it('should call onClick menu item callback', async () => {
     const { container } = render(<ToolbarToggle {...toolbarToggleProps} />);
     const toggleButton = container.querySelector('#foo');
     await act(async () => {
-      fireEvent.click(toggleButton);
+      await fireEvent.click(toggleButton);
     });
     const actionButton = container.querySelector('button.pf-v5-c-menu__item');
     expect(actionButton).toBeTruthy();
     await act(async () => {
-      fireEvent.click(actionButton);
+      await fireEvent.click(actionButton);
     });
     expect(clickSpy).toHaveBeenCalled();
   });

--- a/src/components/Header/HeaderTests/__snapshots__/HeaderAlert.test.js.snap
+++ b/src/components/Header/HeaderTests/__snapshots__/HeaderAlert.test.js.snap
@@ -28,7 +28,7 @@ exports[`HeaderAlert should render correctly dismissable 1`] = `
     class="pf-v5-c-alert__title"
   >
     <span
-      class="pf-v5-u-screen-reader"
+      class="pf-v5-screen-reader"
     >
       Info alert:
     </span>
@@ -92,7 +92,7 @@ exports[`HeaderAlert should render correctly not dismissable 1`] = `
     class="pf-v5-c-alert__title"
   >
     <span
-      class="pf-v5-u-screen-reader"
+      class="pf-v5-screen-reader"
     >
       Info alert:
     </span>

--- a/src/components/Header/HeaderTests/__snapshots__/ToolbarToggle.test.js.snap
+++ b/src/components/Header/HeaderTests/__snapshots__/ToolbarToggle.test.js.snap
@@ -9,7 +9,7 @@ exports[`ToolbarToggle should render correctly 1`] = `
   data-popper-escaped="true"
   data-popper-placement="bottom-end"
   data-popper-reference-hidden="true"
-  style="position: absolute; left: 0px; top: 0px; z-index: 9999; min-width: 0px; transform: translate(0px, 0px);"
+  style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 1; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11); min-width: 0px; transform: translate(0px, 0px);"
 >
   <div
     class="pf-v5-c-menu__content"
@@ -24,14 +24,14 @@ exports[`ToolbarToggle should render correctly 1`] = `
         data-ouia-component-type="PF5/DropdownItem"
         data-ouia-safe="true"
         href="url1"
-        rel="noopener noreferrer"
         role="none"
-        target="_blank"
       >
         <a
           class="pf-v5-c-menu__item"
+          rel="noopener noreferrer"
           role="menuitem"
           tabindex="0"
+          target="_blank"
         >
           <span
             class="pf-v5-c-menu__item-main"

--- a/src/components/Header/HeaderTests/__snapshots__/UserToggle.test.js.snap
+++ b/src/components/Header/HeaderTests/__snapshots__/UserToggle.test.js.snap
@@ -90,7 +90,7 @@ exports[`UserToggle should render correctly with isSmall false 1`] = `
     data-popper-escaped="true"
     data-popper-placement="bottom-end"
     data-popper-reference-hidden="true"
-    style="position: absolute; left: 0px; top: 0px; z-index: 9999; min-width: 0px; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 1; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11); min-width: 0px; transform: translate(0px, 0px);"
   >
     <div
       class="pf-v5-c-menu__content"
@@ -199,15 +199,15 @@ exports[`UserToggle should render correctly with isSmall false 1`] = `
           data-ouia-component-id="OUIA-Generated-DropdownItem-3"
           data-ouia-component-type="PF5/DropdownItem"
           data-ouia-safe="true"
-          rel="noopener noreferrer"
           role="none"
-          target="_blank"
         >
           <a
             class="pf-v5-c-menu__item"
             href="https://www.qa.redhat.com/wapps/ugc/protected/personalInfo.html"
+            rel="noopener noreferrer"
             role="menuitem"
             tabindex="0"
+            target="_blank"
           >
             <span
               class="pf-v5-c-menu__item-main"

--- a/src/components/Navigation/ChromeNavItem.tsx
+++ b/src/components/Navigation/ChromeNavItem.tsx
@@ -54,11 +54,7 @@ const ChromeNavItem = ({
       isActive={active}
       to={href}
       ouiaId={title}
-      component={
-        ((props: LinkWrapperProps) => (
-          <ChromeLink {...props} isBeta={isBetaEnv} isExternal={isExternal} appId={appId} />
-        )) as unknown as React.ReactNode
-      }
+      component={(props: LinkWrapperProps) => <ChromeLink {...props} isBeta={isBetaEnv} isExternal={isExternal} appId={appId} />}
     >
       {typeof title === 'string' && !ignoreCase ? titleCase(title) : title}{' '}
       {isExternal && (

--- a/src/components/Navigation/__snapshots__/Navigation.test.js.snap
+++ b/src/components/Navigation/__snapshots__/Navigation.test.js.snap
@@ -31,7 +31,7 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
       class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
     >
       <span
-        class="pf-v5-u-screen-reader"
+        class="pf-v5-screen-reader"
       />
     </div>
   </section>
@@ -60,7 +60,7 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
             class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
           >
             <span
-              class="pf-v5-u-screen-reader"
+              class="pf-v5-screen-reader"
             />
           </div>
         </a>
@@ -79,7 +79,7 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
             class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
           >
             <span
-              class="pf-v5-u-screen-reader"
+              class="pf-v5-screen-reader"
             />
           </div>
         </a>
@@ -98,7 +98,7 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
             class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
           >
             <span
-              class="pf-v5-u-screen-reader"
+              class="pf-v5-screen-reader"
             />
           </div>
         </a>
@@ -117,7 +117,7 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
             class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__lg ins-m-dark"
           >
             <span
-              class="pf-v5-u-screen-reader"
+              class="pf-v5-screen-reader"
             />
           </div>
         </a>

--- a/src/components/RootApp/RootApp.tsx
+++ b/src/components/RootApp/RootApp.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy, memo, useContext, useEffect } from 'react';
 import { unstable_HistoryRouter as HistoryRouter, HistoryRouterProps } from 'react-router-dom';
 import { HelpTopicContainer, QuickStart, QuickStartContainer, QuickStartContainerProps } from '@patternfly/quickstarts';
+import { useAtomValue } from 'jotai';
 import chromeHistory from '../../utils/chromeHistory';
 import { FeatureFlagsProvider } from '../FeatureFlags';
 import ScalprumRoot from './ScalprumRoot';
@@ -18,6 +19,7 @@ import { DeepRequired } from 'utility-types';
 import ReactDOM from 'react-dom';
 import { FooterProps } from '../Footer/Footer';
 import ChromeAuthContext, { ChromeAuthContextValue } from '../../auth/ChromeAuthContext';
+import { activeModuleAtom } from '../../state/atoms';
 
 const NotEntitledModal = lazy(() => import('../NotEntitledModal'));
 const Debugger = lazy(() => import('../Debugger'));
@@ -29,7 +31,7 @@ const RootApp = memo((props: RootAppProps) => {
   const { activateQuickstart, allQuickStartStates, setAllQuickStartStates, activeQuickStartID, setActiveQuickStartID } = useQuickstartsStates();
   const { helpTopics, addHelpTopics, disableTopics, enableTopics } = useHelpTopicState();
   const dispatch = useDispatch();
-  const activeModule = useSelector(({ chrome: { activeModule } }: ReduxState) => activeModule);
+  const activeModule = useAtomValue(activeModuleAtom);
   const quickStarts = useSelector(
     ({
       chrome: {

--- a/src/hooks/useDisablePendoOnLanding.ts
+++ b/src/hooks/useDisablePendoOnLanding.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
-import { ReduxState } from '../redux/store';
 import { isITLessEnv } from '../utils/consts';
+import { useAtomValue } from 'jotai';
+import { activeModuleAtom } from '../state/atoms';
 
 // interval timing is short because we want to catch the bubble before ASAP so it does not cover the VA button
 const RETRY_ATTEMPS = 2000;
@@ -23,7 +23,7 @@ function retry(fn: () => void, retriesLeft = 50, interval = 100) {
 }
 
 const useDisablePendoOnLanding = () => {
-  const activeModule = useSelector((state: ReduxState) => state.chrome.activeModule);
+  const activeModule = useAtomValue(activeModuleAtom);
 
   const toggleGuides = () => {
     // push the call to the end of the event loop to make sure the pendo script is loaded and initialized

--- a/src/hooks/useTrackPendoUsage.ts
+++ b/src/hooks/useTrackPendoUsage.ts
@@ -1,7 +1,7 @@
-import { useSelector } from 'react-redux';
-import { ReduxState } from '../redux/store';
+import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useRef } from 'react';
 import { useSegment } from '../analytics/useSegment';
+import { activeModuleAtom } from '../state/atoms';
 
 const badgeQuery = 'div[id^="_pendo-badge_"]';
 const RETRY_ATTEMPS = 10;
@@ -9,7 +9,7 @@ const RETRY_INTERVAL = 2000;
 const SEGMENT_EVENT_NAME = 'pendo-badge-clicked';
 
 const useTrackPendoUsage = () => {
-  const activeModule = useSelector<ReduxState>((state) => state.chrome.activeModule);
+  const activeModule = useAtomValue(activeModuleAtom);
   const mutableData = useRef({ activeModule });
   const { analytics } = useSegment();
   const setupEventTracking = useCallback(() => {

--- a/src/hooks/useUserSSOScopes.ts
+++ b/src/hooks/useUserSSOScopes.ts
@@ -3,6 +3,8 @@ import { useSelector } from 'react-redux';
 import { ReduxState } from '../redux/store';
 import { LOGIN_SCOPES_STORAGE_KEY } from '../utils/common';
 import ChromeAuthContext from '../auth/ChromeAuthContext';
+import { useAtomValue } from 'jotai';
+import { activeModuleAtom } from '../state/atoms';
 
 /**
  * If required, attempt to reauthenticate current user with full profile login.
@@ -17,8 +19,9 @@ const useUserSSOScopes = () => {
       return [];
     }
   };
+  const activeModuleId = useAtomValue(activeModuleAtom);
   // get scope module definition
-  const activeModule = useSelector(({ chrome: { activeModule, modules } }: ReduxState) => (activeModule ? (modules || {})[activeModule] : undefined));
+  const activeModule = useSelector(({ chrome: { modules } }: ReduxState) => (activeModuleId ? (modules || {})[activeModuleId] : undefined));
   const requiredScopes = activeModule?.config?.ssoScopes || [];
 
   useEffect(() => {

--- a/src/redux/action-types.ts
+++ b/src/redux/action-types.ts
@@ -21,7 +21,6 @@ export const LOAD_NAVIGATION_LANDING_PAGE = '@@chrome/load-navigation-landing-pa
 export const LOAD_LEFT_NAVIGATION_SEGMENT = '@@chrome/load-navigation-segment';
 export const LOAD_MODULES_SCHEMA = '@@chrome/load-modules-schema';
 
-export const CHANGE_ACTIVE_MODULE = '@@chrome/change-active-module';
 export const SET_PENDO_FEEDBACK_FLAG = '@@chrome/set-pendo-feedback-flag';
 export const TOGGLE_FEEDBACK_MODAL = '@@chrome/toggle-feedback-modal';
 export const TOGGLE_DEBUGGER_MODAL = '@@chrome/toggle-debugger-modal';

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -119,11 +119,6 @@ export const loadModulesSchema = (schema: { [key: string]: ChromeModule }) => ({
   },
 });
 
-export const changeActiveModule = (module: string) => ({
-  type: actionTypes.CHANGE_ACTIVE_MODULE,
-  payload: module,
-});
-
 /**
  * @deprecated
  */

--- a/src/redux/chromeReducers.ts
+++ b/src/redux/chromeReducers.ts
@@ -154,14 +154,6 @@ export function loadModulesSchemaReducer(
   };
 }
 
-export function changeActiveModuleReducer(state: ChromeState, { payload }: { payload: string }): ChromeState {
-  return {
-    ...state,
-    activeModule: payload,
-    appId: payload,
-  };
-}
-
 export function setPendoFeedbackFlag(
   state: ChromeState,
   {

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -4,7 +4,6 @@ import {
   accessRequestsNotificationsReducer,
   addQuickstartstoApp,
   appNavClick,
-  changeActiveModuleReducer,
   clearQuickstartsReducer,
   contextSwitcherBannerReducer,
   disableQuickstartsReducer,
@@ -48,7 +47,6 @@ import {
 import {
   ADD_QUICKSTARTS_TO_APP,
   APP_NAV_CLICK,
-  CHANGE_ACTIVE_MODULE,
   CHROME_GET_ALL_SIDS,
   CHROME_GET_ALL_TAGS,
   CHROME_GET_ALL_WORKLOADS,
@@ -97,7 +95,6 @@ const reducers = {
   [LOAD_NAVIGATION_LANDING_PAGE]: loadNavigationLandingPageReducer,
   [LOAD_LEFT_NAVIGATION_SEGMENT]: loadNavigationSegmentReducer,
   [LOAD_MODULES_SCHEMA]: loadModulesSchemaReducer,
-  [CHANGE_ACTIVE_MODULE]: changeActiveModuleReducer,
   [SET_PENDO_FEEDBACK_FLAG]: setPendoFeedbackFlag,
   [TOGGLE_FEEDBACK_MODAL]: toggleFeedbackModal,
   [TOGGLE_DEBUGGER_MODAL]: toggleDebuggerModal,

--- a/src/redux/store.d.ts
+++ b/src/redux/store.d.ts
@@ -39,7 +39,6 @@ export type NotificationsPayload = {
 export type ChromeState = {
   contextSwitcherOpen: boolean;
   activeApp?: string;
-  activeModule?: string;
   activeProduct?: string;
   /**
    * @deprecated

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai';
+// setup initial chrome atoms
+export const contextSwitcherOpenAtom = atom(false);
+export const activeModuleAtom = atom<string | undefined>(undefined);

--- a/src/state/chromeStore.ts
+++ b/src/state/chromeStore.ts
@@ -1,0 +1,15 @@
+import { createStore } from 'jotai';
+import { activeModuleAtom, contextSwitcherOpenAtom } from './atoms';
+
+const chromeStore = createStore();
+
+// setup initial chrome store state
+chromeStore.set(contextSwitcherOpenAtom, false);
+chromeStore.set(activeModuleAtom, undefined);
+
+// globally handle subscription to activeModuleAtom
+chromeStore.sub(activeModuleAtom, () => {
+  // console.log('activeModule in store', chromeStore.get(activeModuleAtom));
+});
+
+export default chromeStore;

--- a/src/utils/createCase.ts
+++ b/src/utils/createCase.ts
@@ -5,9 +5,10 @@ const log = logger('createCase.js');
 
 import { getEnvDetails, isBeta, isProd } from './common';
 import { HYDRA_ENDPOINT } from './consts';
-import { spinUpStore } from '../redux/redux-config';
 import { ChromeUser } from '@redhat-cloud-services/types';
 import { getUrl } from '../hooks/useBundle';
+import chromeStore from '../state/chromeStore';
+import { activeModuleAtom } from '../state/atoms';
 
 // Lit of products that are bundles
 const BUNDLE_PRODUCTS = [
@@ -62,9 +63,8 @@ async function getAppInfo(activeModule: string) {
 }
 
 async function getProductData() {
-  const { store } = spinUpStore();
-  const activeModule = store.getState().chrome.activeModule || '';
-  const appData = await getAppInfo(activeModule);
+  const activeModule = chromeStore.get(activeModuleAtom);
+  const appData = await getAppInfo(activeModule ?? '');
   return appData;
 }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-29369

The Redux (flux) model is no longer the go-to state management model when it comes to React. Jotai is the spiritual successor to Recoil which is a state management model developed by Facebook engineers. Probably a good candidate to follow.

The good thing is, it allows us a gradual migration. We can pick state variables one by one and move them to the new model.

Important files: 
- https://github.com/RedHatInsights/insights-chrome/pull/2699/files#diff-4f391b6614cfc759f52964ba718774cf55654adf2acc6f23f70cf67eb0c0a08f
- https://github.com/RedHatInsights/insights-chrome/pull/2699/files#diff-35d73a5e8d99567a4b2cf5938c57256b822ff611d504775ca1079bd6d1f8689f
- https://github.com/RedHatInsights/insights-chrome/pull/2699/files#diff-3c8623839f8dcc909b7cac049e0daf4a20b5f4091a709c547758ddbd111c604b

EDIT

### Important to realize why single store state management can be problematic
[performance issues if not used correctly](https://stackblitz.com/edit/stackblitz-starters-4qzcyn?file=src%2Findex.tsx).