### PR TITLE
fix(internal): link to be user access

### DIFF
--- a/src/components/Header/UserToggle.tsx
+++ b/src/components/Header/UserToggle.tsx
@@ -127,7 +127,7 @@ const DropdownItems = ({
         <DropdownItem
           key="Internal"
           component={({ className }) => (
-            <ChromeLink className={className} href="/internal" appId="internal">
+            <ChromeLink className={className} href="/internal/access-requests" appId="internal">
               {intl.formatMessage(messages.internal)}
             </ChromeLink>
           )}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Update ChromeLink href in the Header UserToggle component from "/internal" to "/internal/access-requests"