### PR TITLE
Extends token not active message range.

### DIFF
--- a/cypress/component/OIDCConnector/OIDCUserManagerErrorBoundary.cy.tsx
+++ b/cypress/component/OIDCConnector/OIDCUserManagerErrorBoundary.cy.tsx
@@ -47,7 +47,7 @@ describe('OIDCUserManagerErrorBoundary', () => {
     cy.contains('Fake error').should('exist');
   });
 
-  [SESSION_NOT_ACTIVE, TOKEN_NOT_ACTIVE].forEach((error) => {
+  [SESSION_NOT_ACTIVE, ...TOKEN_NOT_ACTIVE.values()].forEach((error) => {
     it('should try redirect to signin page if error is thrown', () => {
       cy.intercept('GET', '/authorityUrl', {
         statusCode: 200,

--- a/src/auth/OIDCConnector/OIDCUserManagerErrorBoundary.tsx
+++ b/src/auth/OIDCConnector/OIDCUserManagerErrorBoundary.tsx
@@ -10,10 +10,10 @@ type SessionErrorBoundaryState = {
 };
 
 export const SESSION_NOT_ACTIVE = 'Session not active';
-export const TOKEN_NOT_ACTIVE = 'Token not active';
+export const TOKEN_NOT_ACTIVE = new Set(['Token not active', 'Token is not active']);
 
 function isInvalidAuthStateError(error: any): boolean {
-  return error?.error_description === SESSION_NOT_ACTIVE || error?.error_description === TOKEN_NOT_ACTIVE;
+  return error?.error_description === SESSION_NOT_ACTIVE || (error?.error_description && TOKEN_NOT_ACTIVE.has(error?.error_description));
 }
 /**
  *  The session not active and token not active are not handled by the oidc-client library and will "bubble up".


### PR DESCRIPTION
Follow up to token timeout handling.

Jira: https://issues.redhat.com/browse/RHCLOUD-39651


## Summary by Sourcery

Extend token not active error handling to support multiple error message variations

Enhancements:
- Modify error checking logic to support multiple token not active error message formats

Tests:
- Update Cypress tests to handle multiple token not active error messages