### PR TITLE
chore(types): apply types-react-codemod preset-19 for React 19 compat

### DIFF
--- a/src/analytics/SegmentProvider.tsx
+++ b/src/analytics/SegmentProvider.tsx
@@ -103,7 +103,7 @@ const SegmentProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const isITLessEnv = ITLess();
   const isDisabled = localStorage.getItem('chrome:segment:disable') === 'true' || isITLessEnv;
   const disableIntegrations = localStorage.getItem('chrome:analytics:disable') === 'true' || isITLessEnv;
-  const analytics = useRef<AnalyticsBrowser>();
+  const analytics = useRef<AnalyticsBrowser>(undefined);
   const analyticsLoaded = useRef(false);
   const { user } = useContext(ChromeAuthContext);
   const isPreview = useAtomValue(isPreviewAtom);

--- a/src/components/ChromeLink/ChromeLink.tsx
+++ b/src/components/ChromeLink/ChromeLink.tsx
@@ -33,7 +33,7 @@ const LinkWrapper: React.FC<LinkWrapperProps> = memo(
     const moduleRoutes = useAtomValue(moduleRoutesAtom);
     const triggerNavListener = useSetAtom(triggerNavListenersAtom);
     const moduleEntry = useMemo(() => moduleRoutes?.find((route) => href?.includes(route.path)), [href, appId]);
-    const preloadTimeout = useRef<NodeJS.Timeout>();
+    const preloadTimeout = useRef<NodeJS.Timeout>(undefined);
     let actionId = href.split('/').slice(2).join('/');
     if (actionId.includes('/')) {
       actionId = actionId.split('/').pop() as string;

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -105,7 +105,7 @@ export type ChromeApiRootProps = {
 
 const ChromeApiRoot = ({ config, helpTopicsAPI, quickstartsAPI }: ChromeApiRootProps) => {
   const chromeAuth = useContext(ChromeAuthContext);
-  const mutableChromeApi = useRef<ChromeAPI>();
+  const mutableChromeApi = useRef<ChromeAPI>(undefined);
   const isPreview = useAtomValue(isPreviewAtom);
   const addNavListener = useSetAtom(addNavListenerAtom);
   const deleteNavListener = useSetAtom(deleteNavListenerAtom);

--- a/src/components/Stratosphere/Footer.tsx
+++ b/src/components/Stratosphere/Footer.tsx
@@ -2,13 +2,13 @@ import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider'
 import { Flex, FlexItem } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
 import { Level, LevelItem } from '@patternfly/react-core/dist/dynamic/layouts/Level';
 import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
-import React, { VoidFunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 
 import './footer.scss';
 
 const currentYear = new Date().getFullYear();
 
-const FooterLink: VoidFunctionComponent<{ href: string; label: React.ReactNode }> = ({ href, label }) => (
+const FooterLink: FunctionComponent<{ href: string; label: React.ReactNode }> = ({ href, label }) => (
   <Content>
     <Content component="small">
       <a className="chr-c-footer__link" href={href}>

--- a/src/components/Stratosphere/ProductCard.tsx
+++ b/src/components/Stratosphere/ProductCard.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, VoidFunctionComponent } from 'react';
+import React, { Fragment, FunctionComponent } from 'react';
 import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
 import ArrowRightIcon from '@patternfly/react-icons/dist/dynamic/icons/arrow-right-icon';
 import ChromeLink from '../ChromeLink/ChromeLink';
@@ -16,7 +16,7 @@ export type ProductCardProps = {
   };
 };
 
-const ProductCard: VoidFunctionComponent<ProductCardProps> = ({ img, description, link, order }) => {
+const ProductCard: FunctionComponent<ProductCardProps> = ({ img, description, link, order }) => {
   return (
     <Fragment>
       <div className={`chr-c-product-card__title title-${order}`}>

--- a/src/components/Stratosphere/RedirectBanner.test.tsx
+++ b/src/components/Stratosphere/RedirectBanner.test.tsx
@@ -14,7 +14,7 @@ const HydrateAtoms: React.FC<{ initialValues: any[]; children: React.ReactNode }
   return children;
 };
 
-const LocationSpy: React.VoidFunctionComponent<{ changeSpy: jest.Mock }> = ({ changeSpy }) => {
+const LocationSpy: React.FunctionComponent<{ changeSpy: jest.Mock }> = ({ changeSpy }) => {
   const { search, pathname, hash, state } = useLocation();
   useEffect(() => {
     changeSpy({

--- a/src/hooks/useChromeServiceEvents.ts
+++ b/src/hooks/useChromeServiceEvents.ts
@@ -23,7 +23,7 @@ const wsEventListenersRegistry: WsEventListenersRegistry = {
 };
 
 const useChromeServiceEvents = (): AddChromeWsEventListener => {
-  const connection = useRef<WebSocket | undefined>();
+  const connection = useRef<WebSocket | undefined>(undefined);
   const isNotificationsEnabled = useFlag('platform.chrome.notifications-drawer');
   const { token, tokenExpires } = useContext(ChromeAuthContext);
   const retries = useRef(0);


### PR DESCRIPTION
## Why                                                                                                                                                                     
                                                                                                                                                                             
  Prepares insights-chrome for the React 19 type system by fixing two categories of breaking changes that `@types/react@19` introduces. Applied via `npx types-react-codemod@latest preset-19 ./src`.
                                                                                                                                                                             
  ## What changed                                                

  ### `useRef<T>()` → `useRef<T>(undefined)`                                                                                                                                 
  React 19 removes the zero-argument `useRef` overload. Passing `undefined` explicitly is backward-compatible with `@types/react@18` and will be required under
  `@types/react@19`.                                                                                                                                                         
                                                                 
  Files: `SegmentProvider.tsx`, `ChromeLink.tsx`, `ScalprumRoot.tsx`, `useChromeServiceEvents.ts`                                                                            
                                                                 
  ### `VoidFunctionComponent` → `FunctionComponent`                                                                                                                          
  `VFC`/`VoidFunctionComponent` is removed entirely from `@types/react@19`. `FunctionComponent` is the correct replacement and is available in all React versions.
                                                                                                                                                                             
  Files: `Stratosphere/Footer.tsx`, `Stratosphere/ProductCard.tsx`, `Stratosphere/RedirectBanner.test.tsx`                                                                   
                                                                                                                                                                             
  ## What was intentionally excluded                                                                                                                                         
                                                                 
  `RefObject<T>` → `RefObject<T | null>` prop type changes (also emitted by `preset-19`) were reverted. Those are only valid after the `@types/react@19` bump — applying them
   now causes build failures against v18 JSX intrinsic types. They will be re-applied in RHCLOUD-44216.
                                                                                                                                                                             
  ## Test plan                                                   
  - [x] `npm run verify` passes
  - [x] No TypeScript errors (`npx tsc --noEmit`)                                                                                                                            
                                                                                                                                                                             
  Refs: RHCLOUD-44375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal TypeScript and initialization cleanups across hooks, components and tests: explicit ref initializations and component typing adjustments. No functional or UI changes; improves type safety and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->