### PR TITLE
Update chr-render and chr-scope css classes

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -94,23 +94,31 @@ aside {
 @media screen and (min-width : $pf-v6-global--breakpoint--2xl) {
   .chr-scope__default-layout {
     // we do not have PF variables for the header height unfortunately
-    min-height: calc(100vh - 152px /** the size of the masthead on extra large screens */);
+    min-height: calc(100vh - 172px /** the size of the masthead on double extra large screens */);
   }
 }
 
 
-@media screen and (min-width : $pf-v6-global--breakpoint--xl) and (max-width : $pf-v6-global--breakpoint--2xl)  {
+@media screen and (min-width : $pf-v6-global--breakpoint--md) and (max-width : $pf-v6-global--breakpoint--2xl)  {
   .chr-scope__default-layout {
-    min-height: calc(100vh - 118px /** the size of the masthead on large screens */);
+    min-height: calc(100vh - 226px /** the size of the masthead on extra large screens */);
   };
 }
 
 @media only screen and (max-width: $pf-v6-global--breakpoint--md) {
   .ins-m-hide-on-md {display: none;}
+
+  .chr-scope__default-layout {
+    min-height: calc(100vh - 226px /** the size of the masthead on medium screens */);
+  };
 }
 
 @media only screen and (max-width: $pf-v6-global--breakpoint--sm) {
   .ins-m-hide-on-sm {display: none;}
+
+  .chr-scope__default-layout {
+    min-height: calc(100vh - 226px /** the size of the masthead on small screens */);
+  };
 
   .ins-c-table-empty-state.pf-m-grid-md.pf-v6-c-table,
   .ins-c-table-empty-state.pf-m-grid-lg.pf-v6-c-table {


### PR DESCRIPTION
The height of .chr-scope__default-layout (which is a parent container for Insights apps) is hardcoded as 100vh minus the height of the masthead. The masthead heights are incorrect (something must have changed) and this causes a scrollbar to appear in Insights apps, even when the content should not overflow/have a scrollbar. This commit updates the height for all viewport sizes.

Additionally, the Patternfly wizard is not rendering properly due to the default overflow setting of the .chr-render class. As per both Insights UX and the Patternfly documentation, the fotter of an in-page wizard should be fixed at the bottom of the screen. To accomplish this, `overflow: auto` must be set for .chr-render.

## Summary by Sourcery

Adjust layout and rendering styles in chrome CSS to fix erroneous scrollbars and support in-page wizard footers

Enhancements:
- Update .chr-scope__default-layout min-height calculations across breakpoints to reflect current masthead heights
- Enable overflow:auto on .chr-render to allow fixed wizard footers to render correctly