### PR TITLE
feat(quickstarts): enable in app links

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,5 +1,7 @@
 import { TextDecoder, TextEncoder } from 'util';
 import 'whatwg-fetch';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const crypto = require('crypto');
 
 global.SVGPathElement = function () {};
 
@@ -34,6 +36,15 @@ Object.defineProperty(global.window.document, 'cookie', {
   writable: true,
   value: '',
 });
+
+// Crypto object polyfill for JSDOM
+global.window.crypto = {
+  ...crypto,
+};
+// in case the crypto package is mangled or the method does not exist
+if (!global.window.crypto.randomUUID) {
+  global.window.crypto.randomUUID = () => Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
 
 global.window.insights = {
   ...(window.insights || {}),

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ const resolver = path.resolve(__dirname, './scripts/testResolver.js');
 module.exports = {
   coverageDirectory: './coverage/',
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.js', 'src/**/*.ts', '!src/**/*Styles.js'],
+  collectCoverageFrom: ['src/**/*.js', 'src/**/*.ts', 'src/**/*.tsx', '!src/**/*Styles.js'],
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     url: 'https://test.com',

--- a/src/components/RootApp/RootApp.tsx
+++ b/src/components/RootApp/RootApp.tsx
@@ -19,11 +19,13 @@ import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 import { scalprumConfigAtom } from '../../state/atoms/scalprumConfigAtom';
 import { isDebuggerEnabledAtom } from '../../state/atoms/debuggerModalatom';
 import { addQuickstartToAppAtom, clearQuickstartsAtom, populateQuickstartsAppAtom, quickstartsAtom } from '../../state/atoms/quickstartsAtom';
+import useQuickstartLinkStore, { createQuickstartLinkMarkupExtension } from '../../hooks/useQuickstarLinksStore';
 
 const NotEntitledModal = lazy(() => import('../NotEntitledModal'));
 const Debugger = lazy(() => import('../Debugger'));
 
 const RootApp = memo(({ accountId }: { accountId?: string }) => {
+  const quickstartLinkStore = useQuickstartLinkStore();
   const config = useAtomValue(scalprumConfigAtom);
   const { activateQuickstart, allQuickStartStates, setAllQuickStartStates, activeQuickStartID, setActiveQuickStartID } =
     useQuickstartsStates(accountId);
@@ -86,6 +88,9 @@ const RootApp = memo(({ accountId }: { accountId?: string }) => {
     showCardFooters: false,
     language: 'en',
     alwaysShowTaskReview: true,
+    markdown: {
+      extensions: [createQuickstartLinkMarkupExtension(quickstartLinkStore)],
+    },
   };
 
   const helpTopicsAPI = {

--- a/src/hooks/useQuickstarLinksStore.test.tsx
+++ b/src/hooks/useQuickstarLinksStore.test.tsx
@@ -1,0 +1,187 @@
+import React, { PropsWithChildren, useEffect } from 'react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import { unstable_HistoryRouter as BrowserRouter } from 'react-router-dom';
+import useQuickstartLinkStore, { createQuickstartLinkMarkupExtension } from './useQuickstarLinksStore';
+import chromeHistory from '../utils/chromeHistory';
+
+const DEFAULT_LINK = '/test-link';
+const DEFAULT_URL = 'https://test.com/test-link';
+const TEST_UUID: ReturnType<typeof crypto.randomUUID> = 'test-uuid' as any; // Mock UUID for testing
+
+type TestSpy = {
+  current: {
+    addLinkSpy?: jest.SpyInstance;
+  };
+};
+
+function HistoryTrigger({
+  link = DEFAULT_LINK,
+  linkTestId = 'test-link',
+  children,
+  testSpy = { current: {} },
+}: PropsWithChildren<{
+  link?: string;
+  testSpy?: TestSpy;
+  linkTestId?: string;
+}>) {
+  const store = useQuickstartLinkStore();
+  const linkRef = React.useRef<HTMLAnchorElement>(null);
+  useEffect(() => {
+    // map spy functions to access them from test cases
+    const addLinkSpy = jest.spyOn(store, 'addLinkElement');
+    testSpy.current.addLinkSpy = addLinkSpy;
+    if (linkRef.current) {
+      store.addLinkElement(linkTestId);
+    }
+  }, []);
+  return (
+    <BrowserRouter history={chromeHistory as any}>
+      <div>
+        <div>History Trigger</div>
+        <button
+          onClick={() => {
+            // mutate the history
+            window.history.replaceState({ quickstartLink: true }, '', link);
+            // Dispatch a custom event to simulate the history change
+            const e = new Event('replacestate');
+            // Add state to the event to simulate a quickstart link click
+            // can't do in constructor
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            e.state = { quickstartLink: true };
+            window.dispatchEvent(e);
+          }}
+        >
+          Trigger History Push
+        </button>
+      </div>
+      {children}
+      <a ref={linkRef} href={link} id="test-link">
+        Test Link
+      </a>
+    </BrowserRouter>
+  );
+}
+
+describe('useQuickstarLinksStore', () => {
+  describe('link store', () => {
+    it('should init the interface', () => {
+      const { result } = renderHook(() => useQuickstartLinkStore());
+      expect(result.current).toBeDefined();
+      expect(result.current.addLinkElement).toBeDefined();
+      expect(result.current.emptyElements).toBeDefined();
+    });
+
+    it('should register quickstarts link click listener', () => {
+      const historyPushSpy = jest.spyOn(chromeHistory, 'push');
+
+      waitFor(() => {
+        render(<HistoryTrigger></HistoryTrigger>);
+      });
+
+      const triggerButton = screen.getByRole('button');
+      triggerButton.click();
+
+      expect(historyPushSpy).toHaveBeenCalledWith(DEFAULT_LINK);
+      expect(historyPushSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should  push chrome history state on quickstart link click', () => {
+      jest.useFakeTimers();
+      const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+      const testSpy: TestSpy = { current: {} };
+      waitFor(() => {
+        render(<HistoryTrigger testSpy={testSpy}></HistoryTrigger>);
+      });
+
+      // The link addLinkElement is wrapped in timeout to push to the end of execution loop to ensure the link is rendered
+      // we need to postpone the rest of the tests to ensure the link is added to the store
+      jest.runAllTimers();
+      const triggerLink = screen.getByText('Test Link');
+      triggerLink.click();
+
+      expect(replaceStateSpy).toHaveBeenCalledWith({ quickstartLink: true }, '', DEFAULT_URL);
+      expect(testSpy.current.addLinkSpy).toHaveBeenCalledWith('test-link');
+      expect(testSpy.current.addLinkSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not add link element if it is not found', () => {
+      jest.useFakeTimers();
+      const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
+      const testSpy: TestSpy = { current: {} };
+      waitFor(() => {
+        render(<HistoryTrigger linkTestId="foo" testSpy={testSpy}></HistoryTrigger>);
+      });
+
+      // The link addLinkElement is wrapped in timeout to push to the end of execution loop to ensure the link is rendered
+      // we need to postpone the rest of the tests to ensure the link is added to the store
+      jest.runAllTimers();
+      const triggerLink = screen.getByText('Test Link');
+      triggerLink.click();
+
+      expect(testSpy.current.addLinkSpy).toHaveBeenCalledWith('foo');
+      expect(testSpy.current.addLinkSpy).toHaveBeenCalledTimes(1);
+      // Ensure that the interval is cleared after 5 iterations
+      expect(clearIntervalSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('createQuickstartLinkMarkupExtension', () => {
+    jest.spyOn(window.crypto, 'randomUUID').mockReturnValue(TEST_UUID);
+    const mockLinkStore = {
+      addLinkElement: jest.fn(),
+      emptyElements: jest.fn(),
+    };
+
+    beforeEach(() => {
+      mockLinkStore.addLinkElement.mockClear();
+      mockLinkStore.emptyElements.mockClear();
+    });
+
+    it('should match MD link with no origin and call addLinkElement', () => {
+      const markdownText = '[Test Link](/test-link)';
+      const mdExtension = createQuickstartLinkMarkupExtension(mockLinkStore);
+      const result = mdExtension.replace(markdownText);
+      expect(mockLinkStore.addLinkElement).toHaveBeenCalledWith(TEST_UUID);
+      expect(mockLinkStore.addLinkElement).toHaveBeenCalledTimes(1);
+      expect(result).toBe(`<a id="${TEST_UUID}" href="/test-link">Test Link</a>`);
+    });
+
+    it('should match MD link with same origin and call addLinkElement', () => {
+      const markdownText = `[Test Link](${window.location.origin}/test-link)`;
+      const mdExtension = createQuickstartLinkMarkupExtension(mockLinkStore);
+      const result = mdExtension.replace(markdownText);
+      expect(mockLinkStore.addLinkElement).toHaveBeenCalledWith(TEST_UUID);
+      expect(mockLinkStore.addLinkElement).toHaveBeenCalledTimes(1);
+      expect(result).toBe(`<a id="${TEST_UUID}" href="${window.location.origin}/test-link">Test Link</a>`);
+    });
+
+    it('should not match MD link with different origin', () => {
+      const markdownText = '[Test Link](https://example.com/test-link)';
+      const mdExtension = createQuickstartLinkMarkupExtension(mockLinkStore);
+      const result = mdExtension.replace(markdownText);
+      expect(mockLinkStore.addLinkElement).not.toHaveBeenCalled();
+      expect(result).toBe(markdownText); // No change should be made
+    });
+
+    it('should fall back on error and output original MD', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      // Example markdown with no links
+      const markdownText = `
+    # Heading Example
+
+    - List item one
+    - List item two
+
+    **Bold text** and _italic text_.
+
+    > Blockquote example.
+    `;
+      const mdExtension = createQuickstartLinkMarkupExtension(mockLinkStore);
+      const result = mdExtension.replace(markdownText);
+      expect(mockLinkStore.addLinkElement).not.toHaveBeenCalled();
+      expect(result).toBe(markdownText); // No change should be made
+      expect(console.error).toHaveBeenCalledWith('Error creating quickstart link markup', expect.any(Error));
+    });
+  });
+});

--- a/src/hooks/useQuickstarLinksStore.tsx
+++ b/src/hooks/useQuickstarLinksStore.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useMemo } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { registerQuickstartLinkClickListener } from '../utils/chromeHistory';
+
+function useQuickstartLinkStore() {
+  const store = useMemo(() => new Map<string, HTMLAnchorElement>(), []);
+
+  function addLinkElement(id: string) {
+    let iterations = 0;
+    setTimeout(() => {
+      // push execution to end of the call stack
+      const findInterval = setInterval(() => {
+        const element = document.getElementById(id);
+        if (element) {
+          store.set(id, element as HTMLAnchorElement);
+          element.addEventListener('click', (e) => {
+            const { href } = element as HTMLAnchorElement;
+            if (!href) {
+              return;
+            }
+            e.preventDefault();
+            window.history.replaceState(
+              {
+                quickstartLink: true,
+              },
+              '',
+              href
+            );
+          });
+          clearInterval(findInterval);
+        }
+        iterations += 1;
+        if (iterations > 5) {
+          clearInterval(findInterval);
+        }
+      }, 1000);
+    });
+  }
+
+  function emptyElements() {
+    store.clear();
+  }
+  useEffect(() => {
+    const unregister = registerQuickstartLinkClickListener();
+    return () => {
+      unregister();
+      emptyElements();
+    };
+  }, []);
+
+  return {
+    addLinkElement,
+    emptyElements,
+  };
+}
+
+export function createQuickstartLinkMarkupExtension(quickstartLinkStore: ReturnType<typeof useQuickstartLinkStore>) {
+  return {
+    type: 'lang',
+    // matches MD links like [link text](https://example.com)
+    regex: /\[.*\]\(.*\)/g,
+    replace: (text: string) => {
+      try {
+        let [linkText, linkURL] = text.split('](');
+        linkText = linkText.replace(/^\[/, '');
+        linkURL = linkURL.replace(/\)$/, '');
+        let href: string;
+        try {
+          const fullURL = new URL(linkURL);
+          href = fullURL.toString();
+          if (fullURL.origin !== window.location.origin) {
+            // link is external, do not intercept
+            return text;
+          }
+        } catch {
+          // not full URL, is just a pathname
+          href = linkURL;
+        }
+        const linkId = crypto.randomUUID();
+        quickstartLinkStore.addLinkElement(linkId);
+        const node = (
+          <a id={linkId} href={href}>
+            {linkText}
+          </a>
+        );
+        return renderToStaticMarkup(node);
+      } catch (e) {
+        console.error('Error creating quickstart link markup', e);
+        return text;
+      }
+    },
+  };
+}
+
+export default useQuickstartLinkStore;

--- a/src/utils/chromeHistory.ts
+++ b/src/utils/chromeHistory.ts
@@ -2,4 +2,20 @@ import { createBrowserHistory } from 'history';
 
 const history = createBrowserHistory();
 
+// listen on quickstart link click
+export function registerQuickstartLinkClickListener() {
+  function listener(event: Event) {
+    const { state } = event as unknown as { state?: { quickstartLink?: boolean } };
+    const isQuickstartLink = state?.quickstartLink;
+    if (isQuickstartLink) {
+      history.push(window.location.pathname);
+    }
+  }
+
+  window.addEventListener('replacestate', listener);
+  return () => {
+    window.removeEventListener('replacestate', listener);
+  };
+}
+
 export default history;


### PR DESCRIPTION
Tasks: https://issues.redhat.com/browse/RHCLOUD-39724

### Changes

- add quickstarts in app routing

Do not ask for tests the routing tests. Without working e2e env, we don't have navigation tests that would be reliable in either of the environments. We are either blocked from the history API, or it's poorly mocked.

## Summary by Sourcery

New Features:
- Intercept internal links in Quickstart markdown to navigate within the application using browser history APIs, preventing full page reloads.

## Summary by Sourcery

Enable single-page application navigation for internal links within Quickstarts.

New Features:
- Intercept internal links in Quickstart markdown to navigate within the application using browser history APIs, preventing full page reloads.

Enhancements:
- Introduce a markdown extension to process and identify internal Quickstart links.
- Utilize the browser History API to handle link clicks and update the application path.