### PR TITLE
fix(e2e): fix E2E test infrastructure and reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ cypress/downloads
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/.playwright-mcp
 
 .mcp.json

--- a/.tekton/insights-chrome-pull-request.yaml
+++ b/.tekton/insights-chrome-pull-request.yaml
@@ -346,11 +346,11 @@ spec:
             echo "Dev server is ready! Running tests."
 
             echo "Running cypress (partial) integration tests"
-            KONFLUX_RUN=$KONFLUX_RUN NO_COLOR=1 E2E_USER=$CHROME_ACCOUNT E2E_PASSWORD=$CHROME_PASSWORD npx cypress run --spec "cypress/e2e/**/*"
+            KONFLUX_RUN=$KONFLUX_RUN NO_COLOR=1 E2E_USER="$CHROME_ACCOUNT" E2E_PASSWORD="$CHROME_PASSWORD" npx cypress run --spec "cypress/e2e/**/*"
 
             echo "Running Playwright User flow tests (full integration)"
             npx playwright install
-            E2E_USER=$CHROME_ACCOUNT E2E_PASSWORD=$CHROME_PASSWORD npx playwright test
+            E2E_USER="$CHROME_ACCOUNT" E2E_PASSWORD="$CHROME_PASSWORD" npx playwright test
             echo "Tests finished. Killing dev server (PID: $DEV_SERVER_PID)..."
             kill $DEV_SERVER_PID
           securityContext:

--- a/.tekton/run-tests-task.yml
+++ b/.tekton/run-tests-task.yml
@@ -84,4 +84,4 @@ spec:
             set -ex
 
             npm i
-            E2E_BASE=$EE_HOSTNAME E2E_USER=$EE_USERNAME E2E_PASSWORD=$EE_PASSWORD npm run test:e2e
+            E2E_BASE="$EE_HOSTNAME" E2E_USER="$EE_USERNAME" E2E_PASSWORD="$EE_PASSWORD" npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -37,7 +37,38 @@ npm run build --watch
 3. Running tests
 
 ```sh
+# Unit tests (Jest)
 npm run test
+
+# Component tests (Cypress)
+npm run test:ct
+```
+
+4. Running E2E tests
+
+E2E tests require a running dev server and a stage test account (create one via [Ethel](https://account-manager-stage.app.eng.rdu2.redhat.com/#create)).
+
+```sh
+# Start the dev server first
+npm run dev
+
+# Cypress (interactive)
+E2E_USER=<username> E2E_PASSWORD="<password>" npx cypress open --e2e
+
+# Cypress (headless)
+E2E_USER=<username> E2E_PASSWORD="<password>" npx cypress run --e2e
+
+# Cypress (single spec — spec.cy.ts must run first to create the login session)
+E2E_USER=<username> E2E_PASSWORD="<password>" npx cypress run --e2e --spec cypress/e2e/spec.cy.ts,cypress/e2e/ephemeral/init-flow.cy.ts
+
+# Playwright
+E2E_USER=<username> E2E_PASSWORD="<password>" npx playwright test
+```
+
+The CI wrapper starts its own dev server — don't run with a dev server already running:
+
+```sh
+CHROME_ACCOUNT=<username> CHROME_PASSWORD="<password>" npm run ci:cypress-e2e-tests
 ```
 
 ## Running chrome locally

--- a/cypress/e2e/auth/OIDC/OIDCState.cy.ts
+++ b/cypress/e2e/auth/OIDC/OIDCState.cy.ts
@@ -7,7 +7,9 @@ describe.skip('OIDC State', () => {
     // should pass normally
     cy.visit('/');
 
-    cy.contains('Insights QA').should('exist');
+    cy.getUserFullName().then((name) => {
+      cy.contains(name).should('exist');
+    });
 
     // Introduce broken state in URL
 
@@ -31,7 +33,9 @@ describe.skip('OIDC State', () => {
       const url = new URL(win.location.href);
       expect(url.pathname).to.eq('/foo/bar');
       expect(url.search).to.eq('?baz=quaz');
-      cy.contains('Insights QA').should('exist');
+      cy.getUserFullName().then((name) => {
+        cy.contains(name).should('exist');
+      });
     });
   });
 });

--- a/cypress/e2e/ephemeral/init-flow.cy.ts
+++ b/cypress/e2e/ephemeral/init-flow.cy.ts
@@ -5,7 +5,11 @@ describe('Should login and initialize the app', () => {
 
   it('should load the app', () => {
     cy.visit('/');
-    // should find the dropdown menu with the name
-    cy.contains('Insights QA').should('exist');
+    // wait for Chrome to fully initialize
+    cy.contains('h2', 'Welcome to your Hybrid Cloud Console').should('be.visible');
+    // verify the user menu shows the logged-in user's full name
+    cy.getUserFullName().then((name) => {
+      cy.contains(name).should('exist');
+    });
   });
 });

--- a/cypress/e2e/release-gate/refresh-token.cy.ts
+++ b/cypress/e2e/release-gate/refresh-token.cy.ts
@@ -1,18 +1,14 @@
-// Landing page has changed
 describe('Auth', () => {
-  // skipped because test is broken as of August 4, 2025
   it('should force refresh token', () => {
     cy.login();
-    cy.intercept('POST', 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token').as('tokenRefresh');
     cy.visit('/');
-    // initial token request
-    cy.wait('@tokenRefresh');
 
     // wait for chrome to init
     cy.contains('h2', 'Welcome to your Hybrid Cloud Console').should('be.visible');
-    // intercept it after initial load
-    // force token refresh
-    cy.wait(1000);
+
+    // set up intercept THEN trigger refresh — no race condition
+    cy.intercept('POST', 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token').as('tokenRefresh');
+
     cy.window().then((win) => {
       win.insights.chrome.$internal.forceAuthRefresh();
     });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -36,6 +36,35 @@
 //   }
 // }
 
+Cypress.Commands.add('getUserFullName', () => {
+  return cy.window().then((win) => {
+    const oidcKey = Object.keys(win.localStorage).find((key) => key.startsWith('oidc.user:'));
+    if (!oidcKey) {
+      throw new Error('OIDC user key was not found in localStorage');
+    }
+
+    const rawUser = win.localStorage.getItem(oidcKey);
+    if (!rawUser) {
+      throw new Error(`OIDC user payload missing for key: ${oidcKey}`);
+    }
+
+    let parsedUser: { profile?: { first_name?: string; last_name?: string } };
+    try {
+      parsedUser = JSON.parse(rawUser);
+    } catch {
+      throw new Error(`OIDC user payload is not valid JSON for key: ${oidcKey}`);
+    }
+
+    const firstName = parsedUser.profile?.first_name;
+    const lastName = parsedUser.profile?.last_name;
+    if (!firstName || !lastName) {
+      throw new Error('OIDC profile is missing first_name and/or last_name');
+    }
+
+    return `${firstName} ${lastName}`;
+  });
+});
+
 Cypress.Commands.add('login', () => {
   cy.session(
     `login-${Cypress.env('E2E_USER')}`,

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -22,6 +22,12 @@ import 'cypress-localstorage-commands';
 // require('./commands')
 
 declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(): Chainable<void>;
+      getUserFullName(): Chainable<string>;
+    }
+  }
   namespace NodeJS {
     interface ProcessEnv {
       E2E_USER: string;

--- a/scripts/e2e.js
+++ b/scripts/e2e.js
@@ -57,7 +57,7 @@ async function runTests() {
 
   console.log('HTTP Proxy val', { px: process.env.HTTP_PROXY });
   await waitOn(options);
-  execSyncWrapper(`NO_COLOR=1 E2E_USER=${process.env.CHROME_ACCOUNT} E2E_PASSWORD=${process.env.CHROME_PASSWORD} npx cypress run --e2e`);
+  execSyncWrapper(`NO_COLOR=1 E2E_USER="${process.env.CHROME_ACCOUNT}" E2E_PASSWORD="${process.env.CHROME_PASSWORD}" npx cypress run --e2e`);
 }
 
 runTests()


### PR DESCRIPTION
## Summary                                                                                                                                                                 
                                                                                                                                                                             
  - Replace hardcoded `Insights QA` username in E2E tests with a reusable `getUserFullName()` Cypress command that reads the logged-in user's name from the OIDC profile in  
  localStorage                                                                                                                                                               
  - Quote `E2E_USER` / `E2E_PASSWORD` env vars in scripts and Tekton pipelines to handle passwords containing special characters (e.g. `&`)                                  
  - Fix `refresh-token.cy.ts` race condition by registering the intercept after Chrome initializes, right before triggering `forceAuthRefresh()`                             
  - Add E2E test instructions to README                                                                                                                                      
                                                                                                                                                                             
  ## Context                                                                                                                                                                 
                                                                                                                                                                             
  The `insights-qa` stage account was locked out after someone enabled 2FA on it. A new test account was created and its credentials were updated in Vault  (`insights/creds/konflux/insights-chrome`). These changes ensure the tests work with any account, not just `insights-qa`.
                                                                                                                                                                             
  Jira: [RHCLOUD-46829](https://issues.redhat.com/browse/RHCLOUD-46829)                                                                                                      
   
  ## Test plan                                                                                                                                                               
                             
  - [x] `ephemeral/init-flow.cy.ts` passes locally with new test account                                                                                                     
  - [x] `release-gate/refresh-token.cy.ts` passes locally after fix
  - [x] All Cypress E2E tests pass locally                                                                                                                                   
  - [x] Vault secrets updated with new test credentials                                                                                                                      
  - [x] CI pipeline correctly picks up quoted env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded test-running instructions for unit, component, and end-to-end workflows.

* **Bug Fixes**
  * Fixed environment variable quoting in test invocations to preserve special characters/spaces.

* **Tests**
  * Tests updated to assert the logged-in user's actual name rather than hardcoded text.
  * Added a test utility to retrieve the user's full name from the browser session.

* **Chores**
  * Added an ignore rule for Playwright artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHCLOUD-46829]: https://redhat.atlassian.net/browse/RHCLOUD-46829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ