### PR TITLE
feat(permissions): VisibilitySingleton wildcard support

### DIFF
--- a/docs/wildcard-permissions.md
+++ b/docs/wildcard-permissions.md
@@ -1,0 +1,50 @@
+# Wildcard Permission Matching
+
+## Overview
+
+The Chrome visibility functions now support wildcard pattern matching for permission validation. This allows broader permissions to properly cover more specific permission requirements.
+
+## How It Works
+
+Permissions are split by the `:` delimiter into segments. The wildcard character `*` can be used in any segment to match any value in that position.
+
+### Pattern Matching Rules
+
+1. Both the user permission and required permission must have the same number of segments
+2. Each segment is compared individually
+3. A `*` wildcard matches any value in that position
+4. If all segments match (considering wildcards), the permission is granted
+
+## Examples
+
+### Full Wildcard
+
+User has permission: `rbac:*:*`
+
+**Matches:**
+- `rbac:inventory:read` ✅
+- `rbac:inventory:write` ✅
+- `rbac:cost-management:read` ✅
+- `rbac:cost-management:write` ✅
+
+**Does not match:**
+- `rbac:inventory` ❌ (different segment count)
+- `other:inventory:read` ❌ (first segment doesn't match)
+
+### Middle Wildcard
+
+User has permission: `rbac:*:read`
+
+**Matches:**
+- `rbac:inventory:read` ✅
+- `rbac:cost-management:read` ✅
+- `rbac:any-service:read` ✅
+
+### Last Wildcard
+
+User has permission: `rbac:inventory:*`
+
+**Matches:**
+- `rbac:inventory:read` ✅
+- `rbac:inventory:write` ✅
+- `rbac:inventory:delete` ✅


### PR DESCRIPTION
Take into account wildcard perms. Tested with rbac-ui locally and it works.

<img width="1919" height="1052" alt="Screenshot from 2026-02-06 15-36-44" src="https://github.com/user-attachments/assets/17e0a744-2e5c-46ee-9135-faad36b82a21" />

https://redhat-internal.slack.com/archives/C05KTHJU4R4/p1770327795107349

https://issues.redhat.com/browse/RHCLOUD-44872

## Summary by Sourcery

Add wildcard-aware permission matching to visibility utilities so broader RBAC permissions can satisfy specific checks.

New Features:
- Support wildcard-based matching in permission checks used by visibility functions, allowing patterns like rbac:*:* to cover multiple specific permissions.

Documentation:
- Document the wildcard permission matching behavior and rules in a new wildcard-permissions guide.

Tests:
- Expand VisibilitySingleton tests to cover wildcard permission scenarios for both loosePermissions and hasPermissions, including positive and negative cases.