### PR TITLE
Update Caddy-UBI Image Tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/cloudservices/caddy-ubi:421fab5
+FROM quay.io/cloudservices/caddy-ubi:latest
 
 ENV CADDY_TLS_MODE http_port 8000
 


### PR DESCRIPTION
### Overview
---
Updating `Caddy-UBI` Image Tag to `latest` to ensure the newest security patches are applied when Chrome Service Frontend is rebuilt. 

- This fix has been tested via the `security-compliance` branch.
- Security Patches can be reviewed in the `insights-chrome-frontend` Quay Repo