### PR TITLE
Remove relative height from layout parent.

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -82,7 +82,6 @@ aside {
 .chr-render {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
   > main {
       flex-grow: 1;
   }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-35299

### Changes

remove the relative height from the chr-render element. The layout now defines the min-height and the rule is broken if a parent height is relative units.