### PR TITLE
fix: update patternfly quickstarts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "@orama/orama": "^2.0.21",
         "@patternfly/patternfly": "^6.2.3",
-        "@patternfly/quickstarts": "^6.2.2",
+        "@patternfly/quickstarts": "^6.3.1",
         "@patternfly/react-charts": "^8.2.2",
         "@patternfly/react-core": "^6.2.2",
         "@patternfly/react-icons": "^6.2.2",
@@ -3698,19 +3698,18 @@
       }
     },
     "node_modules/@patternfly/quickstarts": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-6.2.2.tgz",
-      "integrity": "sha512-YVO/QglCK3HpuS3TV4fcwXoklpoLCSh/kil2zYTFjcJ14OY8LDlp7vrbWDw799PyldVr+1eo2zp8Aon6MpVQSw==",
-      "license": "MIT",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-6.3.1.tgz",
+      "integrity": "sha512-cuQ+m0K90vbGyNo4oR8UToXo1Jw24QDfCaIoAW0pbUkEcYuSPGqVvrOSf7w5hUMJ8jrXqE7g0T7JkcQXElMbHg==",
       "dependencies": {
-        "dompurify": "^3.1.3",
+        "dompurify": "^3.2.4",
         "history": "^5.0.0"
       },
       "peerDependencies": {
         "@patternfly/react-core": "^6.0.0",
         "marked": "^15.0.6",
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-charts": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@orama/orama": "^2.0.21",
     "@patternfly/patternfly": "^6.2.3",
     "pf-5-styles": "npm:@patternfly/patternfly@^5.4.0",
-    "@patternfly/quickstarts": "^6.2.2",
+    "@patternfly/quickstarts": "^6.3.1",
     "@patternfly/react-charts": "^8.2.2",
     "@patternfly/react-core": "^6.2.2",
     "@patternfly/react-icons": "^6.2.2",


### PR DESCRIPTION
Update quickstarts to include newest bug fixes
- Fixes admonition blocks
- Fixes incorrectly rendered formatting

[RHCLOUD-41204](https://issues.redhat.com/browse/RHCLOUD-41204)
# Before and After
<img width="942" height="1303" alt="image" src="https://github.com/user-attachments/assets/2221b2f0-89a4-4a1d-b199-2d1255ef5616" />

## Summary by Sourcery

Build:
- Bump @patternfly/quickstarts from v6.0.0 to v6.3.1 and update lockfile

## Summary by Sourcery

Update PatternFly quickstarts dependency to v6.3.1 to incorporate bug fixes for admonition blocks and rendering issues.

Bug Fixes:
- Fix admonition block rendering in quickstarts
- Fix incorrect formatting rendering in quickstarts

Build:
- Bump @patternfly/quickstarts from v6.2.2 to v6.3.1 and update lockfile