### PR TITLE
Migrate navigation tests from IQE to Playwright

### DIFF
--- a/playwright/e2e/pages/chrome-navigation.ts
+++ b/playwright/e2e/pages/chrome-navigation.ts
@@ -1,0 +1,70 @@
+import { Page, Locator } from '@playwright/test';
+
+/**
+ * Page Object for Chrome Navigation Sidebar
+ *
+ * This corresponds to IQE's Navigation view in the iqe-platform-ui-plugin repository.
+ *
+ * Provides methods to interact with the Chrome sidebar navigation including:
+ * - Navigation toggle (hamburger menu)
+ * - Sidebar visibility
+ * - Navigation item selection
+ */
+export class ChromeNavigation {
+  readonly page: Page;
+  readonly navToggle: Locator;
+  readonly sidebar: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    // Navigation toggle button (hamburger menu)
+    this.navToggle = page.getByRole('button', { name: 'Global navigation' });
+
+    // Sidebar panel
+    this.sidebar = page.locator('#chr-c-sidebar');
+  }
+
+  /**
+   * Clicks the navigation toggle button
+   */
+  async clickToggle(): Promise<void> {
+    await this.navToggle.click();
+  }
+
+  /**
+   * Checks if the navigation sidebar is visible
+   */
+  async isVisible(): Promise<boolean> {
+    return await this.sidebar.isVisible();
+  }
+
+  /**
+   * Selects a navigation item by name
+   * @param itemName The text of the navigation item to select
+   */
+  async selectItem(itemName: string): Promise<void> {
+    // Find and click the navigation item within the sidebar
+    await this.sidebar.getByRole('link', { name: itemName }).click();
+  }
+
+  /**
+   * Gets the currently selected navigation item(s)
+   * @returns Array of navigation item names that are currently active/selected
+   */
+  async getCurrentlySelected(): Promise<string[]> {
+    // Find navigation items with aria-current="page" attribute
+    const activeItems = this.sidebar.locator('[aria-current="page"]');
+    const count = await activeItems.count();
+
+    const selectedItems: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = await activeItems.nth(i).textContent();
+      if (text) {
+        selectedItems.push(text.trim());
+      }
+    }
+
+    return selectedItems;
+  }
+}

--- a/playwright/e2e/release-gate/navigation.spec.ts
+++ b/playwright/e2e/release-gate/navigation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../setup/test-setup';
+import { ChromeNavigation } from '../pages/chrome-navigation';
 
 test.describe('Navigation', () => {
   test.beforeEach(async ({ page }) => {
@@ -22,5 +23,54 @@ test.describe('Navigation', () => {
 
     // check that we are on all services page
     await expect(page).toHaveURL(/.*\/allservices/);
+  });
+
+  test('navigation toggle hide and show', async ({ page }) => {
+    // Migrated from test_navigation.py::test_nav_toggle
+    const navigation = new ChromeNavigation(page);
+
+    // Navigate to a page with navigation (User Access)
+    await page.goto('/settings/my-user-access');
+    await page.waitForLoadState('load');
+
+    // Verify navigation is initially visible
+    await expect(navigation.sidebar).toBeVisible();
+
+    // Click toggle to hide navigation
+    await navigation.clickToggle();
+    await expect(navigation.sidebar).not.toBeVisible();
+
+    // Click toggle to show navigation again
+    await navigation.clickToggle();
+    await expect(navigation.sidebar).toBeVisible();
+  });
+
+  test('navigation selection persists after refresh', async ({ page }) => {
+    // Migrated from test_navigation.py::test_refresh_navigation
+    const navigation = new ChromeNavigation(page);
+
+    // Navigate to Insights and select Dashboard
+    await page.goto('/insights/dashboard');
+    await page.waitForLoadState('load');
+
+    // Refresh the page
+    await page.reload();
+    await page.waitForLoadState('load');
+
+    // Verify we're still on the dashboard page
+    await expect(page).toHaveURL(/.*\/insights\/dashboard/);
+
+    // Verify navigation item is still selected
+    const selected = await navigation.getCurrentlySelected();
+    expect(selected.some((item) => item.includes('Dashboard'))).toBeTruthy();
+  });
+
+  test('generic 404 page content', async ({ page }) => {
+    // Migrated from test_navigation.py::test_generic_404
+    await page.goto('/404');
+    await page.waitForLoadState('load');
+
+    // Verify 404 page content is displayed
+    await expect(page.getByText(/We lost that page/i)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
Migrates navigation tests from IQE `test_navigation.py` to Playwright.

### Tests Migrated
- **test_nav_toggle**: Tests navigation toggle hide/show functionality
- **test_refresh_navigation**: Tests that navigation selection persists after page refresh
- **test_generic_404**: Tests 404 page displays correct content

### Changes
- Created `ChromeNavigation` page object for navigation interactions
- Added methods to interact with navigation toggle, sidebar visibility, and navigation item selection
- Added 3 new test cases to existing `navigation.spec.ts`

### IQE Source
Tests migrated from: `iqe-platform-ui-plugin/iqe_platform_ui/tests/test_navigation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the Chrome navigation sidebar: toggle show/hide behavior, persistence of the selected item across full page reloads, and 404/error page rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->