### PR TITLE
Adding custom testing task for FE integration test pipeline

### DIFF
--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run-tests
+spec:
+  params:
+    - name: EPHEMERAL_ENV_PROVIDER_SECRET
+      type: string
+      default: ephemeral-env-provider
+      description: "Secret for connecting to ephemeral env provider cluster"
+
+    - name: EPHEMERAL_ENV_URL
+      type: string
+      description: "Url for accessing the UI deployed in the ephemeral environment""
+    - name: EPHEMERAL_ENV_PASSWORD
+      type: string
+      description: "Password for login to your ephemeral environment UI"
+    - name: EPHEMERAL_ENV_USERNAME
+      type: string
+      description: "Username for login to your ephemeral environment UI"
+  results:
+    - name: NS
+      description: ""
+  steps:
+    - name: run-tests
+      image:
+      env:
+        - name: EE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.EPHEMERAL_ENV_USERNAME)
+              key: token
+        - name: EE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.EPHEMERAL_ENV_PASSWORD)
+              key: token
+        - name: EE_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.EPHEMERAL_ENV_URL)
+              key: url
+      script: |
+        #!/bin/bash
+        set -ex
+
+        echo "PLACEHOLDER: run tests"

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -24,23 +24,14 @@ spec:
     - name: run-tests
       image: "quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566"
       env:
+        - name: EE_HOSTNAME
+          value: $(params.EPHEMERAL_ENV_HOSTNAME)
         - name: EE_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: $(params.EPHEMERAL_ENV_USERNAME)
-              key: token
+          value: $(params.EPHEMERAL_ENV_USERNAME)
         - name: EE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: $(params.EPHEMERAL_ENV_PASSWORD)
-              key: token
-        - name: EE_URL
-          valueFrom:
-            secretKeyRef:
-              name: $(params.EPHEMERAL_ENV_URL)
-              key: url
+          value: $(params.EPHEMERAL_ENV_PASSWORD)
       script: |
         #!/bin/bash
         set -ex
 
-        echo "PLACEHOLDER: run tests"
+        echo $EE_HOSTNAME

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -43,11 +43,6 @@ spec:
             secretKeyRef:
               name: $(params.EPHEMERAL_ENV_URL)
               key: url
-        - name: PROJECT_URL
-          valueFrom:
-            secretKeyRef:
-              name: github.com/redhatinsights/insights-chrome 
-              key: url
       script: |
         #!/bin/bash
         set -ex

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -25,7 +25,7 @@ spec:
       image: "quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566"
       env:
         - name: EE_HOSTNAME
-          value: $(params.EPHEMERAL_ENV_HOSTNAME)
+          value: $(params.EPHEMERAL_ENV_URL)
         - name: EE_USERNAME
           value: $(params.EPHEMERAL_ENV_USERNAME)
         - name: EE_PASSWORD

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -9,9 +9,12 @@ spec:
       default: ephemeral-env-provider
       description: "Secret for connecting to ephemeral env provider cluster"
 
+    - name: PROJECT_URL
+      type: string
+      description: "Project URl to grab test task from"
     - name: EPHEMERAL_ENV_URL
       type: string
-      description: "Url for accessing the UI deployed in the ephemeral environment""
+      description: "Url for accessing the UI deployed in the ephemeral environment"
     - name: EPHEMERAL_ENV_PASSWORD
       type: string
       description: "Password for login to your ephemeral environment UI"

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -8,10 +8,6 @@ spec:
       type: string
       default: ephemeral-env-provider
       description: "Secret for connecting to ephemeral env provider cluster"
-
-    - name: PROJECT_URL
-      type: string
-      description: "Project URl to grab test task from"
     - name: EPHEMERAL_ENV_URL
       type: string
       description: "Url for accessing the UI deployed in the ephemeral environment"
@@ -26,7 +22,7 @@ spec:
       description: ""
   steps:
     - name: run-tests
-      image:
+      image: "quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566"
       env:
         - name: EE_USERNAME
           valueFrom:

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -17,9 +17,6 @@ spec:
     - name: EPHEMERAL_ENV_USERNAME
       type: string
       description: "Username for login to your ephemeral environment UI"
-  results:
-    - name: NS
-      description: ""
   steps:
     - name: run-tests
       image: "quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566"
@@ -34,4 +31,4 @@ spec:
         #!/bin/bash
         set -ex
 
-        echo $EE_HOSTNAME
+        echo "write your tests here"

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -40,6 +40,11 @@ spec:
             secretKeyRef:
               name: $(params.EPHEMERAL_ENV_URL)
               key: url
+        - name: PROJECT_URL
+          valueFrom:
+            secretKeyRef:
+              name: github.com/redhatinsights/insights-chrome 
+              key: url
       script: |
         #!/bin/bash
         set -ex


### PR DESCRIPTION
**Description**

The purpose of this PR is to test the tekton pipeline being created for frontend applications. Now that it is working, this will serve as the template used to create your cypress tests. You'll just want to add to: https://github.com/RedHatInsights/insights-chrome/pull/3041/files#diff-7be96f33f266288b651a4e9971d0476f2d14b0498e7f40f4491b464d6e18f887R34-R37
