### PR TITLE
fix: add back org ID ouia component id post PF6 migration

### DIFF
--- a/src/components/Header/UserToggle.tsx
+++ b/src/components/Header/UserToggle.tsx
@@ -79,7 +79,7 @@ const DropdownItems = ({
               </Tooltip>
             )}
             {orgId && (
-              <DescriptionListGroup>
+              <DescriptionListGroup data-ouia-component-id="chrome-user-org-id">
                 <DescriptionListTerm>{intl.formatMessage(messages.orgId)}</DescriptionListTerm>
                 <DescriptionListDescription>{orgId}</DescriptionListDescription>
               </DescriptionListGroup>


### PR DESCRIPTION
This tag was removed as part of the PF6 migration in chrome - however this is breaking our IQE tests. This PR adds it back (also requires a change to the platform UI plugin itself).

See [RHCLOUD-39713](https://issues.redhat.com/browse/RHCLOUD-39713)

## Summary by Sourcery

Bug Fixes:
- Restore the data-ouia-component-id attribute on the organization ID DescriptionListGroup