### PR TITLE
RHCLOUD-41094: Update pr_check.sh

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -79,7 +79,7 @@ DEPLOY_FRONTENDS="true"
 source $CICD_ROOT/cji_smoke_test.sh
 
 
-# Stubbed out for now
+# Stubbed out forever
 mkdir -p $WORKSPACE/artifacts
 cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
 <testsuite tests="1">


### PR DESCRIPTION
An innocuous update to pr_check.sh for the sake of testing the duration of the deployment process.