### PR TITLE
chore(RHCLOUD-40729): fix flaky unit test

### DIFF
--- a/src/components/Header/HeaderTests/ToolbarToggle.test.js
+++ b/src/components/Header/HeaderTests/ToolbarToggle.test.js
@@ -62,10 +62,10 @@ describe('ToolbarToggle', () => {
     });
 
     // wait for async actions on toggle to complete
-    await waitFor(async () => {
-      for (const item of expectedTexts) {
+    await waitFor(() => {
+      expectedTexts.forEach((item) => {
         expect(screen.queryByText(item.title)).not.toBeInTheDocument();
-      }
+      });
     });
     // expect(container.querySelectorAll('.pf-v6-c-menu__list-item')).toHaveLength(0);
   });


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-40729

**I ran the test as it is 50 times without failure**, but Claude seems to think the test is still flaky. Hence, I opened the PR with the recommended changes.

From Claude
---
### Analysis
  Yes, the issue is accurate. The test src/components/Header/HeaderTests/ToolbarToggle.test.js:42-71 is indeed flaky. Here's why:

### Root Cause
  The flakiness occurs on lines 64-69:
```typescript
  // wait for async actions on toggle to complete
  await waitFor(async () => {
    for (const item of expectedTexts) {
      expect(screen.queryByText(item.title)).not.toBeInTheDocument();
    }
  });
```

### The Problem:

  1. The ToolbarToggle component uses PatternFly's Dropdown component, which may have CSS animations or asynchronous DOM updates when closing
  2. When the toggle button is clicked to close the menu (line 61), the isOpen state changes immediately, but the DOM elements may not be removed instantly
  3. The waitFor utility expects a condition to eventually become true, but the loop with multiple assertions creates a race condition:
    - If the menu items haven't been fully removed from the DOM yet when waitFor first checks, the first expect(...).not.toBeInTheDocument() throws
    - waitFor retries, but depending on timing, it might still catch the items mid-removal
  4. The commented-out line 70 (// expect(container.querySelectorAll('.pf-v6-c-menu__list-item')).toHaveLength(0);) suggests previous attempts to fix this
 
### Why It's Intermittent
  - Fast machines/conditions: DOM updates complete before waitFor checks → test passes
  - Slow machines/conditions: DOM elements still present during first waitFor check → test fails
  - The timing depends on CPU speed, React rendering, and PatternFly's internal animations

**Recommendation:** The test needs to be rewritten to properly wait for the DOM elements to be removed, possibly by:
  1. Using waitForElementToBeRemoved instead of waitFor with assertions
  2. Checking a single condition rather than looping through multiple items
  3. Potentially increasing the timeout or ensuring proper cleanup

## Summary by Sourcery

Bug Fixes:
- Reduce flakiness in the ToolbarToggle header test by changing the wait logic to assert item absence in a single waitFor callback without an async loop.