### PR TITLE
RHCLOUD-32008: create internal jotai state for preview

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -28,12 +28,15 @@ import BellIcon from '@patternfly/react-icons/dist/dynamic/icons/bell-icon';
 import { toggleNotificationsDrawer } from '../../redux/actions';
 import useWindowWidth from '../../hooks/useWindowWidth';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
+import { isPreviewAtom } from '../../state/atoms/releaseAtom';
+import chromeStore from '../../state/chromeStore';
 
 const isITLessEnv = ITLess();
 
 export const switchRelease = (isBeta: boolean, pathname: string, previewEnabled: boolean) => {
   cookie.set('cs_toggledRelease', 'true');
   const previewFragment = getRouterBasename(pathname);
+  chromeStore.set(isPreviewAtom, !isBeta);
 
   if (isBeta) {
     return pathname.replace(previewFragment.includes('beta') ? /\/beta/ : /\/preview/, '');

--- a/src/state/atoms/releaseAtom.ts
+++ b/src/state/atoms/releaseAtom.ts
@@ -1,0 +1,5 @@
+import { atomWithToggle } from './utils';
+
+import { isBeta } from '../../utils/common';
+
+export const isPreviewAtom = atomWithToggle(isBeta());

--- a/src/state/atoms/utils.ts
+++ b/src/state/atoms/utils.ts
@@ -1,0 +1,11 @@
+import { WritableAtom, atom } from 'jotai';
+
+// recipe from https://jotai.org/docs/recipes/atom-with-toggle
+export function atomWithToggle(initialValue?: boolean): WritableAtom<boolean, [boolean?], void> {
+  const anAtom = atom(initialValue, (get, set, nextValue?: boolean) => {
+    const update = nextValue ?? !get(anAtom);
+    set(anAtom, update);
+  });
+
+  return anAtom as WritableAtom<boolean, [boolean?], void>;
+}

--- a/src/state/chromeStore.ts
+++ b/src/state/chromeStore.ts
@@ -1,12 +1,15 @@
 import { createStore } from 'jotai';
 import { activeModuleAtom } from './atoms/activeModuleAtom';
 import { contextSwitcherOpenAtom } from './atoms/contextSwitcher';
+import { isPreviewAtom } from './atoms/releaseAtom';
+import { isBeta } from '../utils/common';
 
 const chromeStore = createStore();
 
 // setup initial chrome store state
 chromeStore.set(contextSwitcherOpenAtom, false);
 chromeStore.set(activeModuleAtom, undefined);
+chromeStore.set(isPreviewAtom, isBeta());
 
 // globally handle subscription to activeModuleAtom
 chromeStore.sub(activeModuleAtom, () => {


### PR DESCRIPTION
Adds an internal state variable via jotai to track if preview is enabled or disabled.

Tested locally by adding a sub in the store with a console log (see screenshots). The state is correctly toggled with the preview toggle and initialized when chrome loads.

### Preview disabled
![Screenshot 2024-05-10 at 12 50 32 AM](https://github.com/RedHatInsights/insights-chrome/assets/21317056/ed2145c1-e934-47e5-8980-92d7f5a640af)
### Preview enabled
![Screenshot 2024-05-10 at 12 50 44 AM](https://github.com/RedHatInsights/insights-chrome/assets/21317056/7b1d4155-a387-47a2-886b-4b99de4df4f9)
