### PR TITLE
Remove unused config frontend path.

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -29,7 +29,6 @@ objects:
       frontend:
         paths:
           - /
-          - /config/chrome
       akamaiCacheBustPaths:
         - /config/chrome/fed-modules.json
         - /apps/chrome/index.html


### PR DESCRIPTION
This path is no longer used. It referred to the cloud services config repository.