### PR TITLE
Intercom module styling to fix width

### DIFF
--- a/src/components/OpenShiftIntercom/OpenShiftIntercom.scss
+++ b/src/components/OpenShiftIntercom/OpenShiftIntercom.scss
@@ -1,5 +1,6 @@
-.chr-button-intercom {
-  border-radius: var(--pf-t--global--border--radius--small);
+button.pf-v6-c-button.chr-button-intercom {
+  border-radius: 50%;
+  min-width: 2rem;
   height: 2rem;
   aspect-ratio: 1 / 1;
   padding: 0;


### PR DESCRIPTION
![in](https://github.com/user-attachments/assets/ca6222b0-6160-4686-9293-c48bf900cb71)

The styling wasn't overriding the patternfly defaults (and button wasn't a proper circle).

## Summary by Sourcery

Enhancements:
- Scope the Intercom button styles to the PatternFly button element and enforce a circular shape with fixed dimensions.