### PR TITLE
Make year in footer update automatically

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -9,6 +9,8 @@ import RedHatIcon from '@patternfly/react-icons/dist/dynamic/icons/redhat-icon';
 
 import './Footer.scss';
 
+const currentYear = new Date().getFullYear();
+
 export type FooterProps = {
   setCookieElement: Dispatch<SetStateAction<HTMLAnchorElement | null>>;
   cookieElement: Element | null;
@@ -39,7 +41,7 @@ const Footer = ({ setCookieElement, cookieElement }: FooterProps) => {
           <Flex className="pf-m-column pf-v5-u-align-self-flex-start">
             <TextContent className="pf-v5-l-flex pf-v5-u-mb-sm">
               <Text component="p" className="pf-v5-u-color-400 pf-v5-u-font-size-xs">
-                ©2023 Red Hat, Inc.
+                ©{currentYear} Red Hat, Inc.
               </Text>
             </TextContent>
             <TextContent className="pf-v5-l-flex pf-m-column pf-v5-u-flex-direction-row-on-md pf-v5-u-font-size-xs">

--- a/src/components/Stratosphere/Footer.tsx
+++ b/src/components/Stratosphere/Footer.tsx
@@ -6,6 +6,8 @@ import React, { VoidFunctionComponent } from 'react';
 
 import './footer.scss';
 
+const currentYear = new Date().getFullYear();
+
 const FooterLink: VoidFunctionComponent<{ href: string; label: React.ReactNode }> = ({ href, label }) => (
   <TextContent>
     <Text component="small">
@@ -24,7 +26,7 @@ const Footer = () => (
       </LevelItem>
       <LevelItem className="pf-v5-u-mr-2xl">
         <TextContent>
-          <Text component="small">Copyright c 2023 Red Hat, Inc.</Text>
+          <Text component="small">Copyright c {currentYear} Red Hat, Inc.</Text>
         </TextContent>
       </LevelItem>
       <LevelItem className="pf-v5-u-mr-auto">


### PR DESCRIPTION
Made the year in footer update automatically

[RHCLOUD-32979](https://issues.redhat.com/browse/RHCLOUD-32979)

Before:
![image](https://github.com/RedHatInsights/insights-chrome/assets/50696716/e2f652cf-be09-4fe4-9e0d-0cd1658b9039)

Now:
<img width="710" alt="image" src="https://github.com/RedHatInsights/insights-chrome/assets/50696716/645ad8fb-2632-4215-bb4d-dd43cbf8e40f">
