### PR TITLE
Add dist folder to pr check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,6 +7,7 @@ export IMAGE="quay.io/cloudservices/$COMPONENT"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 export INCLUDE_CHROME_CONFIG="true"
+export DIST_FOLDER=build
 export LANG=C.UTF-8
 cat /etc/redhat-release
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master


### PR DESCRIPTION
Add the same `DIST_FOLDER` env var we use in `build_deploy.sh` to `pr_check.sh` - we need this so I can merge a fix to the build containers so your pr check containers get the right file layout.