### PR TITLE
Switch back to using konflux-consoledot-frontend-build dockerfile task

### DIFF
--- a/.tekton/insights-chrome-pull-request.yaml
+++ b/.tekton/insights-chrome-pull-request.yaml
@@ -231,119 +231,15 @@ spec:
       runAfter:
       - clone-repository
     - name: create-frontend-dockerfile
-      taskSpec:
-        description: >-
-          Tekton task to create a dockerfile for the frontend builds
+      taskRef:
+        resolver: git
         params:
-          - default: "source"
-            description: directory in the `output` Workspace to clone the repo into.
-            name: subdirectory
-            type: string
-          - name: path-context
-            description: path context directory inside the repo
-            type: string
-          - name: component
-            description: name of app-sre application folder this component lives in
-            type: string
-          - name: image
-            description: |
-              image should match the quay repo set by app.yaml in app-interface
-            type: string
-          - name: node-build-version
-            description: node version to build the app
-            type: string
-            default: 16
-          - name: quay-expire-time
-            description: time for the image to expire in Quay. Default is 3 days
-            type: string
-            default: 3d
-          - name: npm-build-script
-            type: string
-            description: npm script to run at build time
-            default: build
-          - name: yarn-build-script
-            type: string
-            description: yarn script to run at build time
-            default: build:prod
-          - name: route-path
-            type: string
-            description: path for the app to be stored
-            default: ""
-          - name: beta-route-path
-            type: string
-            description: path for the beta app to be stored
-            default: ""
-          - name: preview-route-path
-            type: string
-            description: path for the preview app to be stored
-            default: ""
-          - name: ci-root
-            type: string
-            description: root of the ci.sh script
-            default: ""
-          - name: server-name
-            type: string
-            description: name of the server. If empty, same as the app name
-            default: ""
-          - name: dist-folder
-            type: string
-            description: directory where the app.info.json will be written
-            default: "dist"
-        workspaces:
-          - name: source
-            description: workspace where the code is stored
-        steps:
-          - name: create-dockerfile
-            computeResources:
-              requests:
-                memory: 2Gi
-              limits:
-                memory: 5Gi
-            image: quay.io/cloudservices/frontend-build-container:latest
-            script: |
-              #!/usr/bin/env sh
-              set -xe
-
-              # handle empty string as dist-folder parameter
-              # which breaks the frontend-build-container scripts
-              if [ -z "$(params.dist-folder)" ]; then DIST_FOLDER="dist"; fi
-
-              source_path=$(workspaces.source.path)/$(params.subdirectory)/$(params.path-context)
-
-              cp -r  $source_path/. /workspace
-              cd /container_workspace
-              bash universal_build.sh
-
-              cp Dockerfile $source_path
-              cp Caddyfile $source_path
-              cp -r ${DIST_FOLDER}/ $source_path
-            env:
-              - name: COMPONENT
-                value: $(params.component)
-              - name: IMAGE
-                value: $(params.image)
-              - name: NODE_BUILD_VERSION
-                value: $(params.node-build-version)
-              - name: QUAY_EXPIRE_TIME
-                value: $(params.quay-expire-time)
-              - name: NPM_BUILD_SCRIPT
-                value: $(params.npm-build-script)
-              - name: YARN_BUILD_SCRIPT
-                value: $(params.yarn-build-script)
-              - name: ROUTE_PATH
-                value: $(params.route-path)
-              - name: BETA_ROUTE_PATH
-                value: $(params.beta-route-path)
-              - name: PREVIEW_ROUTE_PATH
-                value: $(params.preview-route-path)
-              - name: IS_PR
-                value: "false"
-              - name: CI_ROOT
-                value: $(params.ci-root)
-              - name: SERVER_NAME
-                value: $(params.server-name)
-              - name: DIST_FOLDER
-                value: $(params.dist-folder)
+          - name: url
+            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
+          - name: revision
+            value: e0b400ca6433f1ff05722c412ab837c4bd49a45a  # replace with the latest commit from https://github.com/RedHatInsights/konflux-consoledot-frontend-build/commits
+          - name: pathInRepo
+            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/insights-chrome-push.yaml
+++ b/.tekton/insights-chrome-push.yaml
@@ -228,119 +228,15 @@ spec:
       runAfter:
       - clone-repository
     - name: create-frontend-dockerfile
-      taskSpec:
-        description: >-
-          Tekton task to create a dockerfile for the frontend builds
+      taskRef:
+        resolver: git
         params:
-          - default: "source"
-            description: directory in the `output` Workspace to clone the repo into.
-            name: subdirectory
-            type: string
-          - name: path-context
-            description: path context directory inside the repo
-            type: string
-          - name: component
-            description: name of app-sre application folder this component lives in
-            type: string
-          - name: image
-            description: |
-              image should match the quay repo set by app.yaml in app-interface
-            type: string
-          - name: node-build-version
-            description: node version to build the app
-            type: string
-            default: 16
-          - name: quay-expire-time
-            description: time for the image to expire in Quay. Default is 3 days
-            type: string
-            default: 3d
-          - name: npm-build-script
-            type: string
-            description: npm script to run at build time
-            default: build
-          - name: yarn-build-script
-            type: string
-            description: yarn script to run at build time
-            default: build:prod
-          - name: route-path
-            type: string
-            description: path for the app to be stored
-            default: ""
-          - name: beta-route-path
-            type: string
-            description: path for the beta app to be stored
-            default: ""
-          - name: preview-route-path
-            type: string
-            description: path for the preview app to be stored
-            default: ""
-          - name: ci-root
-            type: string
-            description: root of the ci.sh script
-            default: ""
-          - name: server-name
-            type: string
-            description: name of the server. If empty, same as the app name
-            default: ""
-          - name: dist-folder
-            type: string
-            description: directory where the app.info.json will be written
-            default: "dist"
-        workspaces:
-          - name: source
-            description: workspace where the code is stored
-        steps:
-          - name: create-dockerfile
-            computeResources:
-              requests:
-                memory: 2Gi
-              limits:
-                memory: 5Gi
-            image: quay.io/cloudservices/frontend-build-container:latest
-            script: |
-              #!/usr/bin/env sh
-              set -xe
-
-              # handle empty string as dist-folder parameter
-              # which breaks the frontend-build-container scripts
-              if [ -z "$(params.dist-folder)" ]; then DIST_FOLDER="dist"; fi
-
-              source_path=$(workspaces.source.path)/$(params.subdirectory)/$(params.path-context)
-
-              cp -r  $source_path/. /workspace
-              cd /container_workspace
-              bash universal_build.sh
-
-              cp Dockerfile $source_path
-              cp Caddyfile $source_path
-              cp -r ${DIST_FOLDER}/ $source_path
-            env:
-              - name: COMPONENT
-                value: $(params.component)
-              - name: IMAGE
-                value: $(params.image)
-              - name: NODE_BUILD_VERSION
-                value: $(params.node-build-version)
-              - name: QUAY_EXPIRE_TIME
-                value: $(params.quay-expire-time)
-              - name: NPM_BUILD_SCRIPT
-                value: $(params.npm-build-script)
-              - name: YARN_BUILD_SCRIPT
-                value: $(params.yarn-build-script)
-              - name: ROUTE_PATH
-                value: $(params.route-path)
-              - name: BETA_ROUTE_PATH
-                value: $(params.beta-route-path)
-              - name: PREVIEW_ROUTE_PATH
-                value: $(params.preview-route-path)
-              - name: IS_PR
-                value: "false"
-              - name: CI_ROOT
-                value: $(params.ci-root)
-              - name: SERVER_NAME
-                value: $(params.server-name)
-              - name: DIST_FOLDER
-                value: $(params.dist-folder)
+          - name: url
+            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
+          - name: revision
+            value: e0b400ca6433f1ff05722c412ab837c4bd49a45a  # replace with the latest commit from https://github.com/RedHatInsights/konflux-consoledot-frontend-build/commits
+          - name: pathInRepo
+            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
       workspaces:
       - name: source
         workspace: workspace


### PR DESCRIPTION
Since https://github.com/RedHatInsights/konflux-consoledot-frontend-build/pull/71 was merged, we should now be able to switch back to using the task from `konflux-consoledot-frontend-build` for dockerfile creation.