### PR TITLE
fix: enable nextQuickStart links by fetching referenced quickstarts

### DIFF
--- a/src/components/QuickStart/useQuickstartsStates.stage.test.js
+++ b/src/components/QuickStart/useQuickstartsStates.stage.test.js
@@ -178,4 +178,166 @@ describe('useQuickstartsStates stage', () => {
     expect(postSpy).toHaveBeenCalledTimes(1);
     expect(postSpy).toHaveBeenCalledWith('/api/quickstarts/v1/progress', { accountId: NaN, progress: ['updated-state'], quickstartName: 'test-id' });
   });
+
+  describe('activateQuickstart', () => {
+    let mockMainQuickstart;
+
+    beforeEach(() => {
+      mockMainQuickstart = {
+        content: {
+          metadata: { name: 'main-quickstart' },
+          spec: {
+            displayName: 'Main Quickstart',
+            nextQuickStart: ['next-quickstart-1', 'next-quickstart-2'],
+          },
+        },
+      };
+    });
+
+    test('should fetch and activate a single quickstart without nextQuickStart references', async () => {
+      mockMainQuickstart = JSON.parse(JSON.stringify(mockMainQuickstart)); // clone
+      delete mockMainQuickstart.content.spec.nextQuickStart;
+
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockMainQuickstart] } }));
+
+      const wrapper = ({ children }) => <WrapperComponent>{children}</WrapperComponent>;
+      const { result } = renderHook(() => useQuickstartsStates(), { wrapper });
+
+      await act(async () => {
+        await result.current.activateQuickstart('main-quickstart');
+      });
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(getSpy).toHaveBeenCalledWith('/api/quickstarts/v1/quickstarts', {
+        params: { name: 'main-quickstart' },
+      });
+      expect(result.current.activeQuickStartID).toBe('main-quickstart');
+    });
+
+    test('should fetch main quickstart and referenced quickstarts from nextQuickStart array', async () => {
+      const mockNextQuickstart1 = {
+        content: {
+          metadata: { name: 'next-quickstart-1' },
+          spec: { displayName: 'Next Quickstart 1' },
+        },
+      };
+
+      const mockNextQuickstart2 = {
+        content: {
+          metadata: { name: 'next-quickstart-2' },
+          spec: { displayName: 'Next Quickstart 2' },
+        },
+      };
+
+      // Mock the main quickstart call
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockMainQuickstart] } }));
+
+      // Mock the referenced quickstart calls
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockNextQuickstart1] } }));
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockNextQuickstart2] } }));
+
+      const wrapper = ({ children }) => <WrapperComponent>{children}</WrapperComponent>;
+      const { result } = renderHook(() => useQuickstartsStates(), { wrapper });
+
+      await act(async () => {
+        await result.current.activateQuickstart('main-quickstart');
+      });
+
+      expect(getSpy).toHaveBeenCalledTimes(3);
+      expect(getSpy).toHaveBeenNthCalledWith(1, '/api/quickstarts/v1/quickstarts', {
+        params: { name: 'main-quickstart' },
+      });
+      expect(getSpy).toHaveBeenNthCalledWith(2, '/api/quickstarts/v1/quickstarts', {
+        params: { name: 'next-quickstart-1' },
+      });
+      expect(getSpy).toHaveBeenNthCalledWith(3, '/api/quickstarts/v1/quickstarts', {
+        params: { name: 'next-quickstart-2' },
+      });
+      expect(result.current.activeQuickStartID).toBe('main-quickstart');
+    });
+
+    test('should handle duplicate nextQuickStart references', async () => {
+      mockMainQuickstart = JSON.parse(JSON.stringify(mockMainQuickstart)); // clone
+      mockMainQuickstart.content.spec.nextQuickStart = ['next-quickstart-1', 'next-quickstart-1']; // duplicate
+
+      const mockNextQuickstart = {
+        content: {
+          metadata: { name: 'next-quickstart-1' },
+          spec: { displayName: 'Next Quickstart 1' },
+        },
+      };
+
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockMainQuickstart] } }));
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockNextQuickstart] } }));
+
+      const wrapper = ({ children }) => <WrapperComponent>{children}</WrapperComponent>;
+      const { result } = renderHook(() => useQuickstartsStates(), { wrapper });
+
+      await act(async () => {
+        await result.current.activateQuickstart('main-quickstart');
+      });
+
+      // Should only make 2 calls (1 main + 1 deduplicated next)
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('should handle empty nextQuickStart array', async () => {
+      mockMainQuickstart = JSON.parse(JSON.stringify(mockMainQuickstart)); // clone
+      mockMainQuickstart.content.spec.nextQuickStart = [];
+
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockMainQuickstart] } }));
+
+      const wrapper = ({ children }) => <WrapperComponent>{children}</WrapperComponent>;
+      const { result } = renderHook(() => useQuickstartsStates(), { wrapper });
+
+      await act(async () => {
+        await result.current.activateQuickstart('main-quickstart');
+      });
+
+      // Should only make 1 call for the main quickstart
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(result.current.activeQuickStartID).toBe('main-quickstart');
+    });
+
+    test('should handle errors when fetching referenced quickstarts gracefully', async () => {
+      mockMainQuickstart = JSON.parse(JSON.stringify(mockMainQuickstart)); // clone
+      mockMainQuickstart.content.spec.nextQuickStart = ['non-existent-quickstart'];
+
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      getSpy.mockImplementationOnce(() => Promise.resolve({ data: { data: [mockMainQuickstart] } }));
+      getSpy.mockImplementationOnce(() => Promise.reject(new Error('Quickstart not found')));
+
+      const wrapper = ({ children }) => <WrapperComponent>{children}</WrapperComponent>;
+      const { result } = renderHook(() => useQuickstartsStates(), { wrapper });
+
+      await act(async () => {
+        await result.current.activateQuickstart('main-quickstart');
+      });
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Some referenced quickstarts could not be fetched:', expect.any(Error));
+      expect(result.current.activeQuickStartID).toBe('main-quickstart');
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    test('should handle main quickstart fetch error', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      getSpy.mockImplementationOnce(() => Promise.reject(new Error('Main quickstart fetch failed')));
+
+      const wrapper = ({ children }) => <WrapperComponent>{children}</WrapperComponent>;
+      const { result } = renderHook(() => useQuickstartsStates(), { wrapper });
+
+      await act(async () => {
+        await result.current.activateQuickstart('main-quickstart');
+      });
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Unable to active quickstarts called: ', 'main-quickstart', expect.any(Error));
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-42707

<img width="538" height="880" alt="image" src="https://github.com/user-attachments/assets/5eee9985-adaf-4408-bbff-776c8c13664e" />

## Summary by Sourcery

Enable activateQuickstart to fetch and include referenced quickstarts defined in nextQuickStart, handling duplicates, empty lists, and errors gracefully

New Features:
- Fetch and include referenced quickstarts listed in spec.nextQuickStart when activating a quickstart

Bug Fixes:
- Log warnings for failures fetching referenced quickstarts and log errors for failures fetching the main quickstart

Enhancements:
- Deduplicate nextQuickStart names before fetching
- Populate the quickstarts atom with both main and referenced quickstarts

Tests:
- Add tests for activateQuickstart covering scenarios with no references, multiple references, duplicate references, empty references, and error handling