### PR TITLE
AAP-29825 add ansible-cloud allowed origin

### DIFF
--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -19,8 +19,7 @@ const AUTH_ALLOWED_ORIGINS = [
   /https:\/\/api(?:\.[a-z]+)?\.openshift(?:[a-z]+)?\.com/,
   /https:\/\/api?\.demo-experience(?:\.[a-z]+)?\.demo?\.redhat?\.com/,
   /https:\/\/api?\.aws?\.ap-southeast-1(?:\.[a-z]+)?\.openshift?\.com/,
-  /https:\/\/console-service?\.[a-z]*-[a-z]*\.aws?\.ansiblecloud?\.com\/api/,
-  /https:\/\/console-service?\.[a-z]*-[a-z]*\.aws?\.ansiblecloud?\.redhat?\.com\/api/,
+  /https:\/\/console-service?\.[a-z]*-[a-z]*\.?(?:[a-z]*)\.aws?\.ansiblecloud?(?:\.redhat)?\.com\/api/,
 ];
 const AUTH_EXCLUDED_URLS = [/https:\/\/api(?:\.[a-z]+)?\.openshift(?:[a-z]+)?\.com\/api\/upgrades_info/];
 

--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -20,6 +20,7 @@ const AUTH_ALLOWED_ORIGINS = [
   /https:\/\/api?\.demo-experience(?:\.[a-z]+)?\.demo?\.redhat?\.com/,
   /https:\/\/api?\.aws?\.ap-southeast-1(?:\.[a-z]+)?\.openshift?\.com/,
   /https:\/\/console-service?\.[a-z]*-[a-z]*\.aws?\.ansiblecloud?\.com\/api/,
+  /https:\/\/console-service?\.[a-z]*-[a-z]*\.aws?\.ansiblecloud?\.redhat?\.com\/api/,
 ];
 const AUTH_EXCLUDED_URLS = [/https:\/\/api(?:\.[a-z]+)?\.openshift(?:[a-z]+)?\.com\/api\/upgrades_info/];
 

--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -19,6 +19,7 @@ const AUTH_ALLOWED_ORIGINS = [
   /https:\/\/api(?:\.[a-z]+)?\.openshift(?:[a-z]+)?\.com/,
   /https:\/\/api?\.demo-experience(?:\.[a-z]+)?\.demo?\.redhat?\.com/,
   /https:\/\/api?\.aws?\.ap-southeast-1(?:\.[a-z]+)?\.openshift?\.com/,
+  /https:\/\/console-service?\.[a-z]*-[a-z]*\.aws?\.ansiblecloud?\.com\/api/,
 ];
 const AUTH_EXCLUDED_URLS = [/https:\/\/api(?:\.[a-z]+)?\.openshift(?:[a-z]+)?\.com\/api\/upgrades_info/];
 


### PR DESCRIPTION
As part of onboard ansible-clouds console dot we are adding the the service as allowed-origin