### PR TITLE
Fix masthead spacing issues

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -3,7 +3,8 @@
 
 .chr-c-masthead {
   --pf-v6-c-masthead__content--MinHeight: 48px !important;
-  --pf-v6-c-masthead__main--before--Right: 0;
+  --pf-v6-c-masthead__main--ColumnGap: 0 !important;
+  --pf-v6-c-masthead__main--before--Right: 0; // close gap between hamburger and logo
   .chr-c-brand {
     width: 30px;
   }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -110,7 +110,7 @@ const MemoizedHeader = memo(
                 )}
               </ToolbarGroup>
               <ToolbarGroup className="pf-v6-u-flex-grow-1" variant="filter-group" gap={{ default: 'gapNone' }}>
-                <ToolbarGroup className="pf-v6-u-flex-grow-1 pf-v6-u-mr-sm pf-v6-u-ml-xl" variant="filter-group">
+                <ToolbarGroup className="pf-v6-u-flex-grow-1 pf-v6-u-mr-sm pf-v6-u-ml-4xl-on-2xl" variant="filter-group">
                   <Suspense fallback={null}>
                     <SearchInput onStateChange={hideAllServices} />
                   </Suspense>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-41632

- Remove column gap between hamburger menu and logo
- Adjust search input margin for better spacing on large screens
- Improve overall masthead layout consistency

Old
<img width="1544" height="784" alt="Screenshot 2025-09-30 at 1 42 52 PM" src="https://github.com/user-attachments/assets/b732e7ca-3a93-4f46-a71b-c106d7520f19" />
<img width="1594" height="627" alt="Screenshot 2025-09-30 at 1 42 27 PM" src="https://github.com/user-attachments/assets/e339dc29-376b-408f-91ce-d3e9d9994c5a" />

new