### PR TITLE
update caddy-ubi base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:0d6954b
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:3ce2c4c
 
 ENV CADDY_TLS_MODE http_port 8000
 


### PR DESCRIPTION
Updating to latest caddy-ubi to resolve CVE's

## Summary by Sourcery

Update the Caddy UBI base image to version 3ce2c4c in the Dockerfile to address security vulnerabilities.

Bug Fixes:
- Resolve CVEs by updating to the latest Caddy UBI image.

Build:
- Bump Caddy UBI base image in Dockerfile to tag 3ce2c4c.