### PR TITLE
fix: disabled dpal.js loading

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -21,7 +21,9 @@
             }
         }
     </script>
-    <script id="dpal" src="https://www.redhat.com/ma/dpal.js" type="text/javascript"></script>
+    <!-- The analytics bundle seems to be mangled, until it is fixed, it should be disabled. It is not sending any data -->
+    <!-- https://issues.redhat.com/browse/RHCLOUD-37951 -->
+    <!-- <script id="dpal" src="https://www.redhat.com/ma/dpal.js" type="text/javascript"></script> -->
 </head>
 
 <body class="pf-m-redhat-font">


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-38180

Until the issues with client initialization are fixed, the script will be disabled. More details are in the linked issue.
