### PR TITLE
Hide OpenShift VA behind a feature flag.

### DIFF
--- a/src/components/RootApp/ScalprumRoot.test.js
+++ b/src/components/RootApp/ScalprumRoot.test.js
@@ -38,6 +38,7 @@ jest.mock('@unleash/proxy-client-react', () => {
     ...unleash,
     useFlag: () => false,
     useFlagsStatus: () => ({ flagsReady: true }),
+    useFlags: () => [],
   };
 });
 

--- a/src/components/Routes/VirtualAssistant.tsx
+++ b/src/components/Routes/VirtualAssistant.tsx
@@ -1,20 +1,22 @@
 import React, { Fragment } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { ScalprumComponent } from '@scalprum/react-core';
+import { useFlags } from '@unleash/proxy-client-react';
 
 import './virtual-assistant.scss';
 
-const viableRoutes = [
-  '/',
-  '/insights/*',
-  '/settings/*',
-  '/subscriptions/overview/*',
-  '/subscriptions/inventory/*',
-  '/subscriptions/usage/*',
-  '/openshift/insights/*',
-];
+const flaggedRoutes: { [flagName: string]: string } = { 'platform.va.openshift.insights': '/openshift/insights/*' };
 
 const VirtualAssistant = () => {
+  const viableRoutes = ['/', '/insights/*', '/settings/*', '/subscriptions/overview/*', '/subscriptions/inventory/*', '/subscriptions/usage/*'];
+
+  const allFlags = useFlags();
+  allFlags.forEach((flag) => {
+    if (flaggedRoutes[flag.name] && flag.enabled) {
+      viableRoutes.push(flaggedRoutes[flag.name]);
+    }
+  });
+
   return (
     <Routes>
       {viableRoutes.map((route) => (


### PR DESCRIPTION
Enables hiding of VA via feature flags. Currently, VA is showing in openshift insights but it should not be in prod.