### PR TITLE
Fix GLOBAL_FILTER_UPDATE event to dispatch on mount

### DIFF
--- a/src/chrome/create-chrome.test.ts
+++ b/src/chrome/create-chrome.test.ts
@@ -148,4 +148,16 @@ describe('create chrome', () => {
     await getUserPermissions(promiseSpy as unknown as string);
     expect(promiseSpy).toHaveBeenCalledWith('mocked-user-permissions');
   });
+
+  it('should dispatch GLOBAL_FILTER_UPDATE event immediately when listener is added', () => {
+    const chrome = createChromeContext(chromeContextOptionsMock);
+    const mockCallback = jest.fn();
+
+    // Add a GLOBAL_FILTER_UPDATE listener
+    chrome.on('GLOBAL_FILTER_UPDATE', mockCallback);
+
+    // The callback should be called immediately with the current global filter state
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenCalledWith({ data: {} });
+  });
 });

--- a/src/chrome/create-chrome.ts
+++ b/src/chrome/create-chrome.ts
@@ -130,6 +130,14 @@ export const createChromeContext = ({
       // Add the callback to the listeners (cast to GenericCB for GLOBAL_FILTER_UPDATE)
       eventListeners.get('GLOBAL_FILTER_UPDATE')!.set(listenerId, callback as GenericCB);
 
+      // Dispatch current state to new listener immediately (on mount)
+      try {
+        const currentSelectedTags = chromeStore.get(selectedTagsAtom);
+        (callback as GenericCB)({ data: currentSelectedTags });
+      } catch (error) {
+        console.error('Error dispatching initial GLOBAL_FILTER_UPDATE state:', error);
+      }
+
       // Return unsubscribe function
       return () => {
         const listeners = eventListeners.get('GLOBAL_FILTER_UPDATE');


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-41000

Fixed the GLOBAL_FILTER_UPDATE event to dispatch on mount. Added unit test: "should dispatch GLOBAL_FILTER_UPDATE event immediately when listener is added".