### PR TITLE
Add ask RH help panel link

### DIFF
--- a/src/components/Header/ToolbarToggle.tsx
+++ b/src/components/Header/ToolbarToggle.tsx
@@ -8,6 +8,7 @@ import ChromeLink from '../ChromeLink/ChromeLink';
 import { isPreviewAtom } from '../../state/atoms/releaseAtom';
 
 export type ToolbarToggleDropdownItem = {
+  icon?: React.ReactNode;
   url?: string;
   appId?: string;
   target?: string;
@@ -57,12 +58,13 @@ const ToolbarToggle = (props: ToolbarToggleProps) => {
 
   // Render the question mark icon items
   const dropdownItems = props.dropdownItems.map(
-    ({ url, appId, title, onClick, isHidden, isDisabled, target = '_blank', rel = 'noopener noreferrer', ...rest }) =>
+    ({ icon, url, appId, title, onClick, isHidden, isDisabled, target = '_blank', rel = 'noopener noreferrer', ...rest }) =>
       !isHidden ? (
         <DropdownItem
           key={title}
           ouiaId={title}
           isDisabled={isDisabled}
+          icon={icon}
           component={
             appId && url
               ? ({ className: itemClassName }) => (

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -78,6 +78,7 @@ const Tools = () => {
   const workspacesEnabled = useFlag('platform.rbac.workspaces');
   const workspacesListEnabled = useFlag('platform.rbac.workspaces-list');
   const helpPanelEnabled = useFlag('platform.chrome.help-panel');
+  const askRedHatEnabled = useFlag('platform.chrome.ask-redhat-help');
   const enableGlobalLearningResourcesPage = useFlag('platform.learning-resources.global-learning-resources');
   const isITLessEnv = useFlag('platform.chrome.itless');
   const { user, token } = useContext(ChromeAuthContext);
@@ -187,6 +188,12 @@ const Tools = () => {
         },
       ]
     : [
+        {
+          title: intl.formatMessage(messages.askRedHat),
+          icon: <img className='pf-v6-c-button__icon' src="/apps/frontend-assets/ask-redhat/ask-redhat-icon.svg" />,
+          onClick: () => window.open('https://access.redhat.com/ask', '_blank'),
+          isHidden: askRedHatEnabled,
+        },
         {
           title: intl.formatMessage(messages.apiDocumentation),
           onClick: () => window.open('https://developers.redhat.com/api-catalog/', '_blank'),

--- a/src/locales/Messages.ts
+++ b/src/locales/Messages.ts
@@ -584,4 +584,9 @@ export default defineMessages({
     description: 'Join mailing list',
     defaultMessage: 'Join mailing list',
   },
+  askRedHat: {
+    id: 'askRedHat',
+    description: 'Ask Red Hat',
+    defaultMessage: 'Ask Red Hat',
+  },
 });


### PR DESCRIPTION
## Summary by Sourcery

Add 'Ask Red Hat' link to the header tools help panel behind a feature flag and support custom icons in toolbar dropdown items

New Features:
- Add an "Ask Red Hat" entry in the header tools panel that opens the Red Hat Ask page
- Introduce the 'platform.chrome.ask-redhat-help' feature flag to toggle the Ask Red Hat link

Enhancements:
- Extend ToolbarToggleDropdownItem to accept an icon prop and render custom icons in dropdown items

Documentation:
- Add localization message for the 'Ask Red Hat' label