### PR TITLE
remove category icons from right side of services dropdown

### DIFF
--- a/src/components/AllServicesDropdown/AllServicesMenu.tsx
+++ b/src/components/AllServicesDropdown/AllServicesMenu.tsx
@@ -19,7 +19,6 @@ import AllServicesGallery from './AllServicesGallery';
 import { ServiceTileProps } from '../FavoriteServices/ServiceTile';
 import { AllServicesDropdownContext } from './common';
 import { hidePreviewBannerAtom } from '../../state/atoms/releaseAtom';
-import ServiceIcon from '../FavoriteServices/ServiceIcon';
 import TimesIcon from '@patternfly/react-icons/dist/dynamic/icons/times-icon';
 
 export type AllServicesMenuProps = {
@@ -124,9 +123,7 @@ const AllServicesMenu = ({ setIsOpen, isOpen, menuRef, linkSections, favoritedSe
                             <StarIcon /> My Favorite services
                           </>
                         ) : (
-                          <>
-                            <ServiceIcon icon={selectedService.icon} /> {selectedService.title}
-                          </>
+                          <>{selectedService.title}</>
                         )}
                       </Title>
                     </CardHeader>


### PR DESCRIPTION
Old
![Screenshot 2025-06-03 at 12 32 18 PM](https://github.com/user-attachments/assets/3679f8e7-e94a-44c1-8c81-baeba28b8dce)

New
![Screenshot 2025-06-03 at 12 25 59 PM](https://github.com/user-attachments/assets/6dd9ef45-be51-4490-a5ca-eefce67c5934)

## Summary by Sourcery

Enhancements:
- Delete ServiceIcon import and usage in the AllServicesMenu header to stop rendering the icon adjacent to the selected service title