### PR TITLE
fix(all-services): permissions on new redesign to be used

### DIFF
--- a/src/hooks/useAllLinks.ts
+++ b/src/hooks/useAllLinks.ts
@@ -107,12 +107,11 @@ const filterItem = async (navItems: NavItem[]): Promise<NavItem & { isHidden?: b
 export const fetchBundles = async (feoGenerated = false) => {
   const bundlesNavigation = await fetchNavigationFiles(feoGenerated);
   return await Promise.all(
-      bundlesNavigation.map(async (bundleNav) => ({
-        ...bundleNav,
-        navItems: (await filterItem(bundleNav.navItems)).filter(({ isHidden }) => !isHidden),
-      }))
-    );
-
+    bundlesNavigation.map(async (bundleNav) => ({
+      ...bundleNav,
+      navItems: (await filterItem(bundleNav.navItems)).filter(({ isHidden }) => !isHidden),
+    }))
+  );
 };
 
 const useAllLinks = () => {

--- a/src/hooks/useAllLinks.ts
+++ b/src/hooks/useAllLinks.ts
@@ -106,13 +106,13 @@ const filterItem = async (navItems: NavItem[]): Promise<NavItem & { isHidden?: b
 
 export const fetchBundles = async (feoGenerated = false) => {
   const bundlesNavigation = await fetchNavigationFiles(feoGenerated);
-  const parsedBundles = await Promise.all(
-    bundlesNavigation.map(async (bundleNav) => ({
-      ...bundleNav,
-      navItems: (await filterItem(bundleNav.navItems)).filter(({ isHidden }) => !isHidden),
-    }))
-  );
-  return parsedBundles;
+  return await Promise.all(
+      bundlesNavigation.map(async (bundleNav) => ({
+        ...bundleNav,
+        navItems: (await filterItem(bundleNav.navItems)).filter(({ isHidden }) => !isHidden),
+      }))
+    );
+
 };
 
 const useAllLinks = () => {

--- a/src/layouts/AllServices.tsx
+++ b/src/layouts/AllServices.tsx
@@ -61,8 +61,10 @@ const AllServices = ({ Footer }: AllServicesProps) => {
   };
 
   useEffect(() => {
-    fetchNavigation();
-  }, []);
+    if (enableAllServicesRedesign) {
+      fetchNavigation();
+    }
+  }, [enableAllServicesRedesign]);
 
   useEffect(() => {
     if (!filterValue) {

--- a/src/layouts/AllServices.tsx
+++ b/src/layouts/AllServices.tsx
@@ -18,11 +18,11 @@ import './AllServices.scss';
 import useAllServices from '../hooks/useAllServices';
 import Messages from '../locales/Messages';
 import { updateDocumentTitle } from '../utils/common';
-import fetchNavigationFiles from '../utils/fetchNavigationFiles';
 import { useFlag } from '@unleash/proxy-client-react';
 import AllServicesBundle from '../components/AllServices/AllServicesBundle';
 import { BundleNavigation } from '../@types/types';
 import filterNavItemsByTitle from '../utils/filterNavItemsByTitle';
+import { fetchBundles } from '../hooks/useAllLinks';
 
 const availableBundles = ['openshift', 'insights', 'ansible', 'settings', 'iam', 'subscriptions'];
 
@@ -53,7 +53,7 @@ const AllServices = ({ Footer }: AllServicesProps) => {
   };
 
   const fetchNavigation = async () => {
-    const fetchNav = await fetchNavigationFiles();
+    const fetchNav = await fetchBundles();
     const filteredBundles = fetchNav.filter(({ id }) => availableBundles.includes(id));
     const withOthers = filteredBundles.concat(otherServicesBundle);
     setOriginalBundles(withOthers);


### PR DESCRIPTION
### Description

As a user if there are any permissions applied to any navigation this link is visible on the all services redesign. This PR fixes such issue by checking the permissions and filtering out those links which should not be visible for current user.

## Summary by Sourcery

Filter out navigation links in the All Services redesign based on user permissions so that unauthorized links are hidden.

Bug Fixes:
- Hide navigation links for which the current user lacks permissions in the All Services redesign.

Enhancements:
- Introduce a recursive filterItem utility that marks and removes hidden navItems and routes based on evaluateVisibility.
- Update fetchBundles to apply permission-based filtering to all bundle navigations before rendering.