### PR TITLE
RHCLOUD-27262: Code review comments from search feedback analytics

### DIFF
--- a/src/components/Search/SearchFeedback.scss
+++ b/src/components/Search/SearchFeedback.scss
@@ -1,4 +1,4 @@
-.chr-c-search-feedback {
+.chr-c-search-feedback.pf-v5-c-menu__group {
     display: flex;
     justify-content: flex-end;
     align-items: center;

--- a/src/components/Search/SearchFeedback.test.tsx
+++ b/src/components/Search/SearchFeedback.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import SearchFeedback from './SearchFeedback';
+import SearchFeedback, { SEARCH_FEEDBACK_NEGATIVE, SEARCH_FEEDBACK_POSITIVE } from './SearchFeedback';
 import { SearchItem } from './SearchTypes';
 import { useSegment } from '../../analytics/useSegment';
 
@@ -55,41 +55,51 @@ describe('SearchFeedback', () => {
   });
 
   it('should call trackFeedback() on click when analytics ready - positive feedback', async () => {
-    const track = jest.fn();
+    const track = jest.fn(() => Promise.resolve());
+    const onFeedbackSubmitted = jest.fn();
     (useSegment as jest.Mock).mockImplementation(() => ({
       ready: true,
       analytics: {
         track,
       },
     }));
-    render(<SearchFeedback query={query} results={results} />);
+    render(<SearchFeedback query={query} results={results} onFeedbackSubmitted={onFeedbackSubmitted} />);
     const thumbsUpButton = screen.getAllByRole('menuitem')[0];
     await waitFor(() => {
       fireEvent.click(thumbsUpButton);
     });
     expect(useSegment).toHaveBeenCalled();
-    expect(track).toHaveBeenCalledWith('chrome.search-query-feedback-positive', { query, results });
+    expect(track).toHaveBeenCalledWith(SEARCH_FEEDBACK_POSITIVE, { query, results });
+    waitFor(() => {
+      !!screen.getAllByText('Thank you for your feedback!')[0];
+    });
+    expect(onFeedbackSubmitted).toHaveBeenCalledWith(SEARCH_FEEDBACK_POSITIVE);
   });
 
   it('should call trackFeedback() on click when analytics ready - negative feedback', async () => {
-    const track = jest.fn();
+    const track = jest.fn(() => Promise.resolve());
+    const onFeedbackSubmitted = jest.fn();
     (useSegment as jest.Mock).mockImplementation(() => ({
       ready: true,
       analytics: {
         track,
       },
     }));
-    render(<SearchFeedback query={query} results={results} />);
+    render(<SearchFeedback query={query} results={results} onFeedbackSubmitted={onFeedbackSubmitted} />);
     const thumbsDownButton = screen.getAllByRole('menuitem')[1];
     await waitFor(() => {
       fireEvent.click(thumbsDownButton);
     });
     expect(useSegment).toHaveBeenCalled();
-    expect(track).toHaveBeenCalledWith('chrome.search-query-feedback-negative', { query, results });
+    expect(track).toHaveBeenCalledWith(SEARCH_FEEDBACK_NEGATIVE, { query, results });
+    waitFor(() => {
+      !!screen.getAllByText('Thank you for your feedback!')[0];
+    });
+    expect(onFeedbackSubmitted).toHaveBeenCalledWith(SEARCH_FEEDBACK_NEGATIVE);
   });
 
   it('should throttle trackFeedback() calls for many consecutive clicks', async () => {
-    const track = jest.fn();
+    const track = jest.fn(() => Promise.resolve());
     (useSegment as jest.Mock).mockImplementation(() => ({
       ready: true,
       analytics: {
@@ -107,7 +117,48 @@ describe('SearchFeedback', () => {
       }),
     ]);
     expect(useSegment).toHaveBeenCalled();
-    expect(track).toHaveBeenCalledWith('chrome.search-query-feedback-positive', { query, results });
+    expect(track).toHaveBeenCalledWith(SEARCH_FEEDBACK_POSITIVE, { query, results });
     expect(track.mock.calls.length).toEqual(1);
+  });
+
+  it('should disable buttons and display message if feedback already submitted for query', async () => {
+    const track = jest.fn(() => Promise.resolve());
+    (useSegment as jest.Mock).mockImplementation(() => ({
+      ready: true,
+      analytics: {
+        track,
+      },
+    }));
+    render(<SearchFeedback query={query} results={results} feedbackType={SEARCH_FEEDBACK_POSITIVE} />);
+    const thumbsUpButton = screen.getAllByRole('menuitem')[0];
+    expect(thumbsUpButton).toBeDisabled();
+    await Promise.all([
+      waitFor(() => {
+        fireEvent.click(thumbsUpButton);
+      }),
+    ]);
+    expect(track).not.toHaveBeenCalled();
+    expect(screen.getAllByText('Thank you for your feedback!')[0]).toBeDefined();
+  });
+
+  it('should display error message if submitting feedback fails', async () => {
+    const track = jest.fn(() => Promise.reject());
+    (useSegment as jest.Mock).mockImplementation(() => ({
+      ready: true,
+      analytics: {
+        track,
+      },
+    }));
+    render(<SearchFeedback query={query} results={results} />);
+    const thumbsUpButton = screen.getAllByRole('menuitem')[0];
+    await Promise.all([
+      waitFor(() => {
+        fireEvent.click(thumbsUpButton);
+      }),
+    ]);
+    expect(track).toHaveBeenCalledWith(SEARCH_FEEDBACK_POSITIVE, { query, results });
+    waitFor(() => {
+      !!screen.getAllByText('Something went wrong. Please try again.')[0];
+    });
   });
 });

--- a/src/components/Search/SearchFeedback.tsx
+++ b/src/components/Search/SearchFeedback.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './SearchFeedback.scss';
-import throttle from 'lodash/throttle';
 
 import { Icon } from '@patternfly/react-core/dist/dynamic/components/Icon';
 import OutlinedThumbsUpIcon from '@patternfly/react-icons/dist/dynamic/icons/outlined-thumbs-up-icon';
@@ -8,29 +7,69 @@ import OutlinedThumbsDownIcon from '@patternfly/react-icons/dist/dynamic/icons/o
 import { MenuGroup, MenuItem } from '@patternfly/react-core/dist/dynamic/components/Menu';
 import { useSegment } from '../../analytics/useSegment';
 import type { SearchItem } from './SearchTypes';
-import { SegmentEvent } from '@segment/analytics-next';
+
+export const SEARCH_FEEDBACK_POSITIVE = 'chrome.search-query-feedback-positive';
+export const SEARCH_FEEDBACK_NEGATIVE = 'chrome.search-query-feedback-negative';
+
+export type SearchFeedbackType = typeof SEARCH_FEEDBACK_POSITIVE | typeof SEARCH_FEEDBACK_NEGATIVE | undefined;
 
 export type SearchFeedbackProps = {
   query: string;
   results: SearchItem[];
+  feedbackType?: SearchFeedbackType;
+  onFeedbackSubmitted?: (type: SearchFeedbackType) => void;
 };
 
-const SearchFeedback = ({ query, results }: SearchFeedbackProps) => {
+const SearchFeedback = ({ query, results, feedbackType, onFeedbackSubmitted }: SearchFeedbackProps) => {
   const { ready, analytics } = useSegment();
-  const trackFeedback = (type: string | SegmentEvent) => {
-    ready && analytics && analytics.track(type, { query, results });
+  const [error, setError] = useState<boolean>(false);
+  const [inFlight, setInFlight] = useState<boolean>(false);
+  const [currentFeedbackType, setcurrentFeedbackType] = useState<SearchFeedbackType>(feedbackType);
+
+  useEffect(() => {
+    setcurrentFeedbackType(feedbackType);
+  }, [feedbackType]);
+
+  const trackFeedback = (type: SearchFeedbackType) => {
+    if (!ready || !analytics || inFlight) {
+      return;
+    }
+
+    setInFlight(true);
+    // even if the track API call fails - the analytics API resolves the promise with the context and no indication of failure (retries internally)
+    analytics
+      .track(type as string, { query, results })
+      .then(() => {
+        setcurrentFeedbackType(type);
+        onFeedbackSubmitted?.(type);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError(true);
+      })
+      .finally(() => {
+        setInFlight(false);
+      });
   };
-  const throttledTrackFeedback = throttle(trackFeedback, 5000);
+
+  // TODO move these for translation
+  let label = 'Are these results helpful?';
+  if (currentFeedbackType) {
+    label = 'Thank you for your feedback!';
+  } else if (error) {
+    label = 'Something went wrong. Please try again.';
+  }
+
   return (
-    <MenuGroup className="chr-c-search-feedback pf-v5-u-px-md" label="Are these results helpful?">
-      <MenuItem className="pf-v5-u-px-xs" onClick={() => throttledTrackFeedback('chrome.search-query-feedback-positive')}>
+    <MenuGroup className="chr-c-search-feedback pf-v5-u-px-md" label={label}>
+      <MenuItem className="pf-v5-u-px-xs" isDisabled={!!currentFeedbackType} onClick={() => trackFeedback(SEARCH_FEEDBACK_POSITIVE)}>
         <Icon isInline>
-          <OutlinedThumbsUpIcon className="pf-v5-u-color-200" />
+          <OutlinedThumbsUpIcon className={currentFeedbackType === SEARCH_FEEDBACK_POSITIVE ? 'pf-v5-u-active-color-100' : 'pf-v5-u-color-200'} />
         </Icon>
       </MenuItem>
-      <MenuItem className="pf-v5-u-px-xs" onClick={() => throttledTrackFeedback('chrome.search-query-feedback-negative')}>
+      <MenuItem className="pf-v5-u-px-xs" isDisabled={!!currentFeedbackType} onClick={() => trackFeedback(SEARCH_FEEDBACK_NEGATIVE)}>
         <Icon isInline>
-          <OutlinedThumbsDownIcon className="pf-v5-u-color-200" />
+          <OutlinedThumbsDownIcon className={currentFeedbackType === SEARCH_FEEDBACK_NEGATIVE ? 'pf-v5-u-active-color-100' : 'pf-v5-u-color-200'} />
         </Icon>
       </MenuItem>
     </MenuGroup>

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -20,7 +20,7 @@ import { localQuery } from '../../utils/localSearch';
 import { isPreviewAtom } from '../../state/atoms/releaseAtom';
 import { ReleaseEnv } from '../../@types/types.d';
 import type { SearchItem } from './SearchTypes';
-import SearchFeedback from './SearchFeedback';
+import SearchFeedback, { SearchFeedbackType } from './SearchFeedback';
 
 export type SearchInputprops = {
   isExpanded?: boolean;
@@ -44,6 +44,7 @@ type SearchInputListener = {
 const SearchInput = ({ onStateChange }: SearchInputListener) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
+  const [currentFeedbackType, setcurrentFeedbackType] = useState<SearchFeedbackType>();
   const [isFetching, setIsFetching] = useState(false);
   const [searchItems, setSearchItems] = useState<SearchItem[]>([]);
   const isPreview = useAtomValue(isPreviewAtom);
@@ -60,6 +61,12 @@ const SearchInput = ({ onStateChange }: SearchInputListener) => {
   const { md } = useWindowWidth();
 
   const resultCount = searchItems.length;
+
+  useEffect(() => {
+    if (currentFeedbackType) {
+      setcurrentFeedbackType(undefined);
+    }
+  }, [searchValue]);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -197,7 +204,7 @@ const SearchInput = ({ onStateChange }: SearchInputListener) => {
   if (searchItems.length > 0 && !isFetching) {
     menuFooter = (
       <MenuFooter className="pf-v5-u-px-md">
-        <SearchFeedback query={searchValue} results={searchItems} />
+        <SearchFeedback query={searchValue} results={searchItems} feedbackType={currentFeedbackType} onFeedbackSubmitted={setcurrentFeedbackType} />
       </MenuFooter>
     );
   }


### PR DESCRIPTION
Code review follow up from https://github.com/RedHatInsights/insights-chrome/pull/2897.

- Makes it so feedback may only be submitted once per query. 
  - _Note this is for the lifecycle of the SearchInput - we do not check against a DB to see if you've submitted feedback for "foobar" in a previous session. If that is required we can follow up_
- Changes the label to display a message on success or failure on feedback submission
- Highlights the corresponding feedback button (thumbsup/down) in blue
- Updates tests accordingly

![image](https://github.com/user-attachments/assets/c6f3556a-7c17-4715-bed0-f005058735ee)
![image](https://github.com/user-attachments/assets/9d649106-74f0-424c-b793-116e7c190589)
