### PR TITLE
add ouiaId for orgId in user dropdown

### DIFF
--- a/src/components/Header/UserToggle.tsx
+++ b/src/components/Header/UserToggle.tsx
@@ -73,7 +73,7 @@ const DropdownItems = ({
         </Tooltip>
       )}
       {orgId && (
-        <DropdownItem key="Org ID" isDisabled>
+        <DropdownItem key="Org ID" isDisabled ouiaId="chrome-user-org-id">
           <dl className="chr-c-dropdown-item__stack">
             <dt className="chr-c-dropdown-item__stack--header">{intl.formatMessage(messages.orgId)}</dt>
             <dd className="chr-c-dropdown-item__stack--value">{orgId}</dd>


### PR DESCRIPTION
- Add OUIA ID `chrome-user-org-id` for Org ID so that it can be reliably used in automation for element look-ups. ([RHCLOUD-28151](https://issues.redhat.com/browse/RHCLOUD-28151))