### PR TITLE
feat: add useBreadcrumbs hook

### DIFF
--- a/src/hooks/useBreadcrumbs.ts
+++ b/src/hooks/useBreadcrumbs.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAtomValue } from 'jotai';
+import { activeModuleAtom } from '../state/atoms/activeModuleAtom';
+
+export interface BreadcrumbData {
+  pathname: string;
+  title: string;
+}
+
+interface BreadcrumbsState {
+  applications: BreadcrumbData[];
+}
+
+const useBreadcrumbs = () => {
+  const activeModule = useAtomValue(activeModuleAtom);
+  const previousActiveModule = useRef<string | undefined>(activeModule);
+
+  const [breadcrumbsState, setBreadcrumbsState] = useState<BreadcrumbsState>({
+    applications: [],
+  });
+
+  useEffect(() => {
+    if (previousActiveModule.current !== activeModule) {
+      setBreadcrumbsState((prev) => ({
+        ...prev,
+        applications: [],
+      }));
+      previousActiveModule.current = activeModule;
+    }
+  }, [activeModule]);
+
+  const setApplicationData = (data: BreadcrumbData | BreadcrumbData[]) => {
+    setBreadcrumbsState((prev) => {
+      const newApplications = [...prev.applications];
+
+      if (Array.isArray(data)) {
+        data.forEach(({ pathname, title }) => {
+          const existingIndex = newApplications.findIndex((b) => b.pathname === pathname);
+          if (existingIndex >= 0) {
+            newApplications[existingIndex] = { pathname, title };
+          } else {
+            newApplications.push({ pathname, title });
+          }
+        });
+      } else {
+        const existingIndex = newApplications.findIndex((b) => b.pathname === data.pathname);
+        if (existingIndex >= 0) {
+          newApplications[existingIndex] = data;
+        } else {
+          newApplications.push(data);
+        }
+      }
+
+      return { ...prev, applications: newApplications };
+    });
+  };
+
+  const clearApplicationData = () => {
+    setBreadcrumbsState((prev) => ({
+      ...prev,
+      applications: [],
+    }));
+  };
+
+  return {
+    applicationData: breadcrumbsState.applications,
+    setApplicationData,
+    clearApplicationData,
+  };
+};
+
+export default useBreadcrumbs;


### PR DESCRIPTION
part of [RHCLOUD-42160](https://issues.redhat.com/browse/RHCLOUD-42160)

## Summary by Sourcery

Introduce a useBreadcrumbs hook to manage application breadcrumb state, automatically reset on active module change, and expose methods to set and clear application breadcrumbs

New Features:
- Add useBreadcrumbs hook to manage application breadcrumb state
- Automatically reset breadcrumbs when the active module changes
- Provide setApplicationData and clearApplicationData methods for updating breadcrumbs