### PR TITLE
Remove Vary header from caddy server

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,7 @@
 {
     {$CADDY_TLS_MODE}
     auto_https disable_redirects
+    header -Vary
 }
 :9000 {
     metrics /metrics


### PR DESCRIPTION
This file may no longer be used so this may not need to be merged.