### PR TITLE
Prevent sentry re-initialization

### DIFF
--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -3,6 +3,8 @@ import { BrowserTracing } from '@sentry/tracing';
 import { ChromeUser } from '@redhat-cloud-services/types';
 import { isProd } from './common';
 
+let sentryInitialized = false;
+
 function getAppDetails() {
   const pathName = window.location.pathname.split('/');
   let appGroup;
@@ -32,6 +34,11 @@ function getAppDetails() {
 
 // Actually initialize sentry with the group's api key
 function initSentry() {
+  if (sentryInitialized) {
+    return;
+  }
+
+  sentryInitialized = true;
   const appDetails = getAppDetails();
 
   let API_KEY;


### PR DESCRIPTION
Sentry cannot be initialized more than once per browser session. Currently, sentry is initiated on each token refresh which will be problematic.