### PR TITLE
Return back api.console scope

### DIFF
--- a/src/auth/OIDCConnector/utils.ts
+++ b/src/auth/OIDCConnector/utils.ts
@@ -64,7 +64,7 @@ export function login(auth: AuthContextProps, requiredScopes: string[] = [], red
   // Redirect to login
   Cookies.set('cs_loggedOut', 'false');
   //FIX ME: Temp fix until scope is added in-boundary
-  let scope = ITLess() ? ['openid', ...requiredScopes] : ['openid', ...requiredScopes];
+  let scope = ITLess() ? ['openid', ...requiredScopes] : ['openid', 'api.console', ...requiredScopes];
   const partner = getPartnerScope(window.location.pathname);
   if (partner) {
     scope.push(partner);


### PR DESCRIPTION
Reference tickets: RHCLOUD-29135, ROX-29455
Returning the scope back, since ACS is ready to consume both `sub` and `deprecated_sub` claims.