### PR TITLE
add support for APIKeyDev

### DIFF
--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -170,6 +170,7 @@ export type ChromeModule = {
   };
   analytics?: {
     APIKey?: string;
+    APIKeyDev?: string;
   };
   dynamic?: boolean;
   isFedramp?: boolean;

--- a/src/analytics/SegmentProvider.tsx
+++ b/src/analytics/SegmentProvider.tsx
@@ -34,7 +34,7 @@ function getAdobeVisitorId() {
 
 const getAPIKey = (env: SegmentEnvs = 'dev', module: SegmentModules, moduleAPIKey?: string, moduleAPIKeyDev?: string) => {
   // Use the appropriate key based on environment
-  const envSpecificKey = env === 'dev' ? moduleAPIKeyDev : moduleAPIKey;
+  const envSpecificKey = env === 'prod' ? moduleAPIKey : moduleAPIKeyDev;
 
   return (
     envSpecificKey ||

--- a/src/analytics/SegmentProvider.tsx
+++ b/src/analytics/SegmentProvider.tsx
@@ -32,21 +32,26 @@ function getAdobeVisitorId() {
   return -1;
 }
 
-const getAPIKey = (env: SegmentEnvs = 'dev', module: SegmentModules, moduleAPIKey?: string) =>
-  moduleAPIKey ||
-  {
-    prod: {
-      acs: '9NmgZh57uEaOW9ePKqeKjjUKE8MEqaVU',
-      hacCore: 'cLLG3VVakAECyGRAUnmjRkSqGJkYlRWI',
-      openshift: 'z3Ic4EtzJtHrhXfpKgViJmf2QurSxXb9',
-    },
-    dev: {
-      acs: 'CA5jdEouFKAxwGq7X9i1b7UySMKshj1j',
-      hacCore: '5SuWCF4fRqTzMD8HVsk2r1LEYsYVsHCC',
-      openshift: 'A8iCO9n9Ax9ObvHBgz4hMC9htKB0AdKj',
-    },
-  }[env]?.[module] ||
-  KEY_FALLBACK[env];
+const getAPIKey = (env: SegmentEnvs = 'dev', module: SegmentModules, moduleAPIKey?: string, moduleAPIKeyDev?: string) => {
+  // Use the appropriate key based on environment
+  const envSpecificKey = env === 'dev' ? moduleAPIKeyDev : moduleAPIKey;
+  
+  return envSpecificKey ||
+    moduleAPIKey || // fallback to prod key if dev key not available
+    {
+      prod: {
+        acs: '9NmgZh57uEaOW9ePKqeKjjUKE8MEqaVU',
+        hacCore: 'cLLG3VVakAECyGRAUnmjRkSqGJkYlRWI',
+        openshift: 'z3Ic4EtzJtHrhXfpKgViJmf2QurSxXb9',
+      },
+      dev: {
+        acs: 'CA5jdEouFKAxwGq7X9i1b7UySMKshj1j',
+        hacCore: '5SuWCF4fRqTzMD8HVsk2r1LEYsYVsHCC',
+        openshift: 'A8iCO9n9Ax9ObvHBgz4hMC9htKB0AdKj',
+      },
+    }[env]?.[module] ||
+    KEY_FALLBACK[env];
+};
 
 const isInternal = (email = '') => /@(redhat\.com|.*ibm\.com)$/gi.test(email);
 
@@ -104,6 +109,7 @@ const SegmentProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const activeModule = useAtomValue(activeModuleAtom);
   const activeModuleDefinition = useAtomValue(activeModuleDefinitionReadAtom);
   const moduleAPIKey = activeModuleDefinition?.analytics?.APIKey;
+  const moduleAPIKeyDev = activeModuleDefinition?.analytics?.APIKeyDev;
   const { pathname, search } = useLocation();
   usePageEvent(analytics);
 
@@ -133,7 +139,7 @@ const SegmentProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   const handleModuleUpdate = async () => {
     if (!isDisabled && activeModule && user) {
-      const newKey = getAPIKey(DEV_ENV ? 'dev' : 'prod', activeModule as SegmentModules, moduleAPIKey);
+      const newKey = getAPIKey(DEV_ENV ? 'dev' : 'prod', activeModule as SegmentModules, moduleAPIKey, moduleAPIKeyDev);
       const identityTraits = getIdentityTraits(user, pathname, activeModule, isPreview);
       const identityOptions = {
         context: {
@@ -204,7 +210,7 @@ const SegmentProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     analytics.current.load(
       {
         cdnURL: '/connections/cdn',
-        writeKey: getAPIKey(DEV_ENV ? 'dev' : 'prod', activeModule as SegmentModules, moduleAPIKey),
+        writeKey: getAPIKey(DEV_ENV ? 'dev' : 'prod', activeModule as SegmentModules, moduleAPIKey, moduleAPIKeyDev),
       },
       {
         initialPageview: false,

--- a/src/analytics/SegmentProvider.tsx
+++ b/src/analytics/SegmentProvider.tsx
@@ -35,8 +35,9 @@ function getAdobeVisitorId() {
 const getAPIKey = (env: SegmentEnvs = 'dev', module: SegmentModules, moduleAPIKey?: string, moduleAPIKeyDev?: string) => {
   // Use the appropriate key based on environment
   const envSpecificKey = env === 'dev' ? moduleAPIKeyDev : moduleAPIKey;
-  
-  return envSpecificKey ||
+
+  return (
+    envSpecificKey ||
     moduleAPIKey || // fallback to prod key if dev key not available
     {
       prod: {
@@ -50,7 +51,8 @@ const getAPIKey = (env: SegmentEnvs = 'dev', module: SegmentModules, moduleAPIKe
         openshift: 'A8iCO9n9Ax9ObvHBgz4hMC9htKB0AdKj',
       },
     }[env]?.[module] ||
-    KEY_FALLBACK[env];
+    KEY_FALLBACK[env]
+  );
 };
 
 const isInternal = (email = '') => /@(redhat\.com|.*ibm\.com)$/gi.test(email);


### PR DESCRIPTION
# [RHCLOUD-41398](https://issues.redhat.com/browse/RHCLOUD-41398)

- add support for optional `APIKeyDev`

## Summary by Sourcery

Add support for optional APIKeyDev for analytics in development environment

New Features:
- Allow defining a separate APIKeyDev per module for dev environment

Enhancements:
- Update getAPIKey to prefer APIKeyDev in dev, then fall back to APIKey or built-in defaults