### PR TITLE
feat(search): add support for external links in index

### DIFF
--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -237,7 +237,7 @@ const SearchInput = ({ onStateChange }: SearchInputListener) => {
                     }}
                     key={index}
                     className="pf-v6-u-mb-xs"
-                    component={(props) => <ChromeLink {...props} href={item.pathname} />}
+                    component={(props) => <ChromeLink {...props} href={item.pathname} isExternal={item.isExternal} />}
                   >
                     <SearchTitle title={item.title} bundleTitle={item.bundleTitle.replace(/(\[|\])/gm, '')} className="pf-v6-u-mb-xs" />
                     <SearchDescription description={item.description} />

--- a/src/components/Search/SearchTypes.ts
+++ b/src/components/Search/SearchTypes.ts
@@ -3,4 +3,5 @@ export type SearchItem = {
   bundleTitle: string;
   description: string;
   pathname: string;
+  isExternal?: boolean;
 };

--- a/src/state/atoms/localSearchAtom.ts
+++ b/src/state/atoms/localSearchAtom.ts
@@ -29,6 +29,7 @@ type SearchEntry = {
   bundleTitle: string;
   altTitle?: string[];
   type: 'legacy' | 'generated';
+  isExternal?: boolean;
 };
 
 type GeneratedSearchIndexResponse = {
@@ -73,10 +74,6 @@ const asyncSearchIndexAtom = atom(async () => {
         return;
       }
 
-      if (!entry.href.startsWith('/')) {
-        console.warn('External ink found in the index. Ignoring: ', entry.href);
-        return;
-      }
       idSet.add(entry.id);
       SearchPermissions.set(entry.id, []);
       const bundleTitle = getBundleTitle(entry.href);
@@ -90,6 +87,7 @@ const asyncSearchIndexAtom = atom(async () => {
         bundleTitle: bundleTitle,
         altTitle: entry.alt_title,
         type: 'generated',
+        isExternal: !entry.href.startsWith('/'),
       });
     });
   }
@@ -101,10 +99,6 @@ const asyncSearchIndexAtom = atom(async () => {
         return;
       }
 
-      if (!entry.relative_uri.startsWith('/')) {
-        console.warn('External ink found in the index. Ignoring: ', entry.relative_uri);
-        return;
-      }
       idSet.add(entry.id);
       SearchPermissions.set(entry.id, entry.permissions ?? []);
       searchIndex.push({
@@ -117,6 +111,7 @@ const asyncSearchIndexAtom = atom(async () => {
         bundleTitle: entry.bundleTitle[0],
         altTitle: entry.alt_title,
         type: 'legacy',
+        isExternal: !entry.relative_uri.startsWith('/'),
       });
     });
   }
@@ -132,6 +127,7 @@ const entrySchema = {
   bundleTitle: 'string',
   pathname: 'string',
   type: 'string',
+  isExternal: 'boolean',
 } as const;
 
 async function insertEntry(db: Orama<typeof entrySchema>, entry: SearchEntry) {
@@ -144,6 +140,7 @@ async function insertEntry(db: Orama<typeof entrySchema>, entry: SearchEntry) {
     bundleTitle: entry.bundleTitle,
     pathname: entry.pathname,
     type: entry.type,
+    isExternal: entry.isExternal ?? false,
   });
 }
 

--- a/src/utils/localSearch.ts
+++ b/src/utils/localSearch.ts
@@ -21,6 +21,7 @@ type ResultItem = {
   bundleTitle: string;
   pathname: string;
   id: string;
+  isExternal?: boolean;
 };
 
 const resultCache: {
@@ -155,13 +156,14 @@ export const localQuery = async (db: any, term: string, env: ReleaseEnv = Releas
     }
     const validResults = await Promise.all(searches);
     for (let i = 0; i < Math.min(10, validResults.length); i += 1) {
-      const { title, description, bundleTitle, pathname, id } = validResults[i];
+      const { title, description, bundleTitle, pathname, id, isExternal } = validResults[i];
       results.push({
         title: highlightText(term, title, 'title'),
         description: highlightText(term, description, 'description'),
         bundleTitle,
         pathname,
         id,
+        isExternal,
       });
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for external links in the local search by introducing an isExternal flag, including external URLs in the search index, and propagating this flag to the UI for proper rendering.

New Features:
- Introduce isExternal flag on search entries and schema, removing filtering to include external URLs in the index
- Propagate isExternal into search results and pass to ChromeLink component for proper external link rendering