### PR TITLE
adding media queries to fix styling issues in small dimentions in the feedback modal

### DIFF
--- a/src/components/Feedback/Feedback.scss
+++ b/src/components/Feedback/Feedback.scss
@@ -88,7 +88,7 @@ button.pf-v6-c-button.chr-c-button-feedback {
   }
 }
 
-@media (max-height: 450px), (max-width: 700px) {
+@media (max-height: $pf-v6-global--breakpoint--sm), (max-width: $pf-v6-global--breakpoint--md) {
   .chr-c-feedback-buttons {
     margin-top: var(--pf-t--global--spacer--md);
     position: static;

--- a/src/components/Feedback/Feedback.scss
+++ b/src/components/Feedback/Feedback.scss
@@ -1,3 +1,5 @@
+@import '~@patternfly/patternfly/sass-utilities/scss-variables';
+
 button.pf-v6-c-button.chr-c-button-feedback {
   svg {
     margin-right: var(--pf-t--global--spacer--sm);

--- a/src/components/Feedback/Feedback.scss
+++ b/src/components/Feedback/Feedback.scss
@@ -87,3 +87,11 @@ button.pf-v6-c-button.chr-c-button-feedback {
     border-bottom: 1px solid var(--pf-t--global--border--color--default);
   }
 }
+
+@media (max-height: 450px), (max-width: 700px) {
+  .chr-c-feedback-buttons {
+    margin-top: var(--pf-t--global--spacer--md);
+    position: static;
+    bottom: auto;
+  }
+}


### PR DESCRIPTION
fixes: [RHCLOUD-40959](https://issues.redhat.com/browse/RHCLOUD-40959)

Adding CSS media query to fix button overlap issues.

Before:

<img width="799" height="366" alt="image" src="https://github.com/user-attachments/assets/616593a5-8524-4d0d-8617-44978688eedf" />


After (modal becomes scrollable, instead of the buttons overlapping):

<img width="798" height="395" alt="image" src="https://github.com/user-attachments/assets/ddcf39fa-1147-45dc-adf3-1a6f3bafe31e" />

## Summary by Sourcery

Bug Fixes:
- Fix button overlap in the feedback modal on short or narrow screens by adjusting the button container to static positioning and adding top margin via a media query to enable scrolling.