### PR TITLE
Add aditional logic for pendo guides stopping.

### DIFF
--- a/src/hooks/useDisablePendoOnLanding.ts
+++ b/src/hooks/useDisablePendoOnLanding.ts
@@ -8,15 +8,39 @@ import { isITLessEnv } from '../utils/consts';
 const RETRY_ATTEMPS = 500;
 const RETRY_INTERVAL = 50;
 
+function retry(fn: () => void, retriesLeft = 10, interval = 100) {
+  try {
+    return fn();
+  } catch (error) {
+    console.error(error);
+    const newRetry = retriesLeft - 1;
+    if (newRetry > 0) {
+      setTimeout(() => {
+        retry(fn, newRetry, interval);
+      }, interval);
+    }
+  }
+}
+
 const useDisablePendoOnLanding = () => {
   const activeModule = useSelector((state: ReduxState) => state.chrome.activeModule);
 
   const toggleGuides = () => {
-    if (window.pendo && activeModule === 'landing') {
-      window.pendo.stopGuides?.();
-    } else {
-      window.pendo?.startGuides?.();
-    }
+    // push the call to the end of the event loop to make sure the pendo script is loaded and initialized
+    setTimeout(() => {
+      if (window.pendo && activeModule === 'landing') {
+        // pendo functions might not be ready for what ever reason, we will have to retry a few times to give it a shot
+        retry(() => {
+          window.pendo?.setGuidesDisabled?.(true);
+          window.pendo?.stopGuides?.();
+        });
+      } else if (window.pendo) {
+        retry(() => {
+          window.pendo?.setGuidesDisabled?.(false);
+          window.pendo?.startGuides?.();
+        });
+      }
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
Why?

Even though the `pendo` object might exist on window, it does not mean all the functions do :upside_down_face: . We have to try a few times until the functions are present on the global object.

I've also added a timeout function to push the guides toggle execution on the end of the stack