### PR TITLE
Fix Favoriting Empty state styling

### DIFF
--- a/src/components/AllServicesDropdown/AllServicesDropdown.scss
+++ b/src/components/AllServicesDropdown/AllServicesDropdown.scss
@@ -55,6 +55,12 @@
   }
 }
 
+.chr-c-panel-services-nav {
+  .chr-c-empty-state-favorites {
+    padding-top: var(--pf-t--global--spacer--md);
+  }
+}
+
 @media (max-width: $pf-v6-global--breakpoint--md) {
   .chr-c-panel-services-nav {
     .chr-l-stack__item-browse-all-services {

--- a/src/components/FavoriteServices/EmptyState.tsx
+++ b/src/components/FavoriteServices/EmptyState.tsx
@@ -13,7 +13,7 @@ const EmptyState = () => (
     <Flex className="pf-v6-u-justify-content-center pf-v6-u-align-items-stretch">
       <Stack className="pf-v6-u-justify-content-center">
         <StackItem className="pf-v6-u-text-align-center">
-          <img src="https://console.redhat.com/apps/frontend-assets/favoritedservices/favoriting-emptystate.svg" alt="favoriting image" />
+          <img src="https://console.redhat.com/apps/frontend-assets/favoritedservices/favoriting-emptystate.svg" className="chr-c-empty-state-favorites" alt="favoriting image" />
         </StackItem>
         <StackItem className="pf-v6-u-text-align-center">
           <Content>

--- a/src/components/FavoriteServices/EmptyState.tsx
+++ b/src/components/FavoriteServices/EmptyState.tsx
@@ -13,7 +13,11 @@ const EmptyState = () => (
     <Flex className="pf-v6-u-justify-content-center pf-v6-u-align-items-stretch">
       <Stack className="pf-v6-u-justify-content-center">
         <StackItem className="pf-v6-u-text-align-center">
-          <img src="https://console.redhat.com/apps/frontend-assets/favoritedservices/favoriting-emptystate.svg" className="chr-c-empty-state-favorites" alt="favoriting image" />
+          <img
+            src="https://console.redhat.com/apps/frontend-assets/favoritedservices/favoriting-emptystate.svg"
+            className="chr-c-empty-state-favorites"
+            alt="favoriting image"
+          />
         </StackItem>
         <StackItem className="pf-v6-u-text-align-center">
           <Content>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-39847
- Add top padding to Favoriting empty state (Service dropdown only , not landing page widget)

Old
![Screenshot 2025-05-12 at 1 58 59 PM](https://github.com/user-attachments/assets/02ea3170-7d69-475a-a213-c849faf296bf)

New
![Screenshot 2025-05-12 at 1 58 12 PM](https://github.com/user-attachments/assets/535c30a6-8f90-4d13-abd2-9354a81b1dea)

## Summary by Sourcery

Fix the favoriting empty state styling in the service dropdown by attaching a CSS class to the image and adding top padding for proper spacing.

Bug Fixes:
- Apply a CSS class to the favoriting empty state image for styling
- Add top padding to the favoriting empty state container in the service dropdown