### PR TITLE
Update Facebook URL in footer

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -65,7 +65,7 @@ const ChromeFooter = () => {
           <a href="https://www.youtube.com/user/RedHatVideos">YouTube</a>
         </FooterSocialLink>
         <FooterSocialLink slot="social-links" icon="facebook">
-          <a href="https://www.facebook.com/redhatinc">Facebook</a>
+          <a href="https://www.facebook.com/RedHat/">Facebook</a>
         </FooterSocialLink>
         <FooterSocialLink slot="social-links" icon="x">
           <a href="https://twitter.com/RedHat">X/Twitter</a>


### PR DESCRIPTION
URL update request from [RHCLOUD-43319](https://issues.redhat.com/browse/RHCLOUD-43319)

Facebook account was recently updated, which has changed the URL link for that account page.

## Summary by Sourcery

Bug Fixes:
- Update Facebook URL in footer to reflect new account page