### PR TITLE
Fix error with caddy config

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,8 @@
 {
     {$CADDY_TLS_MODE}
     auto_https disable_redirects
-    header -Vary
 }
+
 :9000 {
     metrics /metrics
 }
@@ -10,6 +10,7 @@
 :8000 {
     {$CADDY_TLS_CERT}
     log
+    header -Vary
     @app_match {
         path /apps/chrome*
     }


### PR DESCRIPTION
Fixes:
Error: adapting config using caddyfile: /opt/app-root/src/Caddyfile:4: unrecognized global option: header