### PR TITLE
Fix dev and ux soo url exception

### DIFF
--- a/src/auth/platformUrl.ts
+++ b/src/auth/platformUrl.ts
@@ -12,7 +12,7 @@ export default function platformUlr(env: typeof DEFAULT_SSO_ROUTES, configSsoUrl
   // we have to use hard coded value for console.dev.redhat.com
   // ugly hack
 
-  if (location.hostname in DEFAULT_SSO_ROUTES.dev.url) {
+  if (DEFAULT_SSO_ROUTES.dev.url.includes(location.hostname)) {
     return sanitizeUrl(DEFAULT_SSO_ROUTES.dev.sso);
   }
   if (configSsoUrl) {


### PR DESCRIPTION
The in-operator will not work in this case. It used only used for objects and their properties, not for array values.