### PR TITLE
feat(help): add sparkle icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18178,7 +18178,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -268,6 +268,8 @@ const Tools = () => {
       });
     };
 
+    const iconAskRedHat = '/apps/frontend-assets/technology-icons/ai-chat-ask-redhat.svg';
+
     return (
       <Tooltip
         aria="none"
@@ -278,7 +280,7 @@ const Tools = () => {
       >
         <Button
           variant="control"
-          icon={<QuestionCircleIcon />}
+          icon={isPreview ? iconAskRedHat : <QuestionCircleIcon />}
           id="HelpPanelToggle"
           ouiaId="chrome-help-panel"
           aria-label="Toggle help panel"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-42924

## Summary by Sourcery

New Features:
- Introduce an Ask Red Hat AI chat sparkle icon asset for the help panel toggle in preview environments.