### PR TITLE
Add a missing OUIA ID

### DIFF
--- a/src/components/FavoriteServices/LandingNavFavorites.tsx
+++ b/src/components/FavoriteServices/LandingNavFavorites.tsx
@@ -55,7 +55,7 @@ const LandingNavFavorites = () => {
               My favorite services
             </Content>
             <Content component={ContentVariants.p} className="pf-v6-u-display-inline">
-              <Link to="/allservices">View all services</Link>
+              <Link ouiaId="FavoritesViewAllServicesButton" to="/allservices">View all services</Link>
             </Content>
           </Content>
         </FlexItem>

--- a/src/components/FavoriteServices/LandingNavFavorites.tsx
+++ b/src/components/FavoriteServices/LandingNavFavorites.tsx
@@ -55,7 +55,9 @@ const LandingNavFavorites = () => {
               My favorite services
             </Content>
             <Content component={ContentVariants.p} className="pf-v6-u-display-inline">
-              <Link ouiaId="FavoritesViewAllServicesButton" to="/allservices">View all services</Link>
+              <Link ouiaId="FavoritesViewAllServicesButton" to="/allservices">
+                View all services
+              </Link>
             </Content>
           </Content>
         </FlexItem>

--- a/src/components/FavoriteServices/LandingNavFavorites.tsx
+++ b/src/components/FavoriteServices/LandingNavFavorites.tsx
@@ -54,10 +54,8 @@ const LandingNavFavorites = () => {
               </Icon>
               My favorite services
             </Content>
-            <Content component={ContentVariants.p} className="pf-v6-u-display-inline">
-              <Link ouiaId="FavoritesViewAllServicesButton" to="/allservices">
-                View all services
-              </Link>
+            <Content ouiaId="FavoritesViewAllServicesButton" component={ContentVariants.p} className="pf-v6-u-display-inline">
+              <Link to="/allservices">View all services</Link>
             </Content>
           </Content>
         </FlexItem>


### PR DESCRIPTION
The "View all services" button on the services menu is difficult to find with XPath alone.

As an example, ".//a[@alt='View all services' and not(@hidden)]" finds 2 elements.

This PR adds the necessary OUIA ID to uniquely identify the button with IQE automation.

Update: The 2 element match issue is more of an issue with stage than prod, which suggests this may be a change introduced by PF6 updates.