### PR TITLE
Fix 'All services' Safari glitch

### DIFF
--- a/src/layouts/AllServices.scss
+++ b/src/layouts/AllServices.scss
@@ -19,8 +19,12 @@
     column-width: 430px;
   }
   .pf-v6-c-card {
-    overflow: hidden;
-    break-inside: avoid-column;
+    break-inside: avoid;
+    // addresses Safari 'break-inside' glitch
+    @supports (-webkit-hyphens: none) {
+     display: inline-block;
+    }
+    width: 100%;
     &__body {
       padding-bottom: 0;
     }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-40582

Old
![Screenshot 2025-06-12 at 11 54 58 AM](https://github.com/user-attachments/assets/ee5f590d-31f6-483d-8195-60f95cd8b80e)

New
![Screenshot 2025-06-12 at 11 53 17 AM](https://github.com/user-attachments/assets/6f3ccd66-0557-4279-ba98-67827077ad8c)

## Summary by Sourcery

Bug Fixes:
- Fix Safari column break glitch in the All Services card layout by updating CSS break-inside rules and applying a WebKit-specific fallback