### PR TITLE
Fix user access location in settings icon

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -75,8 +75,9 @@ const Tools = () => {
   const unreadNotifications = useAtomValue(unreadNotificationsAtom);
   const [isNotificationDrawerExpanded, toggleNotifications] = useAtom(notificationDrawerExpandedAtom);
   const intl = useIntl();
+  const isOrgAdmin = user?.identity?.user?.is_org_admin;
   const settingsPath = isITLessEnv ? `/settings/my-user-access` : enableIntegrations ? `/settings/integrations` : '/settings/sources';
-  const identityAndAccessManagmentPath = '/iam/user-access/overview';
+  const identityAndAccessManagmentPath = isOrgAdmin ? '/iam/user-access/overview' : '/iam/my-user-access';
   const betaSwitcherTitle = `${isPreview ? intl.formatMessage(messages.stopUsing) : intl.formatMessage(messages.use)} ${intl.formatMessage(
     messages.betaRelease
   )}`;
@@ -113,7 +114,7 @@ const Tools = () => {
       items: [
         {
           url: identityAndAccessManagmentPath,
-          title: 'User Access',
+          title: isOrgAdmin ? 'User Access' : 'My User Access',
         },
         {
           url: '/iam/authentication-policy/authentication-factors',


### PR DESCRIPTION
### Description

As a regular user when I click on settings icon I should be brought to my user access. However as an org admin user should be brought to user access.

This PR adjusts the title and link.

### JIRA

[RHCLOUD-33599](https://issues.redhat.com/browse/RHCLOUD-33599)