### PR TITLE
Fix service-accounts link in dropdown

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -154,7 +154,7 @@ const Tools = () => {
           title: 'Authentication Policy',
         },
         {
-          url: '/application-services/service-accounts',
+          url: '/iam/service-accounts',
           title: 'Service Accounts',
         },
       ],


### PR DESCRIPTION
[RHCLOUD-30992](https://issues.redhat.com/browse/RHCLOUD-30992)

Fixed service-accounts link in dropdown to contain /iam instead of /application-services
