### PR TITLE
feat: :sparkles: Add bot to close PRs and Issues after stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 60
+          days-before-close: 5
+          exempt-issue-labels: 'work-in-progress, in-progress, in-review, help-wanted, blocked, wip, depfu, dependabot, dependencies'
+          exempt-draft-pr: true

--- a/README.md
+++ b/README.md
@@ -113,3 +113,17 @@ Available function:
 ## Further reading
 
 More detailed documentation can be found in the [docs section](https://github.com/redhatinsights/insights-chrome/tree/master/docs)
+
+## Staleness
+
+A bot will post a comment after 60 days of inactivity giving the opener 5 days to update their issue/PR before it's closed.
+
+If you want the bot to ignore your issue or PR, please add one of the following labels:
+
+- work-in-progress
+- in-progress
+- in-review
+- help-wanted
+- blocked
+- wip
+- dependencies


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow to automatically manage stale issues and pull requests

New Features:
- Implement a stale bot that automatically manages inactive issues and pull requests

CI:
- Add GitHub Actions workflow to check and close stale issues and PRs after 60 days of inactivity

Documentation:
- Update README.md with information about the staleness bot and its behavior