### PR TITLE
IQE-3075: Add an OUIA ID for iqe-core to consume

### DIFF
--- a/src/components/Header/HeaderTests/__snapshots__/Tools.test.js.snap
+++ b/src/components/Header/HeaderTests/__snapshots__/Tools.test.js.snap
@@ -6,7 +6,7 @@ exports[`Tools should render correctly 1`] = `
 >
   <label
     class="pf-v5-c-switch pf-m-reverse chr-c-beta-switcher"
-    data-ouia-component-id="OUIA-Generated-Switch-2"
+    data-ouia-component-id="PreviewSwitcher"
     data-ouia-component-type="PF5/Switch"
     data-ouia-safe="true"
     for="reversed-switch"

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -266,6 +266,7 @@ const Tools = () => {
         onChange={() => setIsPreview()}
         isReversed
         className="chr-c-beta-switcher"
+        ouiaId="PreviewSwitcher"
       />
     );
   };


### PR DESCRIPTION
iqe-core wants the nav to automagically click the preview switch when `use_beta` is set to true in the framework config (see https://issues.redhat.com/browse/IQE-3075). As such, we want to use an OUIA ID to be able to uniquely interact with the switch. Aria-label is okay, but it could theoretically change and isn't meant to be used as a unique ID for test automation.