### PR TITLE
Remove api.console default scope

### DIFF
--- a/src/auth/OIDCConnector/utils.ts
+++ b/src/auth/OIDCConnector/utils.ts
@@ -65,7 +65,7 @@ export function login(auth: AuthContextProps, requiredScopes: string[] = [], red
   // Redirect to login
   Cookies.set('cs_loggedOut', 'false');
   //FIX ME: Temp fix until scope is added in-boundary
-  let scope = ITLess() ? ['openid', ...requiredScopes] : ['openid', 'api.console', ...requiredScopes];
+  let scope = ITLess() ? ['openid', ...requiredScopes] : ['openid', ...requiredScopes];
   const partner = getPartnerScope(window.location.pathname);
   if (partner) {
     scope.push(partner);


### PR DESCRIPTION
Revert of: https://issues.redhat.com/browse/RHCLOUD-29135

The tenants are not yet ready to use this scope.