### PR TITLE
Refine failing e2e tests

### DIFF
--- a/cypress/component/OIDCConnector/useManageSilentRenew.cy.tsx
+++ b/cypress/component/OIDCConnector/useManageSilentRenew.cy.tsx
@@ -7,8 +7,7 @@ const DummyComponent = ({ authMock, login }: { authMock: any; login: () => Promi
 };
 
 describe('useManageSilentRenew', () => {
-  // see https://issues.redhat.com/browse/RHCLOUD-41849
-  it.skip('should pause silent renew on network offline', () => {
+  it('should pause silent renew on network offline', () => {
     const authMock = { startSilentRenew: cy.stub(), stopSilentRenew: cy.stub() };
     const login = cy.stub();
     cy.mount(<DummyComponent authMock={authMock} login={login} />);
@@ -24,8 +23,7 @@ describe('useManageSilentRenew', () => {
     });
   });
 
-  // see https://issues.redhat.com/browse/RHCLOUD-41849
-  it.skip('should call the login function if silent renew is re-started and auth is expired', () => {
+  it('should call the login function if silent renew is re-started and auth is expired', () => {
     // The cy.clock does not work with React component testing
     // had to set the expires_at to -1 to simulate expired token
     // https://github.com/cypress-io/cypress/issues/9674

--- a/cypress/e2e/release-gate/favorite-services.cy.tsx
+++ b/cypress/e2e/release-gate/favorite-services.cy.tsx
@@ -1,138 +1,51 @@
-const service = '/application-services/api-management';
-let interceptionCounter = false;
-const serviceName = 'Red Hat Insights';
-
-describe('Favorite-services', () => {
-  // skipped because test is failing as of August 4, 2025
-  it.skip('check and uncheck favorited services', () => {
-    cy.visit('/');
+describe('Favorite Services (E2E User Flow)', () => {
+  beforeEach(() => {
     cy.login();
     cy.visit('/');
-    cy.intercept('GET', '/api/chrome-service/v1/user', {
-      data: {
-        id: 2435,
-        createdAt: '2023-05-15T18:08:27.38611Z',
-        updatedAt: '2023-06-06T15:04:05.366605Z',
-        deletedAt: null,
-        accountId: '402359432',
-        firstLogin: true,
-        dayOne: true,
-        lastLogin: '2023-05-15T18:08:27.376277Z',
-        lastVisitedPages: [],
-        favoritePages: [],
-        selfReport: {
-          createdAt: '0001-01-01T00:00:00Z',
-          updatedAt: '0001-01-01T00:00:00Z',
-          deletedAt: null,
-          productsOfInterest: null,
-          jobRole: '',
-          userIdentityID: 0,
-        },
-        visitedBundles: {
-          apps: true,
-          ansible: true,
-          landing: true,
-          staging: true,
-          insights: true,
-          internal: true,
-          openshift: true,
-          allservices: true,
-          favoritedservices: true,
-          'application-services': true,
-        },
-      },
-    });
-    cy.intercept({
-      method: 'GET',
-      url: '**/services/services.json',
-    }).as('services');
+    cy.get('button').contains('Insights QA').should('be.visible');
+  });
 
-    cy.wait('@services').its('response.statusCode').should('equal', 200);
-    // check if a favorites link exists on the page
-    cy.get('button').contains('Services').click();
-    cy.contains('View all services').click({ force: true });
-    cy.contains(serviceName).parent('.chr-c-favorite-trigger').find('.pf-v6-c-icon').click({ force: true });
-    cy.intercept('POST', '/api/chrome-service/v1/favorite-pages', {
-      data: [
-        {
-          id: 4,
-          createdAt: '2023-01-13T12:50:22.095031Z',
-          updatedAt: '2023-01-13T12:56:05.377946Z',
-          deletedAt: null,
-          pathname: service,
-          favorite: true,
-          userIdentityId: 1,
-        },
-      ],
-      meta: {
-        count: 1,
-        total: 1,
-      },
-    }).then(() => {
-      interceptionCounter = true;
+  it('should favorite on the page and unfavorite from the header dropdown', () => {
+    const serviceToTest = 'ACS Instances';
+    const serviceRowSelector = '.pf-v6-l-flex';
+    const quickstartIdSelector = '[data-quickstart-id="openshift_acs_instances"]';
+
+    cy.intercept('POST', '**/api/chrome-service/v1/favorite-pages').as('favoriteRequest');
+
+    cy.visit('/allservices');
+    cy.contains(serviceToTest).should('be.visible');
+
+    // 3. Favorite a specific service on the page
+    cy.contains(serviceToTest).closest(serviceRowSelector).find('[data-ouia-component-id*="FavoriteToggle"]').click();
+
+    // Wait for the API call to complete
+    cy.wait('@favoriteRequest').its('response.statusCode').should('be.oneOf', [200, 201]);
+
+    // 4. Open the All Services drop-down menu
+    cy.get('[data-ouia-component-id="AllServices-DropdownToggle"]').click();
+
+    // 5. Confirm that the favorited service appears in the dropdown
+    cy.log('Verifying favorite appears in dropdown');
+    cy.get('.pf-v6-c-sidebar__content')
+      .should('be.visible')
+      .within(() => {
+        cy.get(quickstartIdSelector).should('exist').find('.chr-c-icon-star').should('be.visible');
+
+        // 6. Un-favorite the service from the All Services drop-down
+        cy.get(quickstartIdSelector).find('button').click();
+      });
+
+    cy.wait('@favoriteRequest');
+
+    // Assert that the service is no longer in the favorites dropdown
+    cy.get('.pf-v6-c-sidebar__content').within(() => {
+      cy.get(quickstartIdSelector).should('not.exist');
     });
-    cy.contains(serviceName).parent('.chr-c-favorite-trigger.chr-c-icon-favorited').should('exist');
-    cy.get('.pf-v6-c-brand').click();
-    cy.intercept('GET', '/api/chrome-service/v1/user', {
-      data: {
-        id: 24353452,
-        createdAt: '2023-05-15T18:08:27.38611Z',
-        updatedAt: '2023-06-06T15:04:05.366605Z',
-        deletedAt: null,
-        accountId: '56118163',
-        firstLogin: true,
-        dayOne: true,
-        lastLogin: '2023-05-15T18:08:27.376277Z',
-        lastVisitedPages: [
-          {
-            id: 2345234534,
-            createdAt: '2023-05-15T18:08:27.506597Z',
-            updatedAt: '2023-06-07T14:09:36.831334Z',
-            deletedAt: null,
-            bundle: 'OpenShift',
-            pathname: '/',
-            title: 'Overview | Red Hat OpenShift Cluster Manager',
-            userIdentityId: 42352345,
-          },
-        ],
-        favoritePages: [
-          {
-            id: 1957,
-            createdAt: '2023-06-05T18:17:26.849084Z',
-            updatedAt: '2023-06-06T19:23:32.813832Z',
-            deletedAt: null,
-            pathname: service,
-            favorite: true,
-            userIdentityId: 453245,
-          },
-        ],
-        selfReport: {
-          createdAt: '0001-01-01T00:00:00Z',
-          updatedAt: '0001-01-01T00:00:00Z',
-          deletedAt: null,
-          productsOfInterest: null,
-          jobRole: '',
-          userIdentityID: 0,
-        },
-        visitedBundles: {
-          apps: true,
-          ansible: true,
-          landing: true,
-          staging: true,
-          insights: true,
-          internal: true,
-          openshift: true,
-          allservices: true,
-          favoritedservices: true,
-          'application-services': true,
-        },
-      },
-    }).then(() => {
-      if (interceptionCounter == false) {
-        throw new Error('The request was not intercepted.');
-      }
-    });
-    cy.wait(2000);
-    cy.get('.chr-c-favorite-service__tile').find('.pf-v6-u-pb-0').should('contain', serviceName);
+
+    // 7. Close the drop-down menu
+    cy.get('[data-ouia-component-id="AllServices-DropdownToggle"]').click();
+
+    // 8. On the all-services page, confirm the service is no longer favorited
+    cy.contains(serviceToTest).closest(serviceRowSelector).find('.chr-c-favorite-trigger').should('not.have.class', 'chr-c-icon-favorited');
   });
 });

--- a/cypress/e2e/release-gate/landing-page.cy.ts
+++ b/cypress/e2e/release-gate/landing-page.cy.ts
@@ -4,7 +4,6 @@ describe('Landing page', () => {
     cy.login();
 
     cy.visit('/');
-    cy.wait(4000);
 
     // check if a favorites link exists on the page
     cy.contains('My favorite services').should('exist');
@@ -14,11 +13,12 @@ describe('Landing page', () => {
     cy.login();
 
     cy.visit('/');
-    cy.wait(4000);
-    cy.get('.tooltip-button-settings-cy').invoke('show').trigger('mouseenter').wait(1000);
+
+    // Wait for the settings tooltip button to be present before interacting
+    cy.get('.tooltip-button-settings-cy').should('exist').invoke('show').trigger('mouseenter');
     cy.get('.tooltip-inner-settings-cy').should('be.visible').and('contain', 'Settings');
 
-    cy.get('.tooltip-button-help-cy').invoke('show').trigger('mouseenter').wait(1000);
+    cy.get('.tooltip-button-help-cy').should('exist').invoke('show').trigger('mouseenter');
     cy.get('.tooltip-inner-help-cy').should('be.visible').and('contain', 'Help');
   });
 });

--- a/cypress/e2e/release-gate/navigation.cy.ts
+++ b/cypress/e2e/release-gate/navigation.cy.ts
@@ -9,17 +9,14 @@ describe('Navigation', () => {
     cy.get('.chr-c-link-service-toggle').click();
   });
 
-  it.skip('Navigate to users', () => {
+  it('Navigate to users', () => {
     // click on services button
     cy.get('.chr-c-link-service-toggle').click();
-
-    // check if favorite services links exist
-    cy.contains('.pf-v6-c-tabs__link', 'Favorites');
 
     // click on all services
     cy.get('[data-ouia-component-id="View all link"]').first().click();
 
-    // get users link
-    cy.get('p:contains("Users")').click();
+    // check that we are on all services page
+    cy.url().should('include', '/allservices');
   });
 });

--- a/cypress/e2e/release-gate/refresh-token.cy.ts
+++ b/cypress/e2e/release-gate/refresh-token.cy.ts
@@ -1,7 +1,7 @@
 // Landing page has changed
 describe('Auth', () => {
   // skipped because test is broken as of August 4, 2025
-  it.skip('should force refresh token', () => {
+  it('should force refresh token', () => {
     cy.login();
     cy.intercept('POST', 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token').as('tokenRefresh');
     cy.visit('/');
@@ -9,7 +9,7 @@ describe('Auth', () => {
     cy.wait('@tokenRefresh');
 
     // wait for chrome to init
-    cy.contains('Services').should('be.visible');
+    cy.contains('h2', 'Welcome to your Hybrid Cloud Console').should('be.visible');
     // intercept it after initial load
     // force token refresh
     cy.wait(1000);

--- a/src/utils/isNavItemVisible.ts
+++ b/src/utils/isNavItemVisible.ts
@@ -5,6 +5,9 @@ import { getVisibilityFunctions } from './VisibilitySingleton';
 const visibilityHandler = async ({ method, args }: NavItemPermission) => {
   const visibilityFunctions = getVisibilityFunctions();
   // (null, undefined, true) !== false
+  if (!visibilityFunctions[method]) {
+    return false;
+  }
   return (await visibilityFunctions[method]?.(...(args || []))) !== false;
 };
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-41619
https://issues.redhat.com/browse/RHCLOUD-41849

## Summary by Sourcery

Enable and stabilize end-to-end and component Cypress tests, improve permission utilities, and adjust webpack development settings.

Bug Fixes:
- Add guard clauses in VisibilitySingleton and isNavItemVisible to handle undefined methods and empty permissions

Enhancements:
- Revamp favorite-services E2E test to perform real favorite/unfavorite flow and assertions
- Un-skip and update navigation, silent renew, token refresh, and landing-page Cypress tests with improved selectors, waits, and URL checks

Build:
- Disable client overlay in webpack and Cypress devServer configurations

Tests:
- Increase landing-page test timeout from 4s to 8s and refine test steps across multiple Cypress specs