### PR TITLE
Add additional token renew error handling.

### DIFF
--- a/src/auth/OIDCConnector/OIDCSecured.tsx
+++ b/src/auth/OIDCConnector/OIDCSecured.tsx
@@ -184,7 +184,16 @@ export function OIDCSecured({
     if (!auth.error) {
       startChrome();
     }
-  }, [auth]);
+    function onRenewError(error: Error) {
+      console.error('Silent renew error', error);
+      state.login();
+    }
+    auth.events.addSilentRenewError(onRenewError);
+
+    return () => {
+      auth.events.removeSilentRenewError(onRenewError);
+    };
+  }, [auth, state]);
 
   useEffect(() => {
     authRef.current = auth;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-35360

### Changes
- call the signInRedirect if token renewal failed

Should help with some of the longer sessions having issues with token refreshes.

Might help with https://issues.redhat.com/browse/RHCLOUD-34646