### PR TITLE
Replace sparkle icon string

### DIFF
--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -1,0 +1,4 @@
+.chr-c-ask-redhat-icon {
+  width: 1em;
+  height: 1em;
+}

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -27,6 +27,7 @@ import { drawerPanelContentAtom } from '../../state/atoms/drawerPanelContentAtom
 import { Label } from '@patternfly/react-core/dist/dynamic/components/Label';
 import UsersIcon from '@patternfly/react-icons/dist/dynamic/icons/users-icon';
 import InternalChromeContext from '../../utils/internalChromeContext';
+import './Tools.scss';
 
 const InternalButton = () => (
   <Button
@@ -268,7 +269,7 @@ const Tools = () => {
       });
     };
 
-    const iconAskRedHat = '/apps/frontend-assets/technology-icons/ai-chat-ask-redhat.svg';
+    const AskRedHatIcon = () => <img src="/apps/frontend-assets/technology-icons/ai-chat-ask-redhat.svg" alt="Ask Red Hat" className="chr-c-ask-redhat-icon" />;
 
     return (
       <Tooltip
@@ -280,7 +281,7 @@ const Tools = () => {
       >
         <Button
           variant="control"
-          icon={isPreview ? iconAskRedHat : <QuestionCircleIcon />}
+          icon={isPreview ? <AskRedHatIcon /> : <QuestionCircleIcon />}
           id="HelpPanelToggle"
           ouiaId="chrome-help-panel"
           aria-label="Toggle help panel"


### PR DESCRIPTION
For [RHCLOUD-44720](https://issues.redhat.com/browse/RHCLOUD-44720)

It sparkles now
<img width="222" height="73" alt="image" src="https://github.com/user-attachments/assets/df53f93a-e6bf-4580-a25c-67701c80dacc" />

## Summary by Sourcery

Enhancements:
- Introduce a dedicated Ask Red Hat icon component with consistent sizing via a new SCSS style.