### PR TITLE
Use correct docs api link

### DIFF
--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -18,7 +18,7 @@ const redirects = [
   },
   {
     path: '/docs',
-    to: '/api/docs',
+    to: '/docs/api',
   },
   {
     path: '/settings',


### PR DESCRIPTION
### Description

When user clicks on docs on api docs they should be redirected to the `/docs/api` site.


### JIRA

https://issues.redhat.com/browse/RHCLOUD-26881