### PR TITLE
help panel menu

### DIFF
--- a/cypress/component/DefaultLayout.cy.js
+++ b/cypress/component/DefaultLayout.cy.js
@@ -11,6 +11,7 @@ import { FeatureFlagsProvider } from '../../src/components/FeatureFlags';
 import Footer from '../../src/components/Footer/Footer';
 import ChromeAuthContext from '../../src/auth/ChromeAuthContext';
 import chromeStore from '../../src/state/chromeStore';
+import InternalChromeContext from '../../src/utils/internalChromeContext';
 
 const testUser = {
   identity: {
@@ -49,16 +50,26 @@ const chromeAuthContextValue = {
   user: testUser,
 };
 
+const mockInternalChromeContext = {
+  drawerActions: {
+    toggleDrawerContent: () => {
+      console.log('mock: toggleDrawerContent called');
+    },
+  },
+};
+
 const Wrapper = ({ children }) => (
   <IntlProvider locale="en">
     <ChromeAuthContext.Provider value={chromeAuthContextValue}>
-      <ScalprumProvider config={{}}>
-        <JotaiProvider store={chromeStore}>
-          <FeatureFlagsProvider>
-            <BrowserRouter>{children}</BrowserRouter>
-          </FeatureFlagsProvider>
-        </JotaiProvider>
-      </ScalprumProvider>
+      <InternalChromeContext.Provider value={mockInternalChromeContext}>
+        <ScalprumProvider config={{}}>
+          <JotaiProvider store={chromeStore}>
+            <FeatureFlagsProvider>
+              <BrowserRouter>{children}</BrowserRouter>
+            </FeatureFlagsProvider>
+          </JotaiProvider>
+        </ScalprumProvider>
+      </InternalChromeContext.Provider>
     </ChromeAuthContext.Provider>
   </IntlProvider>
 );

--- a/src/components/Header/HeaderTests/Tools.test.js
+++ b/src/components/Header/HeaderTests/Tools.test.js
@@ -4,6 +4,7 @@ import { ScalprumProvider } from '@scalprum/react-core';
 import { act, render } from '@testing-library/react';
 import { Provider as JotaiProvider } from 'jotai';
 import { MemoryRouter } from 'react-router-dom';
+import InternalChromeContext from '../../../utils/internalChromeContext';
 
 jest.mock('../UserToggle', () => () => '<UserToggle />');
 jest.mock('../ToolbarToggle', () => () => '<ToolbarToggle />');
@@ -26,6 +27,12 @@ jest.mock('@unleash/proxy-client-react', () => {
   };
 });
 
+const mockInternalChromeContext = {
+  drawerActions: {
+    toggleDrawerContent: jest.fn(),
+  },
+};
+
 beforeAll(() => {
   global.__webpack_init_sharing__ = () => undefined;
   global.__webpack_share_scopes__ = { default: {} };
@@ -47,7 +54,9 @@ describe('Tools', () => {
         <MemoryRouter>
           <ScalprumProvider config={{ notifications: { manifestLocation: '/apps/notifications/fed-mods.json' } }}>
             <JotaiProvider>
-              <Tools onClick={mockClick} />
+              <InternalChromeContext.Provider value={mockInternalChromeContext}>
+                <Tools onClick={mockClick} />
+              </InternalChromeContext.Provider>
             </JotaiProvider>
           </ScalprumProvider>
         </MemoryRouter>

--- a/src/locales/Messages.ts
+++ b/src/locales/Messages.ts
@@ -77,6 +77,11 @@ export default defineMessages({
     description: 'Status page',
     defaultMessage: 'Status page',
   },
+  helpPanel: {
+    id: 'helpPanel',
+    description: 'Help panel',
+    defaultMessage: 'Help panel',
+  },
   knownOutages: {
     id: 'knownOutages',
     description: 'for known outages.',


### PR DESCRIPTION
help panel menu

https://issues.redhat.com/browse/RHCLOUD-40373


https://github.com/user-attachments/assets/0077bc28-f17f-4c24-a95f-83b9b8448fc8



## Summary by Sourcery

Introduce a Help panel menu item in the header Tools menu behind a feature flag

New Features:
- Add a feature-flagged "Help panel" entry in the about menu

Enhancements:
- Implement toggleHelpPanel to open or close the help panel via chromeStore
- Refactor aboutMenuDropdownItems to conditionally include help panel, status page, and support options when the flag is enabled

Chores:
- Add i18n message for the Help panel label

## Summary by Sourcery

Add a feature-flagged Help panel entry to the header Tools menu and refactor dropdown item logic to support it

New Features:
- Add a feature-flagged “Help panel” entry in the Tools about menu to open the help panel via chrome drawer

Enhancements:
- Implement toggleDrawerContent from useChrome to open and close the help panel
- Refactor aboutMenuDropdownItems to conditionally render help panel or existing menu entries based on the feature flag
- Simplify DropdownItem rendering logic for onClick and url actions

Chores:
- Add i18n message for the Help panel label