### PR TITLE
chore: pin caddy-ubi image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/cloudservices/caddy-ubi:latest
+FROM quay.io/cloudservices/caddy-ubi:ec1577c
 
 ENV CADDY_TLS_MODE http_port 8000
 


### PR DESCRIPTION
This pins the caddy-ubi image to the current latest, to enable rolling out future updates to the base image in a much more controlled way