### PR TITLE
Fix quickstarts bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "@orama/orama": "^2.0.21",
         "@patternfly/patternfly": "^6.0.0",
-        "@patternfly/quickstarts": "^6.0.0",
+        "@patternfly/quickstarts": "^6.3.1",
         "@patternfly/react-charts": "^8.0.0",
         "@patternfly/react-core": "^6.0.0",
         "@patternfly/react-icons": "^6.0.0",
@@ -3700,19 +3700,18 @@
       }
     },
     "node_modules/@patternfly/quickstarts": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-6.0.0.tgz",
-      "integrity": "sha512-gk0BBvYtLhksaeL36mTkbfmDdzoGtZmrxkm/QIlReIr+4dQBQfivTv6Z1bLxc/iLPkwA8dcBRc9aKIHb1YTIww==",
-      "license": "MIT",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-6.3.1.tgz",
+      "integrity": "sha512-cuQ+m0K90vbGyNo4oR8UToXo1Jw24QDfCaIoAW0pbUkEcYuSPGqVvrOSf7w5hUMJ8jrXqE7g0T7JkcQXElMbHg==",
       "dependencies": {
-        "dompurify": "^3.1.3",
+        "dompurify": "^3.2.4",
         "history": "^5.0.0"
       },
       "peerDependencies": {
         "@patternfly/react-core": "^6.0.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0",
-        "showdown": ">=2.1.0"
+        "marked": "^15.0.6",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-charts": {
@@ -11590,10 +11589,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
-      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -18601,6 +18599,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -23865,33 +23875,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/showdown": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
-      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.0.0"
-      },
-      "bin": {
-        "showdown": "bin/showdown.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://www.paypal.me/tiviesantos"
-      }
-    },
-    "node_modules/showdown/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@orama/orama": "^2.0.21",
     "@patternfly/patternfly": "^6.0.0",
     "pf-5-styles": "npm:@patternfly/patternfly@^5.4.0",
-    "@patternfly/quickstarts": "^6.0.0",
+    "@patternfly/quickstarts": "^6.3.1",
     "@patternfly/react-charts": "^8.0.0",
     "@patternfly/react-core": "^6.0.0",
     "@patternfly/react-icons": "^6.0.0",


### PR DESCRIPTION
Update quickstarts to include newest bug fixes
- Fixes admonition blocks
- Fixes incorrectly rendered formatting

[RHCLOUD-41204](https://issues.redhat.com/browse/RHCLOUD-41204)
# Before and After
<img width="942" height="1303" alt="image" src="https://github.com/user-attachments/assets/2221b2f0-89a4-4a1d-b199-2d1255ef5616" />

## Summary by Sourcery

Build:
- Bump @patternfly/quickstarts from v6.0.0 to v6.3.1 and update lockfile