### PR TITLE
Add back ip whitelist module to frontend.yml operator definition

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -19,6 +19,11 @@ objects:
         manifestLocation: "/apps/chrome/js/fed-mods.json"
         config:
           ssoUrl: ${SSO_URL}
+        modules:
+          - id: 'satellite-token'
+            module: './SatelliteToken'
+            routes:
+              - pathname: /insights/satellite
       frontend:
         paths:
           - /


### PR DESCRIPTION
As it would seem we are actually using the operator generated fed-modules in our itless envs. This adds the module definition back (originally introduced in https://github.com/RedHatInsights/insights-chrome/pull/2836)