### PR TITLE
chore: bump scalprum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@rhds/elements": "^2.0.1",
         "@rhds/icons": "^1.1.1",
         "@scalprum/core": "^0.8.3",
-        "@scalprum/react-core": "^0.10.0",
+        "@scalprum/react-core": "^0.10.2",
         "@segment/analytics-next": "^1.73.0",
         "@sentry/browser": "^8.33.0",
         "@sentry/react": "^8.33.0",
@@ -5618,9 +5618,9 @@
       }
     },
     "node_modules/@scalprum/react-core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.10.0.tgz",
-      "integrity": "sha512-zZCYXOsS224jAPNX9ZZzMaHHPyxJub7OA2E76/Q6NZ5G58idPY4yYSpxmw2LBjUxAzteNHCKjhz+VZs96LReZg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.10.2.tgz",
+      "integrity": "sha512-EBWOXn8kgYAAhVuoKQ3fx6YXGnCm48l5ScBdbdZM+3xeNoptvckETg/I8pv1MtMwDm7O8rYNsbHnqbwb95Y86w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@rhds/elements": "^2.0.1",
     "@rhds/icons": "^1.1.1",
     "@scalprum/core": "^0.8.3",
-    "@scalprum/react-core": "^0.10.0",
+    "@scalprum/react-core": "^0.10.2",
     "@segment/analytics-next": "^1.73.0",
     "@sentry/browser": "^8.33.0",
     "@sentry/react": "^8.33.0",


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the Scalprum React core dependency to the latest patch version to incorporate recent fixes and improvements.

Chores:
- Bump @scalprum/react-core from version 0.10.0 to 0.10.2
- Regenerate package-lock.json to reflect the updated dependency