### PR TITLE
Add additional token/session error checks.

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -70,7 +70,7 @@ const plugins = (dev = false, beta = false, restricted = false) => {
     }),
     new HtmlWebpackPlugin({
       title: 'Authenticating - Hybrid Cloud Console',
-      filename: dev ? 'silent-check-sso.html' : '../silent-check-sso.html',
+      filename: 'silent-check-sso.html',
       inject: false,
       minify: false,
       template: path.resolve(__dirname, '../src/silent-check-sso.html'),

--- a/cypress/component/OIDCConnector/OIDCUserManagerErrorBoundary.cy.tsx
+++ b/cypress/component/OIDCConnector/OIDCUserManagerErrorBoundary.cy.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import OIDCUserManagerErrorBoundary, { SESSION_NOT_ACTIVE, TOKEN_NOT_ACTIVE } from '../../../src/auth/OIDCConnector/OIDCUserManagerErrorBoundary';
+import { UserManager } from 'oidc-client-ts';
+import ErrorBoundary from '../../../src/components/ErrorComponents/ErrorBoundary';
+import { IntlProvider } from 'react-intl';
+
+const ThrowAbleComponent = ({ error }: { error: any }) => {
+  throw error;
+};
+
+describe('OIDCUserManagerErrorBoundary', () => {
+  let basicFakeManager: UserManager;
+
+  beforeEach(() => {
+    basicFakeManager = new UserManager({
+      authority: '',
+      client_id: '',
+      redirect_uri: '',
+    });
+  });
+
+  it('should render children if no error is thrown', () => {
+    cy.mount(
+      <OIDCUserManagerErrorBoundary userManager={basicFakeManager}>
+        <h1>Child</h1>
+      </OIDCUserManagerErrorBoundary>
+    );
+
+    cy.get('h1').should('exist');
+  });
+
+  it('Should bubble unrelated OIDC timeout error to parent error boundary', () => {
+    cy.on('uncaught:exception', () => {
+      return false;
+    });
+
+    cy.mount(
+      <IntlProvider locale="en">
+        <ErrorBoundary>
+          <OIDCUserManagerErrorBoundary userManager={basicFakeManager}>
+            <ThrowAbleComponent error="Fake error" />
+          </OIDCUserManagerErrorBoundary>
+        </ErrorBoundary>
+      </IntlProvider>
+    );
+
+    cy.contains('Fake error').should('exist');
+  });
+
+  [SESSION_NOT_ACTIVE, TOKEN_NOT_ACTIVE].forEach((error) => {
+    it('should try redirect to signin page if error is thrown', () => {
+      cy.intercept('GET', '/authorityUrl', {
+        statusCode: 200,
+        body: {
+          success: true,
+          error,
+        },
+      }).as(error);
+      const fakeManager = new UserManager({
+        authority: '',
+        client_id: '',
+        redirect_uri: '',
+        metadataUrl: '/authorityUrl',
+      });
+      cy.on('uncaught:exception', () => {
+        return false;
+      });
+      cy.mount(
+        <OIDCUserManagerErrorBoundary userManager={fakeManager}>
+          <ThrowAbleComponent error={{ error_description: error }} />
+        </OIDCUserManagerErrorBoundary>
+      );
+
+      cy.wait(`@${error}`).its('response.body.error').should('eq', error);
+    });
+  });
+});

--- a/src/auth/OIDCConnector/OIDCUserManagerErrorBoundary.tsx
+++ b/src/auth/OIDCConnector/OIDCUserManagerErrorBoundary.tsx
@@ -1,0 +1,63 @@
+import { UserManager } from 'oidc-client-ts';
+import React from 'react';
+import AppPlaceholder from '../../components/AppPlaceholder';
+
+type SessionErrorBoundaryState = {
+  hasError: boolean;
+  hasValidError: boolean;
+  error?: any;
+  errorInfo?: any;
+};
+
+export const SESSION_NOT_ACTIVE = 'Session not active';
+export const TOKEN_NOT_ACTIVE = 'Token not active';
+
+function isInvalidAuthStateError(error: any): boolean {
+  return error?.error_description === SESSION_NOT_ACTIVE || error?.error_description === TOKEN_NOT_ACTIVE;
+}
+/**
+ *  The session not active and token not active are not handled by the oidc-client library and will "bubble up".
+ *  We need a specific error boundary to handle these error. There is no way of preventing the errors from being thrown. And they will always show up in Sentry.
+ * */
+export default class OIDCUserManagerErrorBoundary extends React.Component<
+  {
+    children: React.ReactNode;
+    userManager: UserManager;
+  },
+  SessionErrorBoundaryState
+> {
+  state: SessionErrorBoundaryState = {
+    hasValidError: false,
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(error: any) {
+    const authError = isInvalidAuthStateError(error);
+    return { hasError: true, hasValidError: authError, error };
+  }
+
+  componentDidCatch(error: any, errorInfo: any) {
+    this.setState((prev) => ({
+      ...prev,
+      error,
+      errorInfo,
+    }));
+
+    if (isInvalidAuthStateError(error)) {
+      this.props.userManager.signinRedirect();
+    }
+  }
+
+  render() {
+    if (this.state.hasValidError) {
+      if (isInvalidAuthStateError(this.state.error)) {
+        return <AppPlaceholder />;
+      }
+    } else if (this.state.hasError) {
+      // pass non auth error to parent error boundary
+      throw this.state.error;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/silent-check-sso.html
+++ b/src/silent-check-sso.html
@@ -1,7 +1,7 @@
 <html>
 <body>
   <script>
-    parent.postMessage(location.href, location.origin);
+      parent.postMessage({url: location.href, source: 'oidc-client'}, location.origin);
   </script>
 </body>
 </html>


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/RHCLOUD-37897

Add a new error boundary that should explicitly deal with thrown errors form the OICD user manager. We have no callbacks API in the lib that could handle these exception so extra boundary is needed.

If listed events occur, we force re-authenticate the user. If we thee error does not match, we bubble the error up to the generic boundary. 
