### PR TITLE
Checks service group link value before evaluating visibility.

### DIFF
--- a/src/hooks/useAllServices.ts
+++ b/src/hooks/useAllServices.ts
@@ -80,7 +80,7 @@ const evaluateLinksVisibility = async (sections: AllServicesSection[]): Promise<
   const que: EnhancedSection[] = [];
   sections.forEach((section) => {
     const newLinksQue = section.links.map(async (link) => {
-      if (isAllServicesGroup(link)) {
+      if (isAllServicesGroup(link) && link.links) {
         const nestedLinksQue = await link.links.map(evaluateVisibility);
         const links = await Promise.all(nestedLinksQue);
         return { ...link, links };


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-39406

While switching to the FEO-generated data, it can happen that the legacy all services definition service group links attribute is `null`.

This can occur before the feature flags are loaded and Chrome switches to the FEO-generated output. This does not cause a crash, but there is an error in the console.