### PR TITLE
Service dropdown - add hover to right side

### DIFF
--- a/src/components/AllServicesDropdown/AllServicesDropdown.scss
+++ b/src/components/AllServicesDropdown/AllServicesDropdown.scss
@@ -118,7 +118,11 @@
 }
 
 .chr-c-favorite-service__tile {
+  display: block;
   text-decoration: none !important;
+  &:hover {
+    background: var(--pf-t--global--background--color--200);
+  }
 
   :hover {
     .chr-c-icon-star {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-39741

![Screenshot 2025-05-13 at 2 32 09 PM](https://github.com/user-attachments/assets/fdc32149-080b-40f3-9b3b-2dbb1bb3e782)

## Summary by Sourcery

Add full-width hover styling to favorite service tiles in the service dropdown

Enhancements:
- Make favorite service tiles display as block elements to enable full-row hover effect
- Apply background color on hover to the right side of service dropdown items