### PR TITLE
Update Caddy base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/cloudservices/caddy-ubi:ec1577c
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:0d6954b
 
 ENV CADDY_TLS_MODE http_port 8000
 


### PR DESCRIPTION
Need to test this change in ephemeral

Jira: https://issues.redhat.com/browse/RHCLOUD-39650


## Summary by Sourcery

Chores:
- Update Dockerfile to use a new Caddy base image from a different registry