### PR TITLE
[RHCLOUD-31209] Enable feedback modal on landing page -- Fixes VA feedback

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -26,7 +26,7 @@ const FeedbackRoute = () => {
   const paths =
     localStorage.getItem('chrome:experimental:feedback') === 'true'
       ? ['*']
-      : ['insights/*', 'settings/*', 'openshift/*', 'application-services/*', 'ansible/*', 'edge/*'];
+      : ['/', 'insights/*', 'settings/*', 'openshift/*', 'application-services/*', 'ansible/*', 'edge/*'];
   return (
     <Routes>
       {paths.map((path) => (


### PR DESCRIPTION
Currently the feedback modal is disabled on the landing page, Kat gave us a 👍  to turn it on there which should fix the VA feedback loop

https://issues.redhat.com/browse/RHCLOUD-31209