### PR TITLE
Enable consumption of FEO generated routing, search, and navigation files

### DIFF
--- a/src/state/atoms/localSearchAtom.ts
+++ b/src/state/atoms/localSearchAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai';
 import { Orama, create, insert } from '@orama/orama';
 
-import { getChromeStaticPathname } from '../../utils/common';
+import { GENERATED_SEARCH_FLAG, getChromeStaticPathname } from '../../utils/common';
 import axios from 'axios';
 import { NavItemPermission } from '../../@types/types';
 
@@ -29,7 +29,6 @@ type SearchEntry = {
   altTitle?: string[];
 };
 
-const GENERATED_SEARCH_FLAG = '@chrome:generated-search-index';
 type GeneratedSearchIndexResponse = {
   alt_title?: string[];
   id: string;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -348,6 +348,8 @@ const fedModulesheaders = {
   Expires: '0',
 };
 
+export const GENERATED_SEARCH_FLAG = '@chrome:generated-search-index';
+
 // FIXME: Remove once qaprodauth is dealt with
 // can't use /beta because it will ge redirected by Akamai to /preview and we don't have any assets there\\
 // Always use stable
@@ -356,10 +358,14 @@ const loadCSCFedModules = () =>
     headers: fedModulesheaders,
   });
 
-export const loadFedModules = async () =>
-  Promise.all([
+export const loadFedModules = async () => {
+  const fedModulesPath =
+    localStorage.getItem(GENERATED_SEARCH_FLAG) === 'true'
+      ? '/api/chrome-service/v1/static/fed-modules-generated.json'
+      : `${getChromeStaticPathname('modules')}/fed-modules.json`;
+  return Promise.all([
     axios
-      .get(`${getChromeStaticPathname('modules')}/fed-modules.json`, {
+      .get(fedModulesPath, {
         headers: fedModulesheaders,
       })
       .catch(loadCSCFedModules),
@@ -370,6 +376,7 @@ export const loadFedModules = async () =>
     }
     return staticConfig;
   });
+};
 
 export const generateRoutesList = (modules: { [key: string]: ChromeModule }) =>
   Object.entries(modules)

--- a/src/utils/fetchNavigationFiles.ts
+++ b/src/utils/fetchNavigationFiles.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { BundleNavigation, NavItem, Navigation } from '../@types/types';
 import { Required } from 'utility-types';
 import { itLessBundles, requiredBundles } from '../components/AppFilter/useAppFilter';
-import { ITLess, getChromeStaticPathname } from './common';
+import { GENERATED_SEARCH_FLAG, ITLess, getChromeStaticPathname } from './common';
 
 export function isBundleNavigation(item: unknown): item is BundleNavigation {
   return typeof item !== 'undefined';
@@ -38,6 +38,12 @@ const filesCache: {
 };
 
 const fetchNavigationFiles = async () => {
+  if (localStorage.getItem(GENERATED_SEARCH_FLAG) === 'true') {
+    // aggregate data call
+    const { data: aggregateData } = await axios.get<BundleNavigation[]>('/api/chrome-service/v1/static/bundles-generated.json');
+    const bundleNavigation = aggregateData.filter(isBundleNavigation);
+    return bundleNavigation;
+  }
   const bundles = ITLess() ? itLessBundles : requiredBundles;
   if (filesCache.ready && filesCache.expires > Date.now()) {
     return filesCache.data;


### PR DESCRIPTION
The functionality is hidden behind a local storage flag. It is too soon for a feature flag.

If the flag is not present, chrome will load the current config files.

Jira: https://issues.redhat.com/browse/RHCLOUD-36433
