### PR TITLE
Fix ToolbarToggle test timing issue

### DIFF
--- a/src/components/Header/HeaderTests/ToolbarToggle.test.js
+++ b/src/components/Header/HeaderTests/ToolbarToggle.test.js
@@ -63,11 +63,10 @@ describe('ToolbarToggle', () => {
 
     // wait for async actions on toggle to complete
     await waitFor(async () => {
-      await Promise.resolve();
+      for (const item of expectedTexts) {
+        expect(screen.queryByText(item.title)).not.toBeInTheDocument();
+      }
     });
-    for (const item of expectedTexts) {
-      expect(screen.queryByText(item.title)).not.toBeInTheDocument();
-    }
     // expect(container.querySelectorAll('.pf-v6-c-menu__list-item')).toHaveLength(0);
   });
 


### PR DESCRIPTION
- Move assertion inside waitFor callback to properly wait for DOM updates
- Fixes test failure after PatternFly v6 upgrade where menu items weren't being removed from DOM
- Test now properly waits for dropdown to close before asserting items are not in document

## Summary by Sourcery

Fix timing issue in ToolbarToggle tests by moving assertions inside waitFor to ensure the dropdown has closed and menu items are removed before checking, resolving failures introduced by the PatternFly v6 upgrade

Bug Fixes:
- Fix ToolbarToggle test failure by properly waiting for DOM updates after PatternFly v6 upgrade

Tests:
- Move assertion inside waitFor in ToolbarToggle test to wait for dropdown closure before asserting menu items are not in the document