### PR TITLE
Enable scoped UI id header to same origin.

### DIFF
--- a/cypress/e2e/release-gate/refresh-token.cy.ts
+++ b/cypress/e2e/release-gate/refresh-token.cy.ts
@@ -1,0 +1,23 @@
+// Landing page has changed
+describe('Auth', () => {
+  it('should force refresh token', () => {
+    cy.login();
+    cy.intercept('POST', 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token').as('tokenRefresh');
+    cy.visit('/');
+    // initial token request
+    cy.wait('@tokenRefresh');
+
+    // wait for chrome to init
+    cy.contains('Services').should('be.visible');
+    // intercept it after initial load
+    // force token refresh
+    cy.wait(1000);
+    cy.window().then((win) => {
+      win.insights.chrome.$internal.forceAuthRefresh();
+    });
+
+    cy.wait('@tokenRefresh').then((interception) => {
+      expect(interception.response?.statusCode).to.eq(200);
+    });
+  });
+});

--- a/src/auth/ChromeAuthContext.ts
+++ b/src/auth/ChromeAuthContext.ts
@@ -20,6 +20,7 @@ export type ChromeAuthContextValue<LoginResponse = void> = {
   getOfflineToken: () => Promise<AxiosResponse<OfflineTokenResponse>>;
   doOffline: () => Promise<void>;
   reAuthWithScopes: (...scopes: string[]) => Promise<void>;
+  forceRefresh: () => Promise<unknown>;
 };
 
 const blankUser: ChromeUser = {
@@ -49,6 +50,7 @@ const ChromeAuthContext = createContext<ChromeAuthContextValue>({
   tokenExpires: 0,
   user: blankUser,
   reAuthWithScopes: () => Promise.resolve(),
+  forceRefresh: () => Promise.resolve(),
 });
 
 export default ChromeAuthContext;

--- a/src/auth/OIDCConnector/OIDCSecured.tsx
+++ b/src/auth/OIDCConnector/OIDCSecured.tsx
@@ -114,6 +114,7 @@ export function OIDCSecured({
         encodeURIComponent(redirectUri.toString().split('#')[0])
       );
     },
+    forceRefresh: () => Promise.resolve(),
     doOffline: () => login(authRef.current, ['offline_access'], prepareOfflineRedirect()),
     getUser: () => Promise.resolve(mapOIDCUserToChromeUser(authRef.current.user ?? {}, {})),
     token: authRef.current.user?.access_token ?? '',
@@ -162,6 +163,7 @@ export function OIDCSecured({
       user: chromeUser,
       token: user.access_token,
       tokenExpires: user.expires_at!,
+      forceRefresh: authRef.current.signinSilent,
     }));
     sentry(chromeUser);
   }

--- a/src/chrome/create-chrome.test.ts
+++ b/src/chrome/create-chrome.test.ts
@@ -87,6 +87,9 @@ describe('create chrome', () => {
     token: 'string',
     tokenExpires: 0,
     user: mockUser,
+    forceRefresh() {
+      return Promise.resolve();
+    },
   };
 
   const chromeContextOptionsMock = {

--- a/src/chrome/create-chrome.ts
+++ b/src/chrome/create-chrome.ts
@@ -195,6 +195,8 @@ export const createChromeContext = ({
     },
     $internal: {
       store,
+      // Not supposed to be used by tenants
+      forceAuthRefresh: chromeAuth.forceRefresh,
     },
     enablePackagesDebug: () => warnDuplicatePkg(),
     requestPdf,

--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -31,13 +31,13 @@ const shouldInjectUIHeader = (path: URL | Request | string = '') => {
     // the type URL has a different match function than the cases above
     return location.origin === path.origin && !isExcluded(path.href);
   } else if (path instanceof Request) {
-    const isOriginAllowed = location.origin === path.url;
+    const isOriginAllowed = path.url.startsWith(location.origin);
     return isOriginAllowed && !isExcluded(path.url);
   } else if (typeof path === 'string') {
-    return location.origin === path || !path.startsWith('http');
+    return path.startsWith(location.origin) || path.startsWith('/api');
   }
 
-  return true;
+  return false;
 };
 
 const verifyTarget = (originMatch: string, urlMatch: string) => {


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/RHCLOUD-32526, https://issues.redhat.com/browse/RHCLOUD-32982

Only allows the new UI header to be sent to the same origin of the UI.