### PR TITLE
chore(sentry): add content sources to configList

### DIFF
--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -118,6 +118,11 @@ function initSentry() {
         dsn: 'https://f4b4288bbb7cf6c0b2ac1a2b90a076bf@o490301.ingest.us.sentry.io/4508297557901312',
         project: 'image-builder-rhel',
       },
+      {
+        appName: 'content-sources',
+        dsn: 'https://2578944726a33e0e2e3971c976a87e08@o490301.ingest.us.sentry.io/4510123991171072',
+        project: 'content-sources',
+      },
     ],
     openshift: [
       {


### PR DESCRIPTION
Work is being doing to eventually remove the list entirely from here, but while thats in the works I wanted to add this project to the configured list of apps.

## Summary by Sourcery

Chores:
- Add a new Sentry configuration entry for the content-sources application