### PR TITLE
Fix tag filter padding being overriden by PF

### DIFF
--- a/src/components/GlobalFilter/global-filter-menu.scss
+++ b/src/components/GlobalFilter/global-filter-menu.scss
@@ -1,5 +1,5 @@
 .chr-c-global-filter {
-  padding: var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--lg);
+  padding: var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--lg) !important;
   background: var(--pf-t--global--background--color--100);
   .pf-v6-c-label-group { margin-right: var(--pf-t--global--spacer--xs); }
   .chr-c-chip { background: var(--pf-t--global--border--color--nonstatus--blue--default); }


### PR DESCRIPTION
Importing PF6 Split into an app would cause
```css
.pf-v6-l-split {
    padding: 0;
    ...
}
```
to be applied overriding `.chr-c-global-filter` and causing tag filter to have no padding.

## Before PR
![Screenshot From 2025-06-23 15-15-53](https://github.com/user-attachments/assets/b4448d72-1f67-4985-b0da-6095d9296bec)

## After PR
![Screenshot From 2025-06-23 15-15-46](https://github.com/user-attachments/assets/d2814134-a9e8-4001-89f0-69de66d4e61e)

## Summary by Sourcery

Override PF6 Split’s zero-padding rule on the global filter to restore intended spacing.

Bug Fixes:
- Restore padding on the global filter when PF6 Split is imported.

Enhancements:
- Enforce .chr-c-global-filter padding using !important to override PF defaults.