### PR TITLE
Replace sentry var to check for app names

### DIFF
--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -42,7 +42,7 @@ function initSentry() {
   const appDetails = getAppDetails();
 
   let API_KEY;
-  switch (appDetails.app.group) {
+  switch (appDetails.app.name) {
     case 'advisor':
       API_KEY = 'https://f8eb44de949e487e853185c09340f3cf@o490301.ingest.us.sentry.io/4505397435367424';
       break;


### PR DESCRIPTION
Just for proof of concept, I want sentry to check for advisor in the url. Currently only insights apps are using sentry regardless so no need to check if its insights or any other group like ansible. 

Source maps are currently up for Advisor. With this change I can further investigate mapping against source maps with a wrapper and 'consumed' app. 