### PR TITLE
Update empty state styling

### DIFF
--- a/src/components/FavoriteServices/EmptyState.scss
+++ b/src/components/FavoriteServices/EmptyState.scss
@@ -1,8 +1,9 @@
 @import "~@redhat-cloud-services/frontend-components-utilities/styles/_all";
 @import '~@patternfly/patternfly/patternfly-addons.scss';
 
-.chr-l-stack__item-centered, .chr-c-card-centered {
-  display: flex;
-  justify-content: center;
-  text-align: center;
+.chrome-favoriteServices {
+  .pf-v5-l-flex {
+    height: 100%;
+    background: yellow;
+  }
 }

--- a/src/components/FavoriteServices/EmptyState.scss
+++ b/src/components/FavoriteServices/EmptyState.scss
@@ -4,6 +4,5 @@
 .chrome-favoriteServices {
   .pf-v5-l-flex {
     height: 100%;
-    background: yellow;
   }
 }

--- a/src/components/FavoriteServices/EmptyState.tsx
+++ b/src/components/FavoriteServices/EmptyState.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
-import { StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
+import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
+import { Stack, StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import { Text, TextContent } from '@patternfly/react-core/dist/dynamic/components/Text';
 
 import React from 'react';
@@ -9,25 +10,30 @@ import './EmptyState.scss';
 
 const EmptyState = () => (
   <>
-    <StackItem className="chr-l-stack__item-centered pf-v5-u-mt-xl">
-      <img src="https://console.redhat.com/apps/frontend-assets/favoritedservices/favoriting-emptystate.svg" alt="favoriting image" />
-    </StackItem>
-    <StackItem className="chr-l-stack__item-centered pf-v5-u-mt-md">
-      <TextContent>
-        <Text component="h3" className="pf-v5-m-center">
-          No favorited services
-        </Text>
-        <Text component="small" className="pf-v5-u-mt-sm">
-          Add a service to your favorites to get started here.
-        </Text>
-      </TextContent>
-    </StackItem>
-    <StackItem className="chr-l-stack__item-centered pf-v5-u-mt-md">
-      <Button variant="primary" alt="View all services" component={(props) => <ChromeLink {...props} href="/allservices" />}>
-        View all services
-      </Button>
-    </StackItem>
+    <Flex className="pf-v5-u-justify-content-center pf-v5-u-align-items-stretch">
+      <Stack className="pf-v5-u-justify-content-center">
+        <StackItem className="pf-v5-u-text-align-center">
+          <img src="https://console.redhat.com/apps/frontend-assets/favoritedservices/favoriting-emptystate.svg" alt="favoriting image" />
+        </StackItem>
+        <StackItem className="pf-v5-u-text-align-center">
+          <TextContent>
+            <Text component="h3" className="pf-v5-m-center">
+              No favorited services
+            </Text>
+            <Text component="small" className="pf-v5-u-mt-sm">
+              Add a service to your favorites to get started here.
+            </Text>
+          </TextContent>
+        </StackItem>
+        <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-md">
+          <Button variant="primary" alt="View all services" component={(props) => <ChromeLink {...props} href="/allservices" />}>
+            View all services
+          </Button>
+        </StackItem>
+      </Stack>
+    </Flex>
   </>
 );
 
 export default EmptyState;
+

--- a/src/components/FavoriteServices/EmptyState.tsx
+++ b/src/components/FavoriteServices/EmptyState.tsx
@@ -36,4 +36,3 @@ const EmptyState = () => (
 );
 
 export default EmptyState;
-


### PR DESCRIPTION
(This PR replaces https://github.com/RedHatInsights/insights-chrome/pull/2888, which did not have the styling scoped to the widget)

- Vertically center Empty state

Jira: https://issues.redhat.com/browse/RHCLOUD-32809

Old
<img width="479" alt="Screenshot 2024-07-02 at 10 25 20 AM" src="https://github.com/RedHatInsights/insights-chrome/assets/1287144/40c5e591-1873-42e8-a7d9-2357c407f3ed">


New
<img width="490" alt="Screenshot 2024-07-02 at 10 19 30 AM" src="https://github.com/RedHatInsights/insights-chrome/assets/1287144/4bfe2e95-08bf-4d6d-929b-30a2396c1308">