### PR TITLE
Add favoriting to all-services redesign

### DIFF
--- a/src/components/AllServices/AllServicesLink.tsx
+++ b/src/components/AllServices/AllServicesLink.tsx
@@ -73,6 +73,23 @@ const AllServicesLink = ({ href, title, sectionTitle, bundleTitle, isExternal = 
       <FlexItem>
         <div className="pf-v6-u-font-size-xs pf-v6-u-text-color-disabled">{bundleTitle}</div>
       </FlexItem>
+      <FlexItem
+        className={classNames('chr-c-favorite-trigger', {
+          'chr-c-icon-favorited': isFavorite,
+        })}
+      >
+        {!isExternal && (
+          <Icon
+            data-ouia-component-id={`${category}-${group ? `${group}-` : ''}${titleToId(title ?? '')}-FavoriteToggle`}
+            onClick={() => handleFavouriteToggle(href ?? '#', isFavorite)}
+            aria-label={`${isFavorite ? 'Unfavorite' : 'Favorite'} ${title}`}
+            className="pf-v6-u-ml-sm chr-c-icon-star"
+            isInline
+          >
+            <StarIcon />
+          </Icon>
+        )}
+      </FlexItem>
     </Flex>
   ) : (
     <Content


### PR DESCRIPTION
For [RHCLOUD-38255](https://issues.redhat.com/browse/RHCLOUD-38255)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8bda4601-e4f2-48f9-82c8-3b697db35090" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9075d868-aa44-4df9-a69f-40a2a936a1f7" />

## Summary by Sourcery

Add favoriting functionality to the All Services link component

New Features:
- Implement a favorite toggle icon for services in the All Services view, allowing users to mark and unmark services as favorites

Enhancements:
- Add visual indication for favorited services with a star icon
- Implement conditional rendering of favorite toggle for non-external services