### PR TITLE
fix(all-services): fix all services redesign filter

### DIFF
--- a/src/layouts/AllServices.tsx
+++ b/src/layouts/AllServices.tsx
@@ -23,6 +23,12 @@ import AllServicesBundle from '../components/AllServices/AllServicesBundle';
 import { BundleNavigation } from '../@types/types';
 import filterNavItemsByTitle from '../utils/filterNavItemsByTitle';
 import { fetchBundles } from '../hooks/useAllLinks';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { EmptyState } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateActions } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateFooter } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 const availableBundles = ['openshift', 'insights', 'ansible', 'settings', 'iam', 'subscriptions'];
 
@@ -135,9 +141,27 @@ const AllServices = ({ Footer }: AllServicesProps) => {
                 {enableAllServicesRedesign
                   ? bundles.map((bundle) => <AllServicesBundle key={bundle.id} {...bundle} />)
                   : sections.map((section, index) => <AllServicesSection key={index} {...section} />)}
-                {/* TODO: Add empty state */}
-                {sections.length === 0 && filterValue.length !== 0 && <div>Nothing found</div>}
               </Gallery>
+              {(sections.length === 0 || (enableAllServicesRedesign && bundles.length === 0)) && filterValue.length !== 0 && (
+                <Bullseye>
+                  <EmptyState titleText="No results found" headingLevel="h4" icon={SearchIcon}>
+                    <EmptyStateBody>No results match the filter criteria. Clear all filters and try again.</EmptyStateBody>
+                    <EmptyStateFooter>
+                      <EmptyStateActions>
+                        <Button
+                          variant="link"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setFilterValue('');
+                          }}
+                        >
+                          Clear all filters
+                        </Button>
+                      </EmptyStateActions>
+                    </EmptyStateFooter>
+                  </EmptyState>
+                </Bullseye>
+              )}
             </PageSection>
           </Fragment>
         )}

--- a/src/utils/filterNavItemsByTitle.ts
+++ b/src/utils/filterNavItemsByTitle.ts
@@ -6,11 +6,16 @@ const filterNavItemsByTitle = (items: NavItem[], search: string): NavItem[] => {
 
   return items
     .map((item) => {
-      const filteredRoutes = item.routes ? filterNavItemsByTitle(item.routes, search) : [];
-      const filteredNavItems = item.navItems ? filterNavItemsByTitle(item.navItems, search) : [];
       const matches = item.title?.toLowerCase().includes(lowerSearch);
 
-      if (matches || filteredRoutes.length > 0 || filteredNavItems.length > 0) {
+      if (matches) {
+        return item;
+      }
+
+      const filteredRoutes = item.routes ? filterNavItemsByTitle(item.routes, search) : [];
+      const filteredNavItems = item.navItems ? filterNavItemsByTitle(item.navItems, search) : [];
+
+      if (filteredRoutes.length > 0 || filteredNavItems.length > 0) {
         return {
           ...item,
           routes: filteredRoutes.length > 0 ? filteredRoutes : undefined,


### PR DESCRIPTION
### Description

Currently filtering by bundle name breaks the filtered item, this PR fixes it by sending whole subtree if it matches title. Also add empty state when no items are found

### Before

![Screenshot 2025-05-29 at 10 12 01](https://github.com/user-attachments/assets/e2a3ce4f-2995-4274-bbcd-b35251ad51ec)


### After

![Screenshot 2025-05-29 at 10 12 16](https://github.com/user-attachments/assets/03c1d40b-4be3-481d-a0da-e76aac6da60e)

### JIRA

[RHCLOUD-40295](https://issues.redhat.com/browse/RHCLOUD-40295)

## Summary by Sourcery

Fix filtering in All Services redesign to return full matching subtrees and show an empty state when no items match the filter.

Bug Fixes:
- Return the entire item subtree when its title matches the filter in filterNavItemsByTitle, preventing broken navigation items.

Enhancements:
- Display a PatternFly empty state with a clear filters button when no services match the search in both redesign and legacy layouts.