### PR TITLE
update insights bundle title suffix to RHEL

### DIFF
--- a/src/hooks/useBundle.ts
+++ b/src/hooks/useBundle.ts
@@ -19,7 +19,7 @@ export const bundleMapping: {
   'application-services': 'Application and Data Services',
   openshift: 'OpenShift',
   ansible: 'Ansible Automation Platform',
-  insights: 'Red Hat Insights',
+  insights: 'RHEL',
   edge: 'Edge management',
   settings: 'Settings',
   landing: 'Home',


### PR DESCRIPTION
interact team is working on consolidating the insights page titles [RHINENG-9387](https://issues.redhat.com/browse/RHINENG-9387). It requires those page titles to have 'RHEL' instead of  the 'Red hat insights' suffix at the end. This PR makes this change in chrome repo so that the default suffix is applied to all insights apps in the bundle.