### PR TITLE
Enable feedback on subs pages

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -26,7 +26,7 @@ const FeedbackRoute = () => {
   const paths =
     localStorage.getItem('chrome:experimental:feedback') === 'true'
       ? ['*']
-      : ['/', 'insights/*', 'settings/*', 'openshift/*', 'application-services/*', 'ansible/*', 'edge/*'];
+      : ['/', 'insights/*', 'settings/*', 'openshift/*', 'application-services/*', 'ansible/*', 'edge/*', 'subscriptions/*'];
   return (
     <Routes>
       {paths.map((path) => (


### PR DESCRIPTION
### Description

Subscriptions team would like to see the feedback button on all of their pages. This PR enables it for `subscriptions/*` pages.

### JIRA

https://issues.redhat.com/browse/RHCLOUD-31638

### Screenshot

![Screenshot from 2024-03-26 17-03-44](https://github.com/RedHatInsights/insights-chrome/assets/3439771/098691ff-3950-4bfc-b7db-ec6c9703c08e)