### PR TITLE
Gate DPAL script with feature flag.

### DIFF
--- a/src/analytics/useDpal.ts
+++ b/src/analytics/useDpal.ts
@@ -1,0 +1,32 @@
+import { useFlag } from '@unleash/proxy-client-react';
+import { useEffect, useRef } from 'react';
+
+function useDPAL() {
+  const dpalAdded = useRef(false);
+  const enableDPAL = useFlag('platform.chrome.analytics.dpal');
+  function addDpalScript() {
+    // setup adobe analytics
+    if (!enableDPAL || dpalAdded.current) {
+      return;
+    }
+    // ADD FF to enable adobe analytics
+    const dpalScript = document.createElement('script');
+    dpalScript.src = 'https://www.redhat.com/ma/dpal.js';
+    dpalScript.type = 'text/javascript';
+    dpalScript.id = 'dpal-script';
+    dpalScript.onload = () => {
+      if (typeof window._satellite !== 'undefined' && typeof window._satellite.pageBottom === 'function') {
+        window._satellite.pageBottom();
+        dpalAdded.current = true;
+      }
+    };
+    if (!document.getElementById('dpal-script')) {
+      document.body.appendChild(dpalScript);
+    }
+  }
+  useEffect(() => {
+    addDpalScript();
+  }, [enableDPAL]);
+}
+
+export default useDPAL;

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -6,7 +6,7 @@ import { Provider as JotaiProvider } from 'jotai';
 
 import { spinUpStore } from './redux/redux-config';
 import RootApp from './components/RootApp';
-import { ITLess, getEnv, trustarcScriptSetup } from './utils/common';
+import { getEnv, trustarcScriptSetup } from './utils/common';
 import OIDCProvider from './auth/OIDCConnector/OIDCProvider';
 import messages from './locales/data.json';
 import ErrorBoundary from './components/ErrorComponents/ErrorBoundary';
@@ -16,7 +16,6 @@ import AppPlaceholder from './components/AppPlaceholder';
 import useSessionConfig from './hooks/useSessionConfig';
 import GatewayErrorComponent from './components/ErrorComponents/GatewayErrorComponent';
 
-const isITLessEnv = ITLess();
 const language: keyof typeof messages = 'en';
 const AuthProvider = OIDCProvider;
 
@@ -27,10 +26,6 @@ const useInitializeAnalytics = () => {
   useEffect(() => {
     // setup trust arc
     trustarcScriptSetup();
-    // setup adobe analytics
-    if (!isITLessEnv && typeof window._satellite !== 'undefined' && typeof window._satellite.pageBottom === 'function') {
-      window._satellite.pageBottom();
-    }
   }, []);
 };
 

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -38,6 +38,7 @@ import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 import { ScalprumConfig } from '../../state/atoms/scalprumConfigAtom';
 import transformScalprumManifest from './transformScalprumManifest';
 import { segmentPageOptionsAtom } from '../../state/atoms/segmentPageOptionsAtom';
+import useDPAL from '../../analytics/useDpal';
 
 const ProductSelection = lazy(() => import('../Stratosphere/ProductSelection'));
 
@@ -123,6 +124,8 @@ const ChromeApiRoot = ({ config, helpTopicsAPI, quickstartsAPI }: ChromeApiRootP
   useHandlePendoScopeUpdate(chromeAuth.user, activeModule);
   // setting default tab title
   useTabName();
+  // initialize adobe analytics
+  useDPAL();
 
   useEffect(() => {
     // prepare webpack module sharing scope overrides

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -21,9 +21,6 @@
             }
         }
     </script>
-    <!-- The analytics bundle seems to be mangled, until it is fixed, it should be disabled. It is not sending any data -->
-    <!-- https://issues.redhat.com/browse/RHCLOUD-37951 -->
-    <!-- <script id="dpal" src="https://www.redhat.com/ma/dpal.js" type="text/javascript"></script> -->
 </head>
 
 <body class="pf-m-redhat-font">


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-40453

Brings back the DPAL script. The script can be toggled with a feature flag in case there are additional issues i the future.

## Summary by Sourcery

Gate the Adobe DPAL analytics script behind an Unleash feature flag using a new useDPAL hook and remove legacy analytics injection.

Enhancements:
- Introduce a useDPAL hook to load the DPAL script only when the 'platform.chrome.analytics.dpal' feature flag is enabled
- Replace the old environment-based Adobe analytics setup in ScalprumRoot and bootstrap with the useDPAL hook
- Remove the legacy ITLess environment check and commented DPAL script entry from index.ejs