### PR TITLE
fix(transformScalprumManifest): update root path to be relative to /apps

### DIFF
--- a/src/components/RootApp/transformScalprumManifest.ts
+++ b/src/components/RootApp/transformScalprumManifest.ts
@@ -13,7 +13,7 @@ function transformScalprumManifest(manifest: PluginManifest, config: ScalprumCon
   }
   let baseUrl = manifest.baseURL;
   if (baseUrl === 'auto') {
-    baseUrl = '/';
+    baseUrl = `/apps/${manifest.name}/`;
   }
   const newManifest = {
     ...manifest,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set baseURL of manifests with ‘auto’ to `/apps/<name>/` rather than `/`

Follow up to https://github.com/RedHatInsights/insights-chrome/pull/3173