### PR TITLE
Add e2e test for OIDC scope re-authentication flow

### DIFF
--- a/playwright/e2e/release-gate/RUNNING_SCOPE_REAUTH_TEST.md
+++ b/playwright/e2e/release-gate/RUNNING_SCOPE_REAUTH_TEST.md
@@ -1,0 +1,189 @@
+# Running the OIDC Scope Re-authentication Test
+
+## Quick Start
+
+The test is ready to run for the **Identity Provider Integration** link from the Settings gear menu.
+
+### Prerequisites
+
+1. Set environment variables:
+```bash
+export E2E_USER="your-test-account@redhat.com"
+export E2E_PASSWORD="your-password"
+```
+
+2. Ensure the dev server is running or use the stage environment
+
+### Run the Test
+
+```bash
+# Run in headless mode (fast, no browser window)
+npm run playwright -- scope-reauth.spec.ts
+
+# Run in headed mode (see the browser, recommended for first run)
+npm run playwright:headed -- scope-reauth.spec.ts
+
+# Run in debug mode (step through the test)
+npm run playwright:debug -- scope-reauth.spec.ts
+
+# Run in UI mode (interactive, great for exploration)
+npm run playwright:ui
+```
+
+## What the Test Does
+
+### Test 1: Navigation-triggered Re-auth (Identity Provider Integration)
+
+1. ✅ Logs in to the dashboard with initial scopes
+2. ✅ Clicks the Settings gear icon in the header
+3. ✅ Clicks "Identity Provider Integration" from the dropdown
+4. ✅ Monitors for SSO redirect (to add `api.iam.organization` scope)
+5. ✅ Verifies successful navigation to the IAM page
+6. ✅ Confirms the scope was added to localStorage
+7. ✅ Logs the complete redirect flow
+
+### Test 2: Programmatic Re-auth
+
+1. ✅ Logs in to the dashboard
+2. ✅ Programmatically calls `chrome.auth.reAuthWithScopes('offline_access')`
+3. ✅ Monitors for SSO redirect
+4. ✅ Verifies the `offline_access` scope was added
+
+## Expected Output
+
+When re-authentication occurs, you'll see output like this:
+
+```
+Initial scopes: ["openid", "api.console", "api.ask_red_hat"]
+Initial URL: https://stage.foo.redhat.com:1337/
+
+=== Redirect Flow ===
+URLs visited during navigation:
+1. https://stage.foo.redhat.com:1337/iam/authentication-policy/identity-provider-integration
+2. https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth?client_id=cloud-services&scope=openid%20api.console%20api.ask_red_hat%20api.iam.organization&...
+3. https://sso.stage.redhat.com/auth/realms/redhat-external/login-actions/authenticate?...
+4. https://stage.foo.redhat.com:1337/iam/authentication-policy/identity-provider-integration
+
+=== SSO-related Requests ===
+1. https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth?...
+2. https://sso.stage.redhat.com/auth/realms/redhat-external/login-actions/authenticate?...
+
+Final scopes: ["openid", "api.console", "api.ask_red_hat", "api.iam.organization"]
+IAM organization scope present: true
+✓ Re-authentication redirect detected
+```
+
+## What to Look For
+
+### ✅ Success Indicators
+
+1. **Initial scopes**: Should be the base scopes from login (e.g., `openid`, `api.console`, `api.ask_red_hat`)
+2. **Redirect flow**: Should show at least 3-4 URLs:
+   - Destination page
+   - SSO authentication URL
+   - SSO login-actions URL
+   - Back to destination page
+3. **Final scopes**: Should include `api.iam.organization` in addition to initial scopes
+4. **SSO requests**: Should capture requests to `sso.stage.redhat.com/auth/realms/`
+5. **Final URL**: Should be `/iam/authentication-policy/identity-provider-integration`
+
+### ⚠️ No Re-auth Scenario
+
+If you see:
+```
+ℹ No re-auth needed - user already had required scopes
+```
+
+This means the test account already has the `api.iam.organization` scope from a previous session. This is **not a failure** - it just means the scope was already present. The test will still verify:
+- Navigation succeeded
+- The scope is present in localStorage
+- The page loaded correctly
+
+## Debugging
+
+### Test fails with timeout waiting for SSO
+
+**Possible causes:**
+1. User already has the required scopes (not an error - see "No Re-auth Scenario" above)
+2. The Settings gear button selector changed
+3. The link text changed
+
+**Solution:**
+Run in debug mode to see what's happening:
+```bash
+npm run playwright:debug -- scope-reauth.spec.ts
+```
+
+### Can't find "Settings menu" button
+
+The Settings gear might not be visible on smaller viewports. The test runs in desktop viewport by default (1280x720), but you can verify:
+
+```typescript
+// Add this to see the viewport
+console.log(await page.viewportSize());
+```
+
+### Link not found in dropdown
+
+Verify the link exists and is not hidden. Note that "Identity Provider Integration" is:
+- Only visible in **non-IT-Less environments**
+- Located under "Identity and Access Management" section
+- May require org admin privileges (check user permissions)
+
+### SSO redirect happens too fast to catch
+
+This is actually good - it means re-auth is working. The test captures the URLs even if the redirect is very fast.
+
+## Verifying in the Browser Manually
+
+To manually verify the re-auth flow:
+
+1. Open Chrome DevTools
+2. Go to Application → Local Storage
+3. Find the key `@chrome/login-scopes`
+4. Note the current scopes
+5. Navigate to Settings gear → Identity Provider Integration
+6. Check if scopes were updated with `api.iam.organization`
+
+You can also watch the Network tab filtered to `sso.stage.redhat.com` to see the auth requests.
+
+## CI/CD Integration
+
+Add to your CI pipeline:
+
+```yaml
+- name: Run scope re-auth tests
+  run: npm run playwright -- scope-reauth.spec.ts
+  env:
+    E2E_USER: ${{ secrets.E2E_USER }}
+    E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+```
+
+## Troubleshooting Specific Errors
+
+### Error: "Unable to find role=button with name=Settings menu"
+
+The settings button might be using a different aria-label. Check `src/components/Header/Tools.tsx`:
+- Line 54: `ariaLabel="Settings menu"`
+- Or use the OUIA ID: `ouiaId="chrome-settings"`
+
+Alternative selector:
+```typescript
+await page.getByRole('button', { name: /Settings/i }).click();
+// or
+await page.locator('[ouia-id="chrome-settings"]').click();
+```
+
+### Error: "Unable to find role=link with name=Identity Provider Integration"
+
+Verify:
+1. The link is visible (not hidden by feature flag or IT-Less check)
+2. The exact text hasn't changed in the UI
+3. The dropdown is open before clicking the link
+
+## Additional Resources
+
+- **Full Guide**: See `SCOPE_REAUTH_TEST_GUIDE.md` for detailed customization instructions
+- **Auth Code**: See `src/auth/shouldReAuthScopes.ts` for the re-auth logic
+- **Module Config**: See the IAM module config showing required scopes
+- **Other Playwright Tests**: See other `*.spec.ts` files in this directory for examples

--- a/playwright/e2e/release-gate/SCOPE_REAUTH_TEST_GUIDE.md
+++ b/playwright/e2e/release-gate/SCOPE_REAUTH_TEST_GUIDE.md
@@ -1,0 +1,257 @@
+# OIDC Scope Re-authentication E2E Test Guide
+
+## Overview
+
+The `scope-reauth.spec.ts` test file contains e2e tests that verify the OIDC scope expansion and re-authentication flow. This guide explains how to customize and use these tests.
+
+## Test Scenarios Covered
+
+### 1. Navigation-triggered Re-authentication
+Tests the scenario where navigating to a page/module requiring additional OIDC scopes triggers automatic re-authentication.
+
+**Flow:**
+1. User logs in with base scopes
+2. User navigates to a link/page requiring additional scopes
+3. System detects missing scopes via `shouldReAuthScopes()`
+4. System redirects to SSO for re-authentication with expanded scopes
+5. User is redirected back to the destination page
+6. Scopes are updated in localStorage
+
+### 2. Programmatic Re-authentication
+Tests calling `chrome.auth.reAuthWithScopes()` directly.
+
+**Flow:**
+1. User logs in
+2. Application code calls `window.insights.chrome.auth.reAuthWithScopes('scope-name')`
+3. Re-auth redirect occurs
+4. Scopes are expanded
+
+## Test Configuration
+
+The test is **already configured** to test the **Identity Provider Integration** link from the Settings gear menu, which requires the `api.iam.organization` scope.
+
+## Customizing for Other Scenarios
+
+If you want to test a different link or scope, here's how:
+
+### Step 1: Identify the Navigation Link
+
+Find the specific link, button, or navigation action that triggers re-auth in your UI. Examples:
+
+```typescript
+// Option 1: Click a link from a dropdown menu
+await page.getByRole('button', { name: 'Settings menu' }).click();
+await page.getByRole('link', { name: 'Link Name' }).click();
+
+// Option 2: Click a button
+await page.getByRole('button', { name: 'Access Feature' }).click();
+
+// Option 3: Navigate directly to a URL (less realistic)
+await page.goto('/settings/subscriptions');
+
+// Option 4: Click by test ID (if available)
+await page.getByTestId('nav-link-id').click();
+```
+
+### Step 2: Update the Destination Path
+
+Replace the path in the test:
+
+```typescript
+// CURRENT (configured for Identity Provider Integration)
+const destinationPath = '/iam/authentication-policy/identity-provider-integration';
+
+// EXAMPLE - Change to test a different page
+const destinationPath = '/settings/integrations/aws';
+```
+
+### Step 3: Update the Navigation Trigger
+
+Replace the navigation action:
+
+```typescript
+// CURRENT (configured for Settings gear → Identity Provider Integration)
+await page.getByRole('button', { name: 'Settings menu' }).click();
+await page.getByRole('link', { name: 'Identity Provider Integration' }).click();
+
+// EXAMPLE - Direct link click
+await page.getByRole('link', { name: 'AWS Integration' }).click();
+```
+
+### Step 4: Update the Scope Verification
+
+Update the expected scope if testing a different feature:
+
+```typescript
+// CURRENT (checking for IAM scope)
+const hasIamScope = finalScopes.includes('api.iam.organization');
+
+// EXAMPLE - Check for partner scope
+const hasPartnerScope = finalScopes.includes('api.partner_link.aws');
+```
+
+## What the Test Verifies
+
+### 1. URL Tracking
+The test tracks all URLs visited during the navigation:
+- Initial URL (dashboard)
+- SSO redirect URL (sso.stage.redhat.com)
+- Final destination URL
+
+### 2. Request Monitoring
+Captures all requests to SSO endpoints:
+- Authorization requests (`/auth/realms/...`)
+- Token endpoint requests
+- Keycloak authentication flows
+
+### 3. Scope Validation
+Compares scopes before and after navigation:
+```typescript
+const initialScopes = ['openid', 'api.console']; // Example
+const finalScopes = ['openid', 'api.console', 'offline_access']; // Example
+```
+
+### 4. Re-auth Detection
+Verifies that:
+- SSO redirect occurred (if scopes were missing)
+- Auth realm requests were made
+- User returned to the correct destination
+- localStorage was updated with new scopes
+
+## Understanding the Output
+
+The test logs detailed information:
+
+```
+Initial scopes: ["openid", "api.console", "api.ask_red_hat"]
+Initial URL: https://stage.foo.redhat.com:1337/
+
+=== Redirect Flow ===
+URLs visited during navigation:
+1. https://stage.foo.redhat.com:1337/settings/subscriptions
+2. https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth?client_id=cloud-services&...
+3. https://stage.foo.redhat.com:1337/settings/subscriptions
+
+=== SSO-related Requests ===
+1. https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth?...
+2. https://sso.stage.redhat.com/auth/realms/redhat-external/login-actions/authenticate?...
+
+Final scopes: ["openid", "api.console", "api.ask_red_hat", "offline_access"]
+✓ Re-authentication redirect detected
+```
+
+## Running the Tests
+
+```bash
+# Run all scope re-auth tests
+npm run playwright -- scope-reauth.spec.ts
+
+# Run in headed mode (visible browser)
+npm run playwright:headed -- scope-reauth.spec.ts
+
+# Run in debug mode (step through)
+npm run playwright:debug -- scope-reauth.spec.ts
+
+# Run in UI mode (interactive)
+npm run playwright:ui
+```
+
+## Common Scenarios to Test
+
+### Scenario 1: Identity Provider Integration (Implemented)
+The IAM module requires `api.iam.organization` scope. The test is already configured for this:
+
+```typescript
+const destinationPath = '/iam/authentication-policy/identity-provider-integration';
+
+// Click the Settings gear button
+await page.getByRole('button', { name: 'Settings menu' }).click();
+
+// Click the link in the dropdown
+await page.getByRole('link', { name: 'Identity Provider Integration' }).click();
+
+// Expected scope: 'api.iam.organization'
+```
+
+### Scenario 2: Authentication Factors
+Similar to Identity Provider Integration, requires the same IAM scope:
+
+```typescript
+const destinationPath = '/iam/authentication-policy/authentication-factors';
+await page.getByRole('button', { name: 'Settings menu' }).click();
+await page.getByRole('link', { name: 'Authentication Factors' }).click();
+// Should add scope: 'api.iam.organization'
+```
+
+### Scenario 3: Partner Integration Links
+Partner links (AWS, Azure, GCP) may require partner-specific scopes:
+
+```typescript
+const destinationPath = '/settings/integrations/aws';
+await page.getByRole('link', { name: 'AWS Integration' }).click();
+// Should add scope: 'api.partner_link.aws'
+```
+
+### Scenario 4: API Access Token Generation
+Requesting offline tokens for API access:
+
+```typescript
+// This is already implemented in test #2
+await window.insights.chrome.auth.reAuthWithScopes('offline_access');
+```
+
+## Troubleshooting
+
+### Test Times Out Waiting for SSO Redirect
+**Cause**: User already has the required scopes
+**Solution**: The test handles this gracefully - check console output for "No re-auth needed"
+
+### SSO Redirect Detected but Returns to Wrong Page
+**Cause**: Incorrect destination path
+**Solution**: Verify the `destinationPath` variable matches where the app actually redirects
+
+### Scopes Not Updated in localStorage
+**Cause**: Re-auth may have failed or been cancelled
+**Solution**: Check the SSO request URLs in the console output for errors
+
+### Request Tracking Shows No SSO Requests
+**Cause**: Either no re-auth occurred, or the event listener wasn't set up in time
+**Solution**: Ensure tracking is set up before navigation happens
+
+## Environment Variables Required
+
+The test uses the same environment variables as other e2e tests:
+
+```bash
+E2E_USER=your-test-account@redhat.com
+E2E_PASSWORD=your-password
+```
+
+## Integration with CI/CD
+
+Add to your test suite:
+
+```json
+// package.json
+{
+  "scripts": {
+    "test:scope-reauth": "playwright test scope-reauth.spec.ts"
+  }
+}
+```
+
+## Related Files
+
+- **Auth utilities**: `src/auth/shouldReAuthScopes.ts`
+- **OIDC connector**: `src/auth/OIDCConnector/OIDCSecured.tsx`
+- **Login function**: `src/auth/OIDCConnector/utils.ts`
+- **Scope hook**: `src/hooks/useUserSSOScopes.ts`
+- **Chrome API**: `src/chrome/create-chrome.ts`
+
+## Additional Notes
+
+- The test uses Playwright's `page.on('framenavigated')` to track all URL changes
+- SSO URLs are environment-specific (stage, qa, prod)
+- Scopes are stored in localStorage under the key `@chrome/login-scopes`
+- The re-auth flow maintains the user's session - they don't need to re-enter credentials
+- Silent token renewal uses a different endpoint (`/silent-check-sso.html`)

--- a/playwright/e2e/release-gate/scope-reauth.spec.ts
+++ b/playwright/e2e/release-gate/scope-reauth.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../../helpers/auth';
+
+/**
+ * Tests for OIDC scope re-authentication flow.
+ *
+ * These tests verify that when a user navigates to a page requiring additional
+ * OIDC scopes, the system correctly:
+ * 1. Detects missing scopes
+ * 2. Redirects to SSO for re-authentication
+ * 3. Adds the required scopes to the session
+ * 4. Redirects back to the destination page
+ *
+ * Example: The IAM module requires 'api.iam.organization' scope, which may not
+ * be present in the initial login. Navigating to Identity Provider Integration
+ * should trigger re-auth to add this scope.
+ */
+
+test.describe('OIDC Scope Re-authentication', () => {
+  test('should re-authenticate with additional scopes when navigating to Identity Provider Integration', async ({ page }) => {
+    // Array to track all URLs during the redirect process
+    const redirectUrls: string[] = [];
+    const requestUrls: string[] = [];
+
+    // Track all navigation events
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) {
+        redirectUrls.push(frame.url());
+      }
+    });
+
+    // Track SSO-related requests
+    page.on('request', (request) => {
+      const url = request.url();
+      // Track requests to SSO and token endpoints
+      if (url.includes('sso.stage.redhat.com') || url.includes('/auth/realms/')) {
+        requestUrls.push(url);
+      }
+    });
+
+    // Step 1: Login and land on the dashboard
+    await login(page);
+    await expect(page).toHaveURL('/');
+
+    // Verify initial login completed
+    const userMenu = page.getByRole('button', { name: /User Avatar/ });
+    await expect(userMenu).toBeVisible();
+
+    // Get initial scopes from localStorage
+    const initialScopes = await page.evaluate(() => {
+      const scopes = localStorage.getItem('@chrome/login-scopes');
+      return scopes ? JSON.parse(scopes) : [];
+    });
+
+    console.log('Initial scopes:', initialScopes);
+    console.log('Initial URL:', page.url());
+
+    // Clear the tracking arrays after initial login
+    redirectUrls.length = 0;
+    requestUrls.length = 0;
+
+    // Step 2: Navigate to Identity Provider Integration from the Settings gear menu
+    // This link requires the 'api.iam.organization' scope
+    const destinationPath = '/iam/authentication-policy/identity-provider-integration';
+
+    // Click the Settings gear button in the header
+    await page.getByRole('button', { name: 'Settings menu' }).click();
+
+    // Click on "Identity Provider Integration" link in the dropdown
+    await page.getByRole('link', { name: 'Identity Provider Integration' }).click();
+
+    // Step 3: Wait for potential re-auth redirect to complete
+    // The re-auth flow will redirect to SSO and then back
+    // We need to wait for the final destination to load
+
+    // Wait for either:
+    // - The destination page to load (if scopes already present)
+    // - SSO redirect to happen and complete (if re-auth needed)
+    try {
+      // Wait for SSO redirect if it happens (will go to sso.stage.redhat.com)
+      await page.waitForURL('**/sso.stage.redhat.com/**', { timeout: 5000 });
+      console.log('Detected SSO redirect - re-auth is happening');
+
+      // Wait for redirect back to the destination
+      await page.waitForURL(destinationPath, { timeout: 30000 });
+    } catch (error) {
+      // If no SSO redirect, either scopes were already present or navigation was direct
+      console.log('No SSO redirect detected - checking if already at destination');
+    }
+
+    // Verify we ended up at the correct destination
+    await expect(page).toHaveURL(destinationPath);
+
+    // Step 4: Verify scopes were updated (if re-auth occurred)
+    const finalScopes = await page.evaluate(() => {
+      const scopes = localStorage.getItem('@chrome/login-scopes');
+      return scopes ? JSON.parse(scopes) : [];
+    });
+
+    console.log('Final scopes:', finalScopes);
+
+    // Verify that scopes have potentially expanded
+    // (This depends on what additional scopes the destination requires)
+    expect(finalScopes.length).toBeGreaterThanOrEqual(initialScopes.length);
+
+    // Step 5: Verify the api.iam.organization scope was added
+    const hasIamScope = finalScopes.includes('api.iam.organization');
+    console.log(`IAM organization scope present: ${hasIamScope}`);
+
+    // Step 6: Analyze the redirect flow
+    console.log('\n=== Redirect Flow ===');
+    console.log('URLs visited during navigation:');
+    redirectUrls.forEach((url, index) => {
+      console.log(`${index + 1}. ${url}`);
+    });
+
+    console.log('\n=== SSO-related Requests ===');
+    requestUrls.forEach((url, index) => {
+      console.log(`${index + 1}. ${url}`);
+    });
+
+    // Assertions to verify re-auth happened correctly
+    if (redirectUrls.length > 1) {
+      // If there were redirects, verify the flow went through SSO
+      const hasSSoRedirect = redirectUrls.some(url => url.includes('sso.stage.redhat.com'));
+      const hasAuthRealm = requestUrls.some(url => url.includes('/auth/realms/'));
+
+      if (hasSSoRedirect) {
+        console.log('✓ Re-authentication redirect detected');
+        expect(hasSSoRedirect).toBe(true);
+        expect(hasAuthRealm).toBe(true);
+        expect(hasIamScope).toBe(true); // Verify the IAM scope was added
+
+        // Verify the redirect flow pattern:
+        // 1. Started at destination
+        // 2. Redirected to SSO
+        // 3. Came back to destination
+        const lastUrl = redirectUrls[redirectUrls.length - 1];
+        expect(lastUrl).toContain(destinationPath);
+      } else {
+        console.log('ℹ No re-auth needed - user already had required scopes');
+        // Even if no redirect, the scope should be present
+        expect(hasIamScope).toBe(true);
+      }
+    } else {
+      // If only one URL (direct navigation), scope should still be present
+      expect(hasIamScope).toBe(true);
+    }
+
+    // Verify the page is fully loaded and functional
+    await expect(userMenu).toBeVisible();
+  });
+
+  test('should programmatically trigger re-auth via chrome.auth.reAuthWithScopes', async ({ page }) => {
+    // Track redirect URLs
+    const redirectUrls: string[] = [];
+
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) {
+        redirectUrls.push(frame.url());
+      }
+    });
+
+    // Login first
+    await login(page);
+    await expect(page).toHaveURL('/');
+
+    // Get initial scopes
+    const initialScopes = await page.evaluate(() => {
+      const scopes = localStorage.getItem('@chrome/login-scopes');
+      return scopes ? JSON.parse(scopes) : [];
+    });
+
+    console.log('Initial scopes:', initialScopes);
+
+    // Clear redirect tracking
+    redirectUrls.length = 0;
+
+    // Programmatically request additional scope
+    // This simulates what a micro-frontend module might do
+    const reAuthPromise = page.evaluate(async () => {
+      // @ts-ignore - chrome is globally available
+      await window.insights.chrome.auth.reAuthWithScopes('offline_access');
+    });
+
+    // Wait for SSO redirect
+    await page.waitForURL('**/sso.stage.redhat.com/**', { timeout: 10000 });
+    console.log('Detected SSO redirect for scope expansion');
+
+    // Wait for return to original page
+    await page.waitForURL('/', { timeout: 30000 });
+
+    // Wait for the promise to resolve
+    await reAuthPromise;
+
+    // Verify scopes were updated
+    const finalScopes = await page.evaluate(() => {
+      const scopes = localStorage.getItem('@chrome/login-scopes');
+      return scopes ? JSON.parse(scopes) : [];
+    });
+
+    console.log('Final scopes:', finalScopes);
+    console.log('Redirect flow:', redirectUrls);
+
+    // Verify offline_access scope was added
+    expect(finalScopes).toContain('offline_access');
+    expect(finalScopes.length).toBeGreaterThan(initialScopes.length);
+
+    // Verify redirect happened
+    const hasSSoRedirect = redirectUrls.some(url => url.includes('sso.stage.redhat.com'));
+    expect(hasSSoRedirect).toBe(true);
+  });
+});


### PR DESCRIPTION
This commit adds comprehensive e2e tests for verifying the OIDC scope expansion and re-authentication flow when users navigate to pages requiring additional scopes.

Test Coverage:
- Navigation-triggered re-auth (Identity Provider Integration link)
- Programmatic re-auth via chrome.auth.reAuthWithScopes()
- URL redirect flow tracking during re-auth
- SSO request monitoring
- Scope validation in localStorage

The test is specifically configured to test the Settings gear → Identity Provider Integration link, which requires the 'api.iam.organization' scope.

Files added:
- scope-reauth.spec.ts: Main test file with two test scenarios
- RUNNING_SCOPE_REAUTH_TEST.md: Quick start guide for running the tests
- SCOPE_REAUTH_TEST_GUIDE.md: Detailed customization guide

## Summary by Sourcery

Add end-to-end coverage and documentation for the OIDC scope re-authentication flow used when navigating to features that require additional scopes.

New Features:
- Introduce an e2e Playwright test that exercises OIDC scope expansion and re-authentication via navigation and programmatic APIs.

Documentation:
- Add a detailed guide describing how the OIDC scope re-authentication e2e tests work and how to customize them for different scopes and entry points.
- Add a quick-start guide for running the OIDC scope re-authentication Playwright test locally and in CI.

Tests:
- Add a Playwright spec file to validate navigation-triggered and programmatic OIDC scope re-authentication, including URL redirects, SSO requests, and scope updates.