### PR TITLE
fix(sentry): Update sentry plugin to always initialize | workflow update

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,12 +1,15 @@
-name: sentryConfig
+name: sentryInit
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       commit_hash:
         description: 'The commit hash (or branch/tag) to build'
-        required: true
-        default: 'master'
+        required: false
+        default: ''
 
 jobs:
   createSentryRelease:
@@ -15,29 +18,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.commit_hash }}
+          ref: ${{ github.event.inputs.commit_hash || 'refs/heads/master' }}
 
       - name: Install dependencies
-        env:
-          SENTRY_RELEASE: insights-chrome-${{ github.event.inputs.commit_hash }}
         run: npm ci
 
       - name: Build
         env:
-          SENTRY_RELEASE: insights-chrome-${{ github.event.inputs.commit_hash }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          ENABLE_SENTRY:  ${{ secrets.ENABLE_SENTRY }}
+          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash && github.event.inputs.commit_hash }}
+          SENTRY_AUTH_TOKEN: ${{ github.event.inputs.commit_hash && secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: npm run build --if-present
-
-      - name: Create a Sentry.io release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-        with:
-          tagName: ${{ github.event.inputs.commit_hash }}
-          releaseNamePrefix: insights-chrome
-          environment: master
-          sourcemaps: 'dist/sourcemaps'

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         env:
-          ENABLE_SENTRY:  ${{ secrets.ENABLE_SENTRY }}
+          ENABLE_SENTRY:  true
           SENTRY_RELEASE: ${{ github.event.inputs.commit_hash && github.event.inputs.commit_hash }}
           SENTRY_AUTH_TOKEN: ${{ github.event.inputs.commit_hash && secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -90,18 +90,20 @@ const plugins = (dev = false, beta = false, restricted = false) => {
     }),
     ...(dev ? [new ReactRefreshWebpackPlugin()] : []),
     // Put the Sentry Webpack plugin after all other plugins
-    ...(!dev && process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT
+    ...(process.env.ENABLE_SENTRY
       ? [
           sentryWebpackPlugin({
-            authToken: process.env.SENTRY_AUTH_TOKEN,
+            ...(process.env.SENTRY_AUTH_TOKEN && {
+              authToken: process.env.SENTRY_AUTH_TOKEN,
+            }),
             org: process.env.SENTRY_ORG,
             project: process.env.SENTRY_PROJECT,
-            _experiments: {
-              moduleMetadata: ({ release }) => ({
+            moduleMetadata: ({ release }) => ({
+              ...(process.env.SENTRY_AUTH_TOKEN && {
                 authToken: process.env.SENTRY_AUTH_TOKEN,
-                release,
               }),
-            },
+              release,
+            }),
           }),
         ]
       : []),


### PR DESCRIPTION
This updates the sentry workflow to avoid all instances of uploading source maps for devs in a local set up via the `ENABLE_SENTRY` variable (need to initialize the secret variable).

Locally it wont trigger, but when merged to master, it will always initialize the plugin, but with no authtoken or release variable, therefor only uploading debugIds when its merged to master. Theres an automated script that will trigger the workflow with whatever commit is in production, revealing the authtoken and uploading sourcemaps for whatever is specifically in prod