### PR TITLE
Remove obsolete document title redux state.

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -1,6 +1,6 @@
-import React, { Suspense, useContext, useEffect, useMemo, useState } from 'react';
+import React, { Suspense, useContext, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Provider, useSelector } from 'react-redux';
+import { Provider } from 'react-redux';
 import { IntlProvider, ReactIntlErrorCode } from 'react-intl';
 import { Provider as JotaiProvider, useSetAtom } from 'jotai';
 
@@ -8,7 +8,6 @@ import { spinUpStore } from './redux/redux-config';
 import RootApp from './components/RootApp';
 import registerAnalyticsObserver from './analytics/analyticsObserver';
 import { ITLess, getEnv, trustarcScriptSetup } from './utils/common';
-import { ReduxState } from './redux/store';
 import OIDCProvider from './auth/OIDCConnector/OIDCProvider';
 import messages from './locales/data.json';
 import ErrorBoundary from './components/ErrorComponents/ErrorBoundary';
@@ -47,15 +46,9 @@ const App = ({ initApp }: { initApp: (...args: Parameters<typeof initChromeUserC
     getUser,
     token,
   });
-  const documentTitle = useSelector(({ chrome }: ReduxState) => chrome?.documentTitle);
   const [cookieElement, setCookieElement] = useState<HTMLAnchorElement | null>(null);
 
   useInitializeAnalytics();
-
-  useMemo(() => {
-    const title = typeof documentTitle === 'string' ? `${documentTitle} | Hybrid Cloud Console` : 'Hybrid Cloud Console';
-    document.title = title;
-  }, [documentTitle]);
 
   return <RootApp cookieElement={cookieElement} setCookieElement={setCookieElement} />;
 };

--- a/src/redux/action-types.ts
+++ b/src/redux/action-types.ts
@@ -11,7 +11,6 @@ export const GLOBAL_FILTER_UPDATE = '@@chrome/global-filter-update';
 export const GLOBAL_FILTER_TOGGLE = '@@chrome/global-filter-toggle';
 export const GLOBAL_FILTER_REMOVE = '@@chrome/global-filter-remove';
 
-export const UPDATE_DOCUMENT_TITLE_REDUCER = '@@chrome/update-document-title';
 export const MARK_ACTIVE_PRODUCT = '@@chrome/mark-active-product';
 
 export const STORE_INITIAL_HASH = '@@chrome/store-initial-hash';

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -81,11 +81,6 @@ export const onToggle = () => ({
   type: 'NAVIGATION_TOGGLE',
 });
 
-export const updateDocumentTitle = (title: string) => ({
-  type: actionTypes.UPDATE_DOCUMENT_TITLE_REDUCER,
-  payload: title,
-});
-
 export const markActiveProduct = (product?: string) => ({
   type: actionTypes.MARK_ACTIVE_PRODUCT,
   payload: product,

--- a/src/redux/chromeReducers.ts
+++ b/src/redux/chromeReducers.ts
@@ -24,13 +24,6 @@ export function onPageObjectId(state: ChromeState, { payload }: { payload: strin
   };
 }
 
-export function documentTitleReducer(state: ChromeState, { payload }: { payload: string }): ChromeState {
-  return {
-    ...state,
-    documentTitle: payload,
-  };
-}
-
 export function markActiveProduct(state: ChromeState, { payload }: { payload?: string }): ChromeState {
   return {
     ...state,

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,6 +1,6 @@
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 
-import { documentTitleReducer, loginReducer, markActiveProduct, onPageAction, onPageObjectId } from './chromeReducers';
+import { loginReducer, markActiveProduct, onPageAction, onPageObjectId } from './chromeReducers';
 import {
   globalFilterDefaultState,
   onGetAllSIDs,
@@ -25,7 +25,6 @@ import {
   GLOBAL_FILTER_TOGGLE,
   GLOBAL_FILTER_UPDATE,
   MARK_ACTIVE_PRODUCT,
-  UPDATE_DOCUMENT_TITLE_REDUCER,
   USER_LOGIN,
 } from './action-types';
 import { ChromeState, GlobalFilterState, ReduxState } from './store';
@@ -35,7 +34,6 @@ const reducers = {
   [USER_LOGIN]: loginReducer,
   [CHROME_PAGE_ACTION]: onPageAction,
   [CHROME_PAGE_OBJECT]: onPageObjectId,
-  [UPDATE_DOCUMENT_TITLE_REDUCER]: documentTitleReducer,
   [MARK_ACTIVE_PRODUCT]: markActiveProduct,
 };
 

--- a/src/redux/store.d.ts
+++ b/src/redux/store.d.ts
@@ -6,7 +6,6 @@ export type ChromeState = {
   pageAction?: string;
   pageObjectId?: string;
   initialHash?: string;
-  documentTitle?: string;
 };
 
 export type GlobalFilterWorkloads = {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-34243

The state variable is not used. The tab title is changed directly via browser API and exposed by a Chrome function.