### PR TITLE
Add missing classes to Services icon components

### DIFF
--- a/src/components/AllServicesDropdown/icon-acs.tsx
+++ b/src/components/AllServicesDropdown/icon-acs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ACSIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <defs>
         <style>{`.uuid-2cc71784-83b2-4ce0-a27c-c558cca16f2a{fill:#e00;}.uuid-073bfd7c-dff4-432f-a7b0-f3a025d959a1{fill:#fff;}`}</style>
       </defs>

--- a/src/components/AllServicesDropdown/icon-ai-technology.tsx
+++ b/src/components/AllServicesDropdown/icon-ai-technology.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const AITechnologyIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <g id="uuid-fb69441b-b57f-4918-99bb-aad41e7175f0">
         <rect x="1" y="1" width="36" height="36" rx="9" ry="9" strokeWidth="0" />
         <path

--- a/src/components/AllServicesDropdown/icon-app-services.tsx
+++ b/src/components/AllServicesDropdown/icon-app-services.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const AppServicesIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <defs>
         <style>{`.st0{fill:#EE0000;}.st1{fill:#FFFFFF;}`}</style>
       </defs>

--- a/src/components/AllServicesDropdown/icon-data-science.tsx
+++ b/src/components/AllServicesDropdown/icon-data-science.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const DataScienceIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <defs>
         <style>
           {`.uuid-00fb0b47-b01e-49bb-a511-91a567727439{fill:#e00;}.uuid-f46e1c4f-4336-4ea3-9a78-d01849a9fd26{fill:#fff;}.uuid-21bbc327-fd19-43c3-8c74-cd12b6253304{fill:#4d4d4d;}`}

--- a/src/components/AllServicesDropdown/icon-edge.tsx
+++ b/src/components/AllServicesDropdown/icon-edge.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const EdgeIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 42 42">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 42 42">
       <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <g id="Group-8" fillRule="nonzero">
           <path

--- a/src/components/AllServicesDropdown/icon-placeholder.tsx
+++ b/src/components/AllServicesDropdown/icon-placeholder.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const PlaceholderIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <defs>
         <style>{`.babc916c-e1fb-432c-82f5-f31008f864ae{fill:red;}.bd54039f-1ff7-4ad7-a5a2-655d1144d9f5{fill:#fff;}`}</style>
       </defs>

--- a/src/components/AllServicesDropdown/icon-quay-io.tsx
+++ b/src/components/AllServicesDropdown/icon-quay-io.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const QuayIoIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <g id="Symbols" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <g id="Technology_icon-Red_Hat-Quay-Standard-RGB" fillRule="nonzero">
           <g id="uuid-16df5206-ca64-41dd-b57e-55c66370cb99" fill="#000000">

--- a/src/components/AllServicesDropdown/icon-rh.tsx
+++ b/src/components/AllServicesDropdown/icon-rh.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const RHIcon = () => {
   return (
-    <svg width="24" height="30" viewBox="0 0 24 30">
+    <svg className="platform-icon allservices-icon" width="24" height="30" viewBox="0 0 24 30">
       <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <g id="Group-7" fillRule="nonzero">
           <path

--- a/src/components/AllServicesDropdown/icon-services.tsx
+++ b/src/components/AllServicesDropdown/icon-services.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ServicesIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <style type="text/css">
         {`.st0{fill:#EE0000;}`}
         {`.st1{fill:#FFFFFF;}`}

--- a/src/components/AllServicesDropdown/icon-trusted-artifact.tsx
+++ b/src/components/AllServicesDropdown/icon-trusted-artifact.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const TrustedArtifactIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <g id="uuid-a65c70ad-12b3-4cda-8a7e-1f2cfe14ffa5">
         <rect x="1" y="1" width="36" height="36" rx="9" ry="9" strokeWidth="0" />
         <path

--- a/src/components/AllServicesDropdown/icon-trusted-content.tsx
+++ b/src/components/AllServicesDropdown/icon-trusted-content.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const TrustedContentIcon = () => {
   return (
-    <svg width="28" height="28" viewBox="0 0 38 38">
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
       <defs>
         <style>
           {`.uuid-d17ab8ef-2669-408a-93d8-60828bdd8082{fill:#e00;}.uuid-c4741b83-a3db-4b6d-858c-b3ae14c63c56{fill:#fff;}.uuid-83ce5ebd-b119-4710-9c52-7f345a2ee75e{fill:#4d4d4d;}`}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-40043

Old
![Screenshot 2025-05-14 at 12 22 38 PM](https://github.com/user-attachments/assets/74e79c42-473c-4929-822d-a826d5e13bdc)

New
![Screenshot 2025-05-14 at 12 21 14 PM](https://github.com/user-attachments/assets/3b145ced-930c-4194-a7bc-82e869798dc5)

## Summary by Sourcery

Enhancements:
- Add className "platform-icon allservices-icon" to SVG elements in all AllServicesDropdown icon components