### PR TITLE
fix(frontend.yml): update default image to pull from the Konflux repo

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -43,4 +43,4 @@ parameters:
   - name: SSO_URL
     required: true
   - name: IMAGE
-    value: quay.io/cloudservices/insights-chrome-frontend
+    value: quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome


### PR DESCRIPTION
The legacy Jenkins server builds are once again failing with the following error on master:

```
16:00:02 build_app_info.sh: line 132: build/app.info.json: No such file or directory
16:00:03 + teardown_docker
16:00:03 + _container_exists chrome-master-2c168ab-1767887867
```

This is likely due to the change we merged recently to update the paths in the docker image, and the legacy build scripts can't find the new directory like our FEC utils can.

This is breaking ephemeral deployments, so I'd like to try defaulting our frontend.yml image to the Konflux one instead (where bonfire is pulling the image). 