### PR TITLE
Favoriting styling fix and clean-up

### DIFF
--- a/src/components/AllServicesDropdown/AllServicesDropdown.scss
+++ b/src/components/AllServicesDropdown/AllServicesDropdown.scss
@@ -126,10 +126,6 @@
     }
   }
 
-  .chr-c-icon-star {
-    visibility: hidden;
-  }
-
   .chr-c-favorite-button {
     :hover {
       background-color: none;

--- a/src/components/AllServicesDropdown/AllServicesGalleryLink.tsx
+++ b/src/components/AllServicesDropdown/AllServicesGalleryLink.tsx
@@ -47,9 +47,11 @@ const AllServicesGalleryLink = ({ href, title, description, isExternal, category
         </SplitItem>
         <SplitItem className="pf-v6-u-mt-sm">
           {isExternal ? (
-            <Icon className="pf-v6-u-ml-sm chr-c-icon-external-link pf-v6-u-text-color-link" isInline>
-              <ExternalLinkAltIcon />
-            </Icon>
+            <Button variant="plain">
+              <Icon className="pf-v6-u-ml-0 chr-c-icon-external-link pf-v6-u-text-color-link" isInline>
+                <ExternalLinkAltIcon />
+              </Icon>
+            </Button>
           ) : (
             <Button
               variant="plain"

--- a/src/components/AllServicesDropdown/AllServicesGalleryLink.tsx
+++ b/src/components/AllServicesDropdown/AllServicesGalleryLink.tsx
@@ -47,11 +47,9 @@ const AllServicesGalleryLink = ({ href, title, description, isExternal, category
         </SplitItem>
         <SplitItem className="pf-v6-u-mt-sm">
           {isExternal ? (
-            <Button variant="plain">
-              <Icon className="pf-v6-u-ml-0 chr-c-icon-external-link pf-v6-u-text-color-link" isInline>
-                <ExternalLinkAltIcon />
-              </Icon>
-            </Button>
+            <Icon className="pf-v6-u-mr-sm chr-c-icon-external-link pf-v6-u-text-color-link" isInline>
+              <ExternalLinkAltIcon />
+            </Icon>
           ) : (
             <Button
               variant="plain"

--- a/src/components/AllServicesDropdown/AllServicesMenu.tsx
+++ b/src/components/AllServicesDropdown/AllServicesMenu.tsx
@@ -107,7 +107,7 @@ const AllServicesMenu = ({ setIsOpen, isOpen, menuRef, linkSections, favoritedSe
                       actions={{
                         actions: [
                           <Button
-                            className="pf-v6-u-mr-xs"
+                            className="pf-v6-u-mr-sm"
                             icon={<TimesIcon />}
                             key="close"
                             variant="plain"

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -167,40 +167,10 @@ aside {
 
 .chr-c-favorite-trigger {
   cursor: pointer;
-  .chr-c-icon-star {
-    --pf-v6-c-icon__content--Color: var(--pf-t--global--icon--color--subtle);
-    visibility: hidden;
-    .favorite {
-      visibility: visible;
-    }
-  }
-  &:hover {
-    .chr-c-icon-star {
-      visibility: visible;
-    }
-    .pf-v6-c-icon {
-      --pf-v6-c-icon__content--Color: var(--pf-t--global--icon--color--subtle);
-      &:hover {
-        --pf-v6-c-icon__content--Color: var(--pf-t--global--icon--color--regular);
-      }
-    }
-    .pf-v6-c-icon-external-link, .pf-v6-c-icon-external-link:hover {
-      --pf-v6-c-icon__content--Color: var(--pf-t--global--text--color--link--hover);
-    }
-  }
 }
 .chr-c-favorite-trigger.chr-c-icon-favorited {
-  .chr-c-icon-star {
-    visibility: visible;
-  }
   .pf-v6-c-icon {
     --pf-v6-c-icon__content--Color: var(--pf-t--global--icon--color--favorite--default);
-    &:hover {
-      --pf-v6-c-icon__content--Color: var(--pf-t--global--icon--color--favorite--hover);
-      .chr-c-icon-external-link, .chr-c-icon-external-link:hover {
-        --pf-v6-c-icon__content--Color: var(--pf-t--global--text--color--link--hover);
-      }
-    }
   }
 }
 .chr-c-link-favorite-card { //trigger not needed here
@@ -212,9 +182,6 @@ aside {
         --pf-v6-c-icon__content--Color: var(--pf-t--global--text--color--link--hover);
       }
     }
-  }
-  .pf-v6-c-icon.chr-c-icon-star {
-    visibility: visible;
   }
 }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-38827


- show black star for accessibility on services drop-down and all-services page


Old
![Screenshot 2025-04-28 at 11 39 34 AM](https://github.com/user-attachments/assets/63e4fad7-ad38-43a8-b64f-004019c5a399)

![Screenshot 2025-04-28 at 11 39 59 AM](https://github.com/user-attachments/assets/33239a5f-d54f-4bbe-894c-0e52353e490c)

New

![Screenshot 2025-04-28 at 11 38 07 AM](https://github.com/user-attachments/assets/f8ed48e0-9d6e-4ca3-b6d0-3a987487f6e7)

![Screenshot 2025-04-28 at 11 37 18 AM](https://github.com/user-attachments/assets/4d70c2ee-57a2-4d42-bcd6-0afea10e3cb2)

## Summary by Sourcery

Simplify and correct the styling for the favorite icon component.

Bug Fixes:
- Fix visibility and hover state inconsistencies for the favorite icon.

Chores:
- Adjust spacing for icons within the All Services dropdown components.