### PR TITLE
Send user to User access overview

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -116,7 +116,7 @@ const Tools = () => {
   const intl = useIntl();
   const location = useLocation();
   const settingsPath = isITLessEnv ? `/settings/my-user-access` : enableIntegrations ? `/settings/integrations` : '/settings/sources';
-  const identityAndAccessManagmentPath = '/iam/user-access/users';
+  const identityAndAccessManagmentPath = '/iam/user-access/overview';
   const betaSwitcherTitle = `${isPreview ? intl.formatMessage(messages.stopUsing) : intl.formatMessage(messages.use)} ${intl.formatMessage(
     messages.betaRelease
   )}`;


### PR DESCRIPTION
### Description

If user clicks on Settings -> User access they are send over to `/iam/user-access/users` this is incorrect as we want users to be sent over to overview. This PR fixes such issue, by changing `identityAndAccessManagmentPath` to `/iam/user-access/overview`

### JIRA

https://issues.redhat.com/browse/RHCLOUD-30991