### PR TITLE
Add bundle grouping to favorited services

### DIFF
--- a/src/components/FavoriteServices/ServiceTile.tsx
+++ b/src/components/FavoriteServices/ServiceTile.tsx
@@ -7,11 +7,11 @@ import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider'
 import StarIcon from '@patternfly/react-icons/dist/dynamic/icons/star-icon';
 
 import ChromeLink from '../ChromeLink';
-import { bundleMapping } from '../../hooks/useBundle';
 
 import './ServiceTile.scss';
 import useFavoritePagesWrapper from '../../hooks/useFavoritePagesWrapper';
 import { FavorableIcons } from './ServiceIcon';
+import { FavoritedBundleProps } from './ServicesGallery';
 
 export type ServiceTileProps = {
   name: React.ReactNode;
@@ -21,45 +21,53 @@ export type ServiceTileProps = {
   icon?: FavorableIcons;
 };
 
-const ServiceTile = ({ name, pathname, description, isExternal }: ServiceTileProps) => {
-  const bundle = bundleMapping[pathname.split('/')[1]];
+const ServiceTile = ({ bundleName, services }: FavoritedBundleProps) => {
+  const bundle = bundleName;
   const { unfavoritePage } = useFavoritePagesWrapper();
   return (
-    <ChromeLink isExternal={isExternal} href={pathname} className="chr-c-favorite-service__tile">
+    <>
       <Content className="pf-v6-u-px-lg pf-v6-u-pt-md">
         <Content component="small">{bundle}</Content>
       </Content>
-      <Split className="chr-c-link-favorite-card pf-v6-u-px-lg">
-        <SplitItem className="pf-v6-u-pt-md" isFilled>
-          {name}
-        </SplitItem>
-        <SplitItem className="pf-v6-u-mt-md">
-          <Button
-            icon={
-              <Icon className="pf-v6-u-ml-sm chr-c-icon-star">
-                <StarIcon />
-              </Icon>
-            }
-            onClick={(e) => {
-              // do not trigger click events on the the parent elements
-              e.stopPropagation();
-              e.preventDefault();
-              unfavoritePage(pathname);
-            }}
-            className="pf-v6-u-p-0"
-            variant="plain"
-          />
-        </SplitItem>
-      </Split>
-      <Content className="pf-v6-u-px-lg pf-v6-u-pb-md">
-        {description ? (
-          <Content component="small" className="pf-v6-u-color-100">
-            {description}
-          </Content>
-        ) : null}
-      </Content>
+      {services.map((service) => {
+        return (
+          <>
+            <ChromeLink isExternal={service.isExternal} href={service.pathname} className="chr-c-favorite-service__tile">
+              <Split className="chr-c-link-favorite-card pf-v6-u-px-lg">
+                <SplitItem className="pf-v6-u-pt-md" isFilled>
+                  {service.name}
+                </SplitItem>
+                <SplitItem className="pf-v6-u-mt-md">
+                  <Button
+                    icon={
+                      <Icon className="pf-v6-u-ml-sm chr-c-icon-star">
+                        <StarIcon />
+                      </Icon>
+                    }
+                    onClick={(e) => {
+                      // do not trigger click events on the the parent elements
+                      e.stopPropagation();
+                      e.preventDefault();
+                      unfavoritePage(service.pathname);
+                    }}
+                    className="pf-v6-u-p-0"
+                    variant="plain"
+                  />
+                </SplitItem>
+              </Split>
+              <Content className="pf-v6-u-px-lg pf-v6-u-pb-md">
+                {service.description ? (
+                  <Content component="small" className="pf-v6-u-color-100">
+                    {service.description}
+                  </Content>
+                ) : null}
+              </Content>
+            </ChromeLink>
+          </>
+        );
+      })}
       <Divider />
-    </ChromeLink>
+    </>
   );
 };
 

--- a/src/components/FavoriteServices/ServicesGallery.tsx
+++ b/src/components/FavoriteServices/ServicesGallery.tsx
@@ -4,15 +4,35 @@ import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import ServiceTile, { ServiceTileProps } from './ServiceTile';
 import ChromeLink from '../ChromeLink';
 import EmptyState from './EmptyState';
+import { bundleMapping } from '../../hooks/useBundle';
+
+export type FavoritedBundleProps = {
+  bundleName: string;
+  services: ServiceTileProps[];
+};
 
 const FavoriteServicesGallery = ({ favoritedServices }: { favoritedServices: ServiceTileProps[] }) => {
+  const bundles: FavoritedBundleProps[] = [];
+  favoritedServices.forEach((service) => {
+    const newBundleName = bundleMapping[service.pathname.split('/')[1]];
+    if (bundles.some((bundle) => bundle.bundleName === newBundleName)) {
+      const index = bundles.findIndex((bundle) => bundle.bundleName === newBundleName);
+      bundles[index].services = [...bundles[index].services, service];
+    } else {
+      bundles.push({
+        bundleName: newBundleName,
+        services: [service],
+      });
+    }
+  });
+
   return (
     <>
       {favoritedServices.length === 0 ? (
         <EmptyState />
       ) : (
         <>
-          {favoritedServices.map((props, index) => (
+          {bundles.map((props, index) => (
             <ServiceTile {...props} key={index} />
           ))}
           <Alert variant="info" title="Want to add more favorites?" className="pf-v6-u-m-md" isInline>


### PR DESCRIPTION
For [RHCLOUD-38664](https://issues.redhat.com/browse/RHCLOUD-38664). Instead of each service being listed unordered and individually, this PR adds grouping so they're under their respective bundles.


https://github.com/user-attachments/assets/577a6a60-7f13-400b-be99-8a636e726230

