### PR TITLE
Fix wrapping issue in 'All services' bundle header

### DIFF
--- a/src/components/AllServices/AllServicesBundle.tsx
+++ b/src/components/AllServices/AllServicesBundle.tsx
@@ -60,13 +60,11 @@ const AllServicesBundle = ({ id, title, description, navItems }: AllServicesBund
         <Split hasGutter>
           <SplitItem> {bundleIcon} </SplitItem>
           <SplitItem className="pf-v6-u-pt-xs" isFilled>
-            <Content component={ContentVariants.h4} className="pf-v6-u-mb-xs">
-              {title}
-            </Content>
+            <Content component={ContentVariants.h4}>{title}</Content>
             <Content component={ContentVariants.small}>
               {itemOverview ? (
                 <ChromeLink
-                  className="chr-c-favorite-service__tile"
+                  className="chr-c-favorite-service__tile pf-v6-u-display-inline"
                   href={itemOverview.href ? itemOverview.href : ''}
                   data-ouia-component-id={`${title}`}
                 >
@@ -74,7 +72,7 @@ const AllServicesBundle = ({ id, title, description, navItems }: AllServicesBund
                 </ChromeLink>
               ) : itemDashboard ? (
                 <ChromeLink
-                  className="chr-c-favorite-service__tile"
+                  className="chr-c-favorite-service__tile pf-v6-u-display-inline"
                   href={itemDashboard.href ? itemDashboard.href : ''}
                   data-ouia-component-id={`${title}`}
                 >
@@ -85,7 +83,7 @@ const AllServicesBundle = ({ id, title, description, navItems }: AllServicesBund
 
               {itemLearningResources ? (
                 <ChromeLink
-                  className="chr-c-favorite-service__tile"
+                  className="chr-c-favorite-service__tile pf-v6-u-display-inline"
                   href={itemLearningResources.href ? itemLearningResources.href : ''}
                   data-ouia-component-id={`${title}`}
                 >


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-40184

Old
![Screenshot 2025-05-21 at 10 20 28 AM](https://github.com/user-attachments/assets/1bae1895-ea53-4da6-891f-c5a3dce6c033)

New
![Screenshot 2025-05-21 at 10 19 09 AM](https://github.com/user-attachments/assets/8f56fbd4-48fd-4714-a3a8-a0a0191faa69)

## Summary by Sourcery

Fix wrapping issues in the 'All services' bundle header by adjusting spacing utilities and enforcing inline display for link tiles

Bug Fixes:
- Remove bottom margin on the h4 header to prevent unintended line breaks
- Add pf-v6-u-display-inline class to service tiles to keep links on the same line