### PR TITLE
[Draft] Stage access POC task

### DIFF
--- a/.tekton/stage-access-poc.yml
+++ b/.tekton/stage-access-poc.yml
@@ -15,6 +15,23 @@ spec:
     - name: E2E_PASSWORD
       type: string
   steps:
+    - name: init
+      params:
+      - name: image-url
+        value: $(params.output-image)
+      - name: rebuild
+        value: $(params.rebuild)
+      - name: skip-checks
+        value: $(params.skip-checks)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+        - name: kind
+          value: task
+        resolver: bundles
     - name: clone-repository-oci-ta
       params:
       - name: url
@@ -22,7 +39,7 @@ spec:
       - name: revision
         value: $(params.revision)
       runAfter:
-      - init
+        - init
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
## Summary by Sourcery

Add an initialization step to the Stage Access POC pipeline to bootstrap the image build process before cloning the repository.

New Features:
- Add an 'init' step to the stage POC integration test pipeline to run the Tekton init task with image-url, rebuild, and skip-checks parameters before subsequent steps.

Enhancements:
- Make the clone-repository-oci-ta step explicitly run after the new init step.