### PR TITLE
feat: add ARH scope to default scopes

### DIFF
--- a/src/auth/OIDCConnector/utils.ts
+++ b/src/auth/OIDCConnector/utils.ts
@@ -64,7 +64,7 @@ export function login(auth: AuthContextProps, requiredScopes: string[] = [], red
   // Redirect to login
   Cookies.set('cs_loggedOut', 'false');
   //FIX ME: Temp fix until scope is added in-boundary
-  let scope = ITLess() ? ['openid', ...requiredScopes] : ['openid', 'api.console', ...requiredScopes];
+  let scope = ITLess() ? ['openid', ...requiredScopes] : ['openid', 'api.console', 'api.ask_red_hat', ...requiredScopes];
   const partner = getPartnerScope(window.location.pathname);
   if (partner) {
     scope.push(partner);


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-41454

## Summary by Sourcery

New Features:
- Include api.ask_red_hat in the default OIDC scopes for non-ITLess environments.