### PR TITLE
Add / to cache bust paths

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -30,6 +30,8 @@ objects:
         paths:
           - /
       akamaiCacheBustPaths:
+        # / should not be cached whatsoever
+        - /
         - /config/chrome/fed-modules.json
         - /apps/chrome/index.html
         - /apps/chrome/js/fed-mods.json


### PR DESCRIPTION
Temporary fix for bad caching. bandaid for incident 

https://redhat-internal.slack.com/archives/C0A538HH36U/p1766006019375609
https://redhat-internal.slack.com/archives/C05M0SNTLM8/p1766004678098189?thread_ts=1765999171.121999&cid=C05M0SNTLM8

## Summary by Sourcery

Bug Fixes:
- Ensure the root path (/) participates in Akamai cache busting to mitigate incorrect caching at the site root.