### PR TITLE
Fixed title and route in Notifications menu

### DIFF
--- a/src/components/NotificationsDrawer/DrawerPanelContent.tsx
+++ b/src/components/NotificationsDrawer/DrawerPanelContent.tsx
@@ -140,9 +140,9 @@ const DrawerPanelBase = ({ innerRef }: DrawerPanelProps) => {
     </DropdownItem>,
     <Divider key="divider" />,
     <DropdownItem key="quick links" description="Quick links" />,
-    <DropdownItem key="event log" onClick={() => onNavigateTo('/settings/notifications/eventlog')}>
+    <DropdownItem key="notifications log" onClick={() => onNavigateTo('/settings/notifications/notificationslog')}>
       <Flex>
-        <FlexItem>View event log</FlexItem>
+        <FlexItem>View notifications log</FlexItem>
       </Flex>
     </DropdownItem>,
     (isOrgAdmin || hasNotificationsPermissions) && (


### PR DESCRIPTION
Change link title from "View event log" to "View notifications log" and change routing from "/settings/notifications/eventlog" to "/settings/notifications/notificationslog"

https://issues.redhat.com/browse/RHCLOUD-32790

Before:
![image](https://github.com/RedHatInsights/insights-chrome/assets/51480040/9882c61a-1dbd-4ae2-a07e-b662daa278f8)

After:
![image](https://github.com/RedHatInsights/insights-chrome/assets/51480040/784a7fb7-6d62-4fe7-a3ab-0a8275807164)
