### PR TITLE
Drawer crash

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -24,6 +24,7 @@ import { isPreviewAtom, togglePreviewWithCheckAtom } from '../../state/atoms/rel
 import { notificationDrawerExpandedAtom } from '../../state/atoms/notificationDrawerAtom';
 import useSupportCaseData from '../../hooks/useSupportCaseData';
 import { ScalprumComponent, ScalprumComponentProps } from '@scalprum/react-core';
+import { drawerPanelContentAtom } from '../../state/atoms/drawerPanelContentAtom';
 
 const InternalButton = () => (
   <Button
@@ -243,12 +244,13 @@ const Tools = () => {
   const toggleDrawer = () => {
     setIsNotificationsDrawerExpanded((prev) => !prev);
   };
+  const drawerContent = useAtomValue(drawerPanelContentAtom);
 
   const drawerBellProps: ScalprumComponentProps<Record<string, unknown>, NotificationBellProps> = {
     scope: 'notifications',
     module: './NotificationsDrawerBell',
     fallback: null,
-    isNotificationDrawerExpanded,
+    isNotificationDrawerExpanded: drawerContent?.scope === 'notifications' && isNotificationDrawerExpanded,
     // Do not show the error component if module fails to load
     // Prevents broken layout
     ErrorComponent: <Fragment />,


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-39837

### Changes
- use the correct `ErrorComponent prop`, currently, the component type is crashing UI after the drawer bell fails to load
- fix drawer bel highlight condition

## Summary by Sourcery

Fix drawer bell component rendering and prevent UI crashes when notifications fail to load

Bug Fixes:
- Corrected ErrorComponent prop to prevent UI crashes
- Fixed drawer bell highlight condition to work correctly with drawer content

Enhancements:
- Improved error handling for notification drawer component