### PR TITLE
Fix link to All learning resources

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -184,7 +184,7 @@ const Tools = () => {
       ? [
           {
             title: intl.formatMessage(messages.globalLearningResourcesPage),
-            onClick: () => window.open('/learning-resources', '_blank'),
+            onClick: () => window.open('/learning-resources', '_self'),
           },
         ]
       : []),

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -193,7 +193,10 @@ const Tools = () => {
       ? [
           {
             title: intl.formatMessage(messages.globalLearningResourcesPage),
-            onClick: () => window.open('/learning-resources', '_self'),
+            url: '/learning-resources',
+            isHidden: false,
+            appId: 'learningResources',
+            target: '_self',
           },
         ]
       : []),


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-38232

## Summary by Sourcery

Bug Fixes:
- Change window.open target from '_blank' to '_self' for the global Learning Resources link