### PR TITLE
add sentry workflow

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,0 +1,43 @@
+name: sentryConfig
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        description: 'The commit hash (or branch/tag) to build'
+        required: true
+        default: 'master'
+
+jobs:
+  createSentryRelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.commit_hash }}
+
+      - name: Install dependencies
+        env:
+          SENTRY_RELEASE: insights-chrome-${{ github.event.inputs.commit_hash }}
+        run: npm ci
+
+      - name: Build
+        env:
+          SENTRY_RELEASE: insights-chrome-${{ github.event.inputs.commit_hash }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: npm run build --if-present
+
+      - name: Create a Sentry.io release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          tagName: ${{ github.event.inputs.commit_hash }}
+          releaseNamePrefix: insights-chrome
+          environment: master
+          sourcemaps: 'dist/sourcemaps'


### PR DESCRIPTION
This adds a workflow to upload source maps for sentry. Source maps will be triggering via a gitlab workflow. There will be no additional steps in release 