### PR TITLE
Fix SSO login breakage in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ cypress/downloads
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+.hypothesis

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -55,7 +55,7 @@ Cypress.Commands.add('login', () => {
 
       cy.get('body').then((body) => {
         // Ephemeral login is different
-        if (body.find('#username').length > 0) {
+        if (body.find('#username :visible').length > 0) {
           // If the username field is present, it means we are on the SSO login page
           cy.get('#username').type(Cypress.env('E2E_USER'));
           cy.get('#password').type(Cypress.env('E2E_PASSWORD'));


### PR DESCRIPTION
Update the locator for the username to work.

## Summary by ~Sourcery~ Tweed

Fix SSO login breakage in Cypress tests by updating the username locator.

Bug Fixes:
- Fix SSO login detection in Cypress tests by checking for a visible username field.
