### PR TITLE
POC of KFX Cypress run

### DIFF
--- a/.tekton/insights-chrome-pull-request.yaml
+++ b/.tekton/insights-chrome-pull-request.yaml
@@ -15,7 +15,6 @@ metadata:
     pipelines.appstudio.openshift.io/type: build
   name: insights-chrome-on-pull-request
   namespace: hcc-platex-services-tenant
-spec:
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -330,6 +329,68 @@ spec:
 
             npm install
             npm test
+          securityContext:
+            runAsUser: 0
+          workingDir: /var/workdir
+        volumes:
+        - emptyDir: {}
+          name: workdir
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: run-e2e-tests
+      description: Validates frontend end-to-end tests
+      params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+      runAfter:
+      - clone-repository-oci-ta
+      taskSpec:
+        metadata: {}
+        params:
+        - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+          name: SOURCE_ARTIFACT
+          type: string
+        spec:
+        stepTemplate:
+          computeResources: {}
+          volumeMounts:
+          - mountPath: /var/workdir
+            name: workdir
+        steps:
+        - args:
+          - use
+          - $(params.SOURCE_ARTIFACT)=/var/workdir
+          computeResources: {}
+          image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+          name: use-trusted-artifact
+        - computeResources: {}
+          image: quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566
+          name: e2e-tests
+          env: # Define environment variables for this step
+          - name: CHROME_ACCOUNT # The name of the environment variable inside the container
+            valueFrom:
+              secretKeyRef:
+                name: chrome-frontend-e2e-credentials # The name of your Kubernetes Secret
+                key: CHROME_ACCOUNT # The specific key within the secret to use
+          - name: CHROME_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: chrome-frontend-e2e-credentials
+                key: CHROME_PASSWORD
+          - name: CI
+            value: "true"
+
+          script: |
+            #!/bin/bash
+            set -ex
+
+            cat /etc/hosts
+
+            curl https://console.stage.redhat.com
+
+            npm install
+            npm run test:e2e
           securityContext:
             runAsUser: 0
           workingDir: /var/workdir
@@ -670,6 +731,12 @@ spec:
       optional: true
   taskRunTemplate:
     serviceAccountName: build-pipeline-insights-chrome
+    podTemplate:
+      hostAliases:
+      - ip: "127.0.0.1"
+        hostnames:
+        - "stage.foo.redhat.com"
+        - "prod.foo.redhat.com"
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/stage-access-poc.yml
+++ b/.tekton/stage-access-poc.yml
@@ -1,80 +1,69 @@
 apiVersion: tekton.dev/v1beta1
-kind: Task
+kind: Pipeline
 metadata:
-  name: run-tests
+  name: e2e-tests
 spec:
   params:
-    - name: git-url
-      value: '{{source_url}}'
+    - name: repo_url
+      description: Git repository URL
+      type: string
+      default: '{{repo_url}}'
     - name: revision
-      value: '{{revision}}'
-    - name: E2E_URL
+      description: Git revision (branch, tag, sha)
       type: string
-    - name: E2E_USER
-      type: string
-    - name: E2E_PASSWORD
-      type: string
-  steps:
-    - name: clone-repository-oci-ta
-      params:
-      - name: url
-        value: $(params.git-url)
-      - name: revision
-        value: $(params.revision)
-      runAfter:
-      - init
+      default: '{{revision}}'
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        metadata:
+          creationTimestamp:
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+  tasks:
+    - name: clone-repository
       taskRef:
-        params:
-        - name: name
-          value: git-clone-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d35e5d501cb5f5f88369511f76249857cb5ac30250e1dcf086939321964ff6b9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
+        name: git-clone-oci-ta
+        bundle: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d35e5d501cb5f5f88369511f76249857cb5ac30250e1dcf086939321964ff6b9
+      params:
+        - name: url
+          value: $(params.repo_url)
+        - name: revision
+          value: $(params.revision)
       workspaces:
-      - name: basic-auth
-        workspace: git-auth
-    - name: run-tests
+        - name: output
+          workspace: source
+    - name: run-cypress-e2e
       runAfter:
-        - clone-repository-oci-ta
+        - clone-repository
       taskSpec:
-        metadata: {}
-        params:
-        - description: The Trusted Artifact URI pointing to the artifact with the
-            application source code.
-          name: SOURCE_ARTIFACT
-          type: string
-        spec: null
-        stepTemplate:
-          computeResources: {}
-          volumeMounts:
-          - mountPath: /var/workdir
-            name: workdir
+        workspaces:
+          - name: source
         steps:
-        - args:
-          - use
-          - $(params.SOURCE_ARTIFACT)=/var/workdir
-          computeResources: {}
-          image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
-          name: use-trusted-artifact
-        - computeResources: {}
-          image: "quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566"
-          env:
-            - name: E2E_URL
-              value: $(params.E2E_URL)
-            - name: E2E_USER
-              value: $(params.E2E_USER)
-            - name: E2E_PASSWORD
-              value: $(params.E2E_PASSWORD)
-          script: |
-            #!/bin/bash
-            set -ex
-
-            npm i
-            E2E_BASE=$E2E_URL E2E_USER=$E2E_USER E2E_PASSWORD=$E2E_PASSWORD npm run test:e2e
+          - name: run-cypress-e2e
+            image: quay.io/redhat-user-workloads/rh-platform-experien-tenant/cypress-e2e-image/cypress-e2e-image:af9f17cb332f8e4a7f2e629bccbeeb1451490566
+            workingDir: /workspace/source
+            env:
+              - name: E2E_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: e2e-frontend-tests-secrets
+                    key: E2E_URL
+              - name: E2E_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: e2e-frontend-tests-secrets
+                    key: E2E_USER
+              - name: E2E_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: e2e-frontend-tests-secrets
+                    key: E2E_PASSWORD
+            script: |
+              #!/bin/bash
+              set -ex
+              npm i
+              E2E_BASE=$E2E_URL E2E_USER=$E2E_USER E2E_PASSWORD=$E2E_PASSWORD npm run test:e2e

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -54,18 +54,10 @@ Cypress.Commands.add('login', () => {
       // login into the session
 
       cy.get('body').then((body) => {
-        // Ephemeral login is different
-        if (body.find('#username').length > 0) {
-          // If the username field is present, it means we are on the SSO login page
-          cy.get('#username').type(Cypress.env('E2E_USER'));
-          cy.get('#password').type(Cypress.env('E2E_PASSWORD'));
-          cy.get('#kc-login').click();
-        } else {
-          cy.get('#username-verification').type(Cypress.env('E2E_USER'));
-          cy.get('#login-show-step2').click();
-          cy.get('#password').type(Cypress.env('E2E_PASSWORD'));
-          cy.get('#rh-password-verification-submit-button').click();
-        }
+        cy.get('#username-verification').type(Cypress.env('E2E_USER'));
+        cy.get('#login-show-step2').click();
+        cy.get('#password').type(Cypress.env('E2E_PASSWORD'));
+        cy.get('#rh-password-verification-submit-button').click();
       });
     },
     { cacheAcrossSpecs: true }


### PR DESCRIPTION
## Summary by Sourcery

Implement a proof-of-concept Tekton Pipeline for running Cypress end-to-end tests by replacing a monolithic Task with a multi-task Pipeline that clones the repository and executes Cypress tests using workspaces and secrets for configuration

Enhancements:
- Convert existing Tekton Task to a Pipeline named e2e-tests that orchestrates a git-clone task and a Cypress test task
- Rename and consolidate parameters (repo_url, revision) and introduce a shared 'source' workspace for the cloned code
- Use a dedicated git-clone-oci-ta TaskRef for cloning and bind its output to the 'source' workspace
- Inline the run-cypress-e2e taskSpec to install dependencies, pull E2E credentials from a Kubernetes secret, and execute Cypress tests within the workspace