### PR TITLE
fix: :memo: Update wording in feedback modal

### DIFF
--- a/locales/translation-template.json
+++ b/locales/translation-template.json
@@ -88,8 +88,8 @@
     "description": "Email"
   },
   "enterFeedback": {
-    "defaultMessage": "Enter your feedback",
-    "description": "Enter your feedback"
+    "defaultMessage": "Enter your feedback: Do not include any personal information or other sensitive information.",
+    "description": "Enter your feedback: Do not include any personal information or other sensitive information."
   },
   "feedback": {
     "defaultMessage": "Feedback",

--- a/src/locales/Messages.ts
+++ b/src/locales/Messages.ts
@@ -94,8 +94,8 @@ export default defineMessages({
   },
   enterFeedback: {
     id: 'enterFeedback',
-    description: 'Enter your feedback',
-    defaultMessage: 'Enter your feedback',
+    description: 'Enter your feedback: Do not include any personal information or other sensitive information.',
+    defaultMessage: 'Enter your feedback: Do not include any personal information or other sensitive information.',
   },
   researchOpportunities: {
     id: 'researchOpportunities',

--- a/src/locales/data.json
+++ b/src/locales/data.json
@@ -22,7 +22,7 @@
     "describeReportBug": "Describe the bug you encountered. Include where it is located and what action caused it. If this issue is urgent or blocking your workflow,",
     "directInfluence": ", your feedback will directly influence the future of Red Hat’s products. Opt in below to hear about future research opportunities via email.",
     "email": "Email",
-    "enterFeedback": "Enter your feedback",
+    "enterFeedback": "Enter your feedback: Do not include any personal information or other sensitive information.",
     "feedback": "Feedback",
     "feedbackSent": "Feedback Sent",
     "filterByTags": "Filter by tags",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -21,7 +21,7 @@
   "describeReportBug": "Describe the bug you encountered. Include where it is located and what action caused it. If this issue is urgent or blocking your workflow,",
   "directInfluence": ", your feedback will directly influence the future of Red Hat’s products. Opt in below to hear about future research opportunities via email.",
   "email": "Email",
-  "enterFeedback": "Enter your feedback",
+  "enterFeedback": "Enter your feedback: Do not include any personal information or other sensitive information.",
   "feedback": "Feedback",
   "feedbackSent": "Feedback Sent",
   "filterByTags": "Filter by tags",


### PR DESCRIPTION
## Summary by Sourcery

Update feedback modal prompt to warn users against including personal or sensitive information, and sync the change across the locale template and translation files.

Enhancements:
- Clarify feedback modal prompt with a warning not to include personal or sensitive information.

Chores:
- Update translation-template.json, data.json, and translations.json to reflect the revised feedback prompt text.

<img width="1161" alt="Screenshot 2025-05-14 at 2 45 14 PM" src="https://github.com/user-attachments/assets/af060241-c8c8-4db4-9c04-fd5db16ea88c" />
