### PR TITLE
fx(ws): enable workspaces label in settings navigation based on feature flag

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -75,6 +75,7 @@ const Tools = () => {
   const togglePreviewWithCheck = useSetAtom(togglePreviewWithCheckAtom);
   const enableIntegrations = useFlag('platform.sources.integrations');
   const workspacesEnabled = useFlag('platform.rbac.workspaces');
+  const workspacesListEnabled = useFlag('platform.rbac.workspaces-list');
   const enableGlobalLearningResourcesPage = useFlag('platform.learning-resources.global-learning-resources');
   const isITLessEnv = useFlag('platform.chrome.itless');
   const { user, token } = useContext(ChromeAuthContext);
@@ -121,7 +122,7 @@ const Tools = () => {
           url: identityAndAccessManagmentPath,
           title: isOrgAdmin ? (workspacesEnabled ? 'Acess management' : 'User Access') : 'My User Access',
           description:
-            isOrgAdmin && workspacesEnabled ? (
+            workspacesEnabled || workspacesListEnabled ? (
               <Label status="custom" color="teal" variant="outline" icon={<UsersIcon />} isCompact>
                 Workspaces model available
               </Label>


### PR DESCRIPTION
### Description

The workspaces label can be shown to anybody who has either `platform.rbac.workspaces` or `platform.rbac.workspaces-list`. We could also show it based on the permissions, but that would be too complex, I'd like to see user's reaction and integration on it and we can add the permissions check later on.

## Summary by Sourcery

Enable the Workspaces label in settings navigation when either the existing workspaces flag or a new workspaces-list feature flag is active.

Enhancements:
- Introduce a new feature flag (platform.rbac.workspaces-list) in the header tools component
- Update the condition to display the Workspaces label when either workspaces or workspaces-list feature flags are enabled