### PR TITLE
Fix Quickstart wizard steps height issue

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -155,6 +155,11 @@ aside {
     }
   }
 
+// https://github.com/patternfly/patternfly-quickstarts/issues/392
+.pfext-quick-start-task .pf-v6-c-wizard {
+  height: initial;
+}
+
 // remove float from restart button so it's not obscured by pendo or the va badge
 .pfext-quick-start-footer__restartbtn {
   float: none;


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-39148
https://github.com/patternfly/patternfly-quickstarts/issues/392

Before
![Screenshot 2025-05-16 at 9 04 22 AM](https://github.com/user-attachments/assets/e02b1c24-670a-4fb9-9fd8-3019d1ae7d75)

After
![Screenshot 2025-05-16 at 9 04 39 AM](https://github.com/user-attachments/assets/aa734586-884c-410c-8b8f-6d88f960580a)

## Summary by Sourcery

Bug Fixes:
- Reset the quickstart wizard height to `initial` to fix steps height clipping