### PR TITLE
Services Nav Fixes

### DIFF
--- a/cypress/component/AllServicesDropdown/AllServicesDropdown.cy.tsx
+++ b/cypress/component/AllServicesDropdown/AllServicesDropdown.cy.tsx
@@ -88,4 +88,71 @@ describe('<AllServicesDropdown />', () => {
     // Run the procedure again and check if the menu closed
     checkMenuClosed();
   });
+
+  it('should automatically minimize tabs after clicking on small screen', () => {
+    cy.intercept('http://localhost:8080/api/chrome-service/v1/static/stable/stage/services/services.json', [
+      {
+        id: 'testSection',
+        description: 'Test section description',
+        title: 'Test section',
+        icon: 'CloudUploadAltIcon',
+        links: [
+          {
+            title: 'Test Link',
+            href: '/test/link',
+            description: 'Test link description',
+          },
+        ],
+      },
+    ]);
+    cy.window().then((win) => {
+      (win as any).foo = {
+        init: () => undefined,
+        get: () => () => ({
+          default: () => <div>Foo</div>,
+        }),
+      };
+    });
+    const store = createStore(() => ({
+      chrome: {
+        moduleRoutes: [
+          {
+            path: '/test/link',
+            scope: 'foo',
+            module: 'bar',
+          },
+        ],
+      },
+    }));
+    cy.viewport(320, 568);
+    cy.mount(
+      <ScalprumProvider
+        config={{
+          foo: {
+            name: 'foo',
+            manifestLocation: '/foo/bar.json',
+          },
+        }}
+      >
+        <Provider store={store}>
+          <BrowserRouter>
+            <IntlProvider locale="en">
+              <AllServicesDropdown />
+            </IntlProvider>
+          </BrowserRouter>
+        </Provider>
+      </ScalprumProvider>
+    );
+
+    // open the Services dropdown
+    cy.get('.pf-v5-c-menu-toggle__text').click();
+    // check that the services tabs are not expanded
+    cy.get('[data-ouia-component-id="OUIA-Generated-Tabs-2"]').should('not.have.class', 'pf-m-expanded');
+    // click to expand the services tabs
+    cy.get('[data-ouia-component-id="OUIA-Generated-Button-plain-4"]').click();
+    cy.get('[data-ouia-component-id="OUIA-Generated-Tabs-2"]').should('have.class', 'pf-m-expanded');
+    // check that the services tabs are not expanded after clicking on a section
+    cy.contains('Test section').click();
+    cy.get('[data-ouia-component-id="OUIA-Generated-Tabs-2"]').should('not.have.class', 'pf-m-expanded');
+  });
 });

--- a/cypress/component/AllServicesDropdown/AllServicesDropdown.cy.tsx
+++ b/cypress/component/AllServicesDropdown/AllServicesDropdown.cy.tsx
@@ -147,12 +147,12 @@ describe('<AllServicesDropdown />', () => {
     // open the Services dropdown
     cy.get('.pf-v5-c-menu-toggle__text').click();
     // check that the services tabs are not expanded
-    cy.get('[data-ouia-component-id="OUIA-Generated-Tabs-2"]').should('not.have.class', 'pf-m-expanded');
-    // click to expand the services tabs
-    cy.get('[data-ouia-component-id="OUIA-Generated-Button-plain-4"]').click();
-    cy.get('[data-ouia-component-id="OUIA-Generated-Tabs-2"]').should('have.class', 'pf-m-expanded');
+    cy.get('[data-ouia-component-id="all-services-tabs"]').should('not.have.class', 'pf-m-expanded');
+    // expand the services tabs
+    cy.contains('Favorites').click();
+    cy.get('[data-ouia-component-id="all-services-tabs"]').should('have.class', 'pf-m-expanded');
     // check that the services tabs are not expanded after clicking on a section
     cy.contains('Test section').click();
-    cy.get('[data-ouia-component-id="OUIA-Generated-Tabs-2"]').should('not.have.class', 'pf-m-expanded');
+    cy.get('[data-ouia-component-id="all-services-tabs"]').should('not.have.class', 'pf-m-expanded');
   });
 });

--- a/src/components/AllServicesDropdown/AllServicesMenu.tsx
+++ b/src/components/AllServicesDropdown/AllServicesMenu.tsx
@@ -40,6 +40,12 @@ const AllServicesMenu = ({ setIsOpen, isOpen, menuRef, linkSections, favoritedSe
     setActiveTabKey(tabIndex);
   };
 
+  const handleClickOutside = (event: React.MouseEvent<any>) => {
+    if (isOpen && panelRef.current && !panelRef.current?.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
   const onTabClick = (section: AllServicesSection, index: number) => {
     setSelectedService(section);
     setActiveTabKey(index);
@@ -51,6 +57,8 @@ const AllServicesMenu = ({ setIsOpen, isOpen, menuRef, linkSections, favoritedSe
 
   const tabContentRef = React.createRef<HTMLElement>();
 
+  const panelRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <AllServicesDropdownContext.Provider
       value={{
@@ -60,9 +68,14 @@ const AllServicesMenu = ({ setIsOpen, isOpen, menuRef, linkSections, favoritedSe
         },
       }}
     >
-      <div ref={menuRef} className="pf-v5-u-w-100 chr-c-page__services-nav-dropdown-menu" data-testid="chr-c__find-app-service">
+      <div
+        ref={menuRef}
+        className="pf-v5-u-w-100 chr-c-page__services-nav-dropdown-menu"
+        data-testid="chr-c__find-app-service"
+        onClick={handleClickOutside}
+      >
         <Backdrop>
-          <Panel variant="raised" className="pf-v5-u-p-0 chr-c-panel-services-nav">
+          <Panel variant="raised" className="pf-v5-u-p-0 chr-c-panel-services-nav" ref={panelRef}>
             <PanelMain>
               <Sidebar>
                 <SidebarPanel>

--- a/src/components/AllServicesDropdown/AllServicesMenu.tsx
+++ b/src/components/AllServicesDropdown/AllServicesMenu.tsx
@@ -49,6 +49,7 @@ const AllServicesMenu = ({ setIsOpen, isOpen, menuRef, linkSections, favoritedSe
   const onTabClick = (section: AllServicesSection, index: number) => {
     setSelectedService(section);
     setActiveTabKey(index);
+    setIsExpanded(false);
   };
 
   const onToggle = (_e: React.MouseEvent<any>, isExpanded: boolean) => {

--- a/src/components/AllServicesDropdown/AllServicesTabs.tsx
+++ b/src/components/AllServicesDropdown/AllServicesTabs.tsx
@@ -75,6 +75,7 @@ const AllServicesTabs = ({
       toggleText={activeTabTitle}
       role="region"
       className="pf-v5-u-p-md pf-v5-u-pr-0"
+      ouiaId={'all-services-tabs'}
     >
       <TabWrapper
         onClick={(e) => {


### PR DESCRIPTION
Made the following fixes to the Services Dropdown:
- Clicking outside of the Nav dropdown closes it ([RHCLOUD-26592](https://issues.redhat.com/browse/RHCLOUD-26592))
- On small screens, automatically close the category Nav once one is selected ([RHCLOUD-26873](https://issues.redhat.com/browse/RHCLOUD-26873))