### PR TITLE
Add POC for e2e stage testing

### DIFF
--- a/.tekton/stage-access-poc.yml
+++ b/.tekton/stage-access-poc.yml
@@ -1,0 +1,80 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run-tests
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: E2E_URL
+      type: string
+    - name: E2E_USER
+      type: string
+    - name: E2E_PASSWORD
+      type: string
+  steps:
+    - name: clone-repository-oci-ta
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta@sha256:0f4360ce144d46171ebd2e8f4d4575539a0600e02208ba5fc9beeb2c27ddfd4c
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: run-tests
+      runAfter:
+        - clone-repository-oci-ta
+      taskSpec:
+        metadata: {}
+        params:
+        - description: The Trusted Artifact URI pointing to the artifact with the
+            application source code.
+          name: SOURCE_ARTIFACT
+          type: string
+        spec: null
+        stepTemplate:
+          computeResources: {}
+          volumeMounts:
+          - mountPath: /var/workdir
+            name: workdir
+        steps:
+        - args:
+          - use
+          - $(params.SOURCE_ARTIFACT)=/var/workdir
+          computeResources: {}
+          image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+          name: use-trusted-artifact
+        - computeResources: {}
+          image: "quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566"
+          env:
+            - name: E2E_URL
+              value: $(params.E2E_URL)
+            - name: E2E_USER
+              value: $(params.E2E_USER)
+            - name: E2E_PASSWORD
+              value: $(params.E2E_PASSWORD)
+          script: |
+            #!/bin/bash
+            set -ex
+
+            npm i
+            E2E_BASE=$E2E_URL E2E_USER=$E2E_USER E2E_PASSWORD=$E2E_PASSWORD npm run test:e2e


### PR DESCRIPTION
just messing around with squid proxy to see if we can access stage from Konflux clusters (should work)

## Summary by Sourcery

Add a proof-of-concept Tekton Task to enable end-to-end testing against the stage environment from Konflux clusters via CI.

CI:
- Introduce .tekton/stage-access-poc.yml defining a run-tests Task with parameters for source repo, revision, stage URL, and credentials.

Tests:
- Add pipeline steps to clone the repository using an OCI-based git-clone Task and execute Cypress E2E tests with npm install and test:e2e using injected E2E_URL, E2E_USER, and E2E_PASSWORD.