### PR TITLE
Allow both notifications and help-panel to show drawer

### DIFF
--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -76,6 +76,8 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
     setIsNotificationsDrawerExpanded((prev) => !prev);
   };
   const isNotificationsEnabled = useFlag('platform.chrome.notifications-drawer');
+  const isHelpPanelEnabled = useFlag('platform.chrome.help-panel');
+  const isDrawerEnabled = isNotificationsEnabled || isHelpPanelEnabled;
   const { pathname } = useLocation();
   const noBreadcrumb = !['/', '/allservices', '/favoritedservices', '/learning-resources'].includes(pathname);
   return (
@@ -96,7 +98,7 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
           />
         </Masthead>
       }
-      {...(isNotificationsEnabled && {
+      {...(isDrawerEnabled && {
         onNotificationDrawerExpand: focusDrawer,
         notificationDrawer: <DrawerPanel ref={drawerPanelRef} toggleDrawer={toggleDrawer} />,
         isNotificationDrawerExpanded: isNotificationsDrawerExpanded,


### PR DESCRIPTION
After trying to toggle the `platform.chrome.help-panel` in prod-preview, the drawer wasn't being displayed on button toggle. The culprit was that the drawer display was tied to the notifications drawer feature flag which wasn't enabled in prod preview. This PR allows either flag to be used to display drawer content.

## Summary by Sourcery

Allow the drawer to be toggled when either the notifications-drawer or help-panel feature flag is enabled by introducing a help-panel flag and combining it with the existing notifications flag.

New Features:
- Introduce platform.chrome.help-panel feature flag to control drawer visibility.

Enhancements:
- Combine notifications-drawer and help-panel flags into a single isDrawerEnabled flag for rendering the drawer.