### PR TITLE
Update image URLs to new frontend-assets paths

### DIFF
--- a/src/components/FavoriteServices/EmptyState.tsx
+++ b/src/components/FavoriteServices/EmptyState.tsx
@@ -14,7 +14,7 @@ const EmptyState = () => (
       <Stack className="pf-v6-u-justify-content-center">
         <StackItem className="pf-v6-u-text-align-center">
           <img
-            src="https://console.redhat.com/apps/frontend-assets/favoritedservices/favoriting-emptystate.svg"
+            src="https://console.redhat.com/apps/frontend-assets/background-images/favoriting-emptystate.svg"
             className="chr-c-empty-state-favorites"
             alt="favoriting image"
           />

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -171,7 +171,7 @@ const Tools = () => {
       enabled: askRedHatEnabled,
       item: {
         title: intl.formatMessage(messages.askRedHat),
-        icon: <img className="pf-v6-c-button__icon" src="/apps/frontend-assets/ask-redhat/ask-redhat-icon.svg" />,
+        icon: <img className="pf-v6-c-button__icon" src="/apps/frontend-assets/technology-icons/ai-chat-ask-redhat.svg" />,
         onClick: () => window.open('https://access.redhat.com/ask', '_blank'),
       },
     },


### PR DESCRIPTION
- Update favoriting empty state image path from favoritedservices/ to background-images/
- Update Ask Red Hat icon path from ask-redhat/ to technology-icons/ with new filename

These changes align with the reorganized frontend-assets repository structure.

## Summary by Sourcery

Align image asset URLs to match the reorganized frontend-assets structure

Enhancements:
- Update favoriting empty state image path to background-images directory
- Update Ask Red Hat icon path and filename to technology-icons directory