### PR TITLE
Revert "Add service icons to services dropdown"

### DIFF
--- a/src/components/AllServicesDropdown/AllServicesTabs.tsx
+++ b/src/components/AllServicesDropdown/AllServicesTabs.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { useAtomValue } from 'jotai';
 import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider';
 import { Icon } from '@patternfly/react-core/dist/dynamic/components/Icon';
-import { Tab, TabProps, TabTitleIcon, TabTitleText, Tabs, TabsProps } from '@patternfly/react-core/dist/dynamic/components/Tabs';
+import { Tab, TabProps, TabTitleText, Tabs, TabsProps } from '@patternfly/react-core/dist/dynamic/components/Tabs';
 
 import AngleRightIcon from '@patternfly/react-icons/dist/dynamic/icons/angle-right-icon';
 import StarIcon from '@patternfly/react-icons/dist/dynamic/icons/star-icon';
@@ -14,7 +14,6 @@ import ChromeLink from '../ChromeLink';
 import './AllServicesTabs.scss';
 import PlatformServiceslinks from './PlatformServicesLinks';
 import { isPreviewAtom } from '../../state/atoms/releaseAtom';
-import ServiceIcon from '../FavoriteServices/ServiceIcon';
 
 export type AllServicesTabsProps = {
   activeTabKey: string | number;
@@ -110,10 +109,10 @@ const AllServicesTabs = ({
           eventKey={FAVORITE_TAB_ID}
           title={
             <TabTitleText className="pf-v6-u-text-color-regular">
-              <TabTitleIcon>
-                <StarIcon />
-              </TabTitleIcon>{' '}
               My Favorite services
+              <Icon className="chr-c-icon-service-tab pf-v6-u-ml-sm" status="warning" isInline>
+                <StarIcon />
+              </Icon>
               <Icon className="pf-v6-u-float-inline-end pf-v6-u-mt-xs">
                 <AngleRightIcon />
               </Icon>
@@ -129,9 +128,6 @@ const AllServicesTabs = ({
             eventKey={index}
             title={
               <TabTitleText>
-                <TabTitleIcon>
-                  <ServiceIcon icon={section.icon} />
-                </TabTitleIcon>{' '}
                 {section.title}
                 <Icon className="pf-v6-u-float-inline-end pf-v6-u-mt-xs">
                   <AngleRightIcon />


### PR DESCRIPTION
Reverts RedHatInsights/insights-chrome#3048

## Summary by Sourcery

Bug Fixes:
- Revert accidental addition of service icons in services dropdown tabs