### PR TITLE
Fix 'Ask Red Hat' icon rendering

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -171,7 +171,7 @@ const Tools = () => {
       enabled: askRedHatEnabled,
       item: {
         title: intl.formatMessage(messages.askRedHat),
-        icon: <img className="pf-v6-c-button__icon" src="/apps/frontend-assets/technology-icons/ai-chat-ask-redhat.svg" />,
+        icon: <img className="pf-v6-c-button__icon" height="26" width="26" src="/apps/frontend-assets/technology-icons/ai-chat-ask-redhat.svg" />,
         onClick: () => window.open('https://access.redhat.com/ask', '_blank'),
       },
     },


### PR DESCRIPTION
- Add explicit height and width attributes to Ask Red Hat icon
- Ensures consistent icon sizing in the header tools section
- Improves visual consistency with other header icons

Old
<img width="446" height="332" alt="Screenshot 2025-10-02 at 10 54 12 AM" src="https://github.com/user-attachments/assets/8065d54d-d6af-4e0c-8f4a-1f1cb8ad8463" />

New
<img width="447" height="319" alt="Screenshot 2025-10-02 at 10 52 16 AM" src="https://github.com/user-attachments/assets/4aeac5a6-371c-4884-8c0a-81a9ef995bf6" />

## Summary by Sourcery

Enhancements:
- Add explicit height and width attributes to Ask Red Hat icon for consistent sizing