### PR TITLE
RHCLOUD-44391: fix: improve settings menu item extraction selector

### DIFF
--- a/playwright/e2e/pages/chrome-topbar.ts
+++ b/playwright/e2e/pages/chrome-topbar.ts
@@ -219,6 +219,37 @@ export class ChromeTopbar {
   }
 
   /**
+   * Selects a specific item from the settings menu by OUIA ID
+   * More stable than text-based selection
+   * @param ouiaId The OUIA component ID of the menu item
+   */
+  async selectSettingsItemByOuiaId(ouiaId: string): Promise<void> {
+    await this.openSettings();
+
+    const menuItem = this.settingsButton.locator(`[data-ouia-component-id="${ouiaId}"]`);
+    await menuItem.waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
+    await menuItem.click();
+  }
+
+  /**
+   * Checks if a settings menu item with the given OUIA ID exists and is visible
+   * @param ouiaId The OUIA component ID to check for
+   * @returns true if the item exists and is visible, false otherwise
+   */
+  async hasSettingsMenuItem(ouiaId: string): Promise<boolean> {
+    await this.openSettings();
+
+    const menuItem = this.settingsButton.locator(`[data-ouia-component-id="${ouiaId}"]`);
+
+    try {
+      await menuItem.waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Opens the services menu
    */
   async openServices(): Promise<void> {

--- a/playwright/e2e/pages/chrome-topbar.ts
+++ b/playwright/e2e/pages/chrome-topbar.ts
@@ -175,17 +175,17 @@ export class ChromeTopbar {
   async getSettingsMenuItems(): Promise<string[]> {
     await this.openSettings();
 
-    // Target only actual menu item links/buttons, not all <li> elements
-    // This avoids nested structural elements
-    const menuItemLinks = this.settingsButton.locator('li > a, li > button');
-    await menuItemLinks.first().waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
+    // Target menu items by OUIA component ID for more reliable selection
+    // This is more stable than DOM structure selectors
+    const menuItems = this.settingsButton.locator('[data-ouia-component-id]');
+    await menuItems.first().waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
 
-    const count = await menuItemLinks.count();
+    const count = await menuItems.count();
 
     const items: string[] = [];
     for (let i = 0; i < count; i++) {
-      const link = menuItemLinks.nth(i);
-      const text = await link.innerText();
+      const item = menuItems.nth(i);
+      const text = await item.innerText();
       if (text) {
         // Extract just the first line to avoid badges/extra text
         const cleanText = text.trim().split('\n')[0].trim();

--- a/playwright/e2e/pages/chrome-topbar.ts
+++ b/playwright/e2e/pages/chrome-topbar.ts
@@ -175,34 +175,21 @@ export class ChromeTopbar {
   async getSettingsMenuItems(): Promise<string[]> {
     await this.openSettings();
 
-    // Wait for menu items to render
-    const menuItems = this.settingsButton.locator('li');
-    await menuItems.first().waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
+    // Target only actual menu item links/buttons, not all <li> elements
+    // This avoids nested structural elements
+    const menuItemLinks = this.settingsButton.locator('li > a, li > button');
+    await menuItemLinks.first().waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
 
-    const count = await menuItems.count();
+    const count = await menuItemLinks.count();
 
     const items: string[] = [];
     for (let i = 0; i < count; i++) {
-      const menuItem = menuItems.nth(i);
-
-      // Try to get just the main text, not nested badges/descriptions
-      // First try to find a link or button within the item
-      const link = menuItem.locator('a, button').first();
-      const linkCount = await link.count();
-
-      if (linkCount > 0) {
-        const text = await link.innerText();
-        if (text) {
-          items.push(text.trim());
-        }
-      } else {
-        // Fallback to getting the text content
-        const text = await menuItem.textContent();
-        if (text) {
-          // Clean up text by taking only the first line or removing extra whitespace
-          const cleanText = text.trim().split('\n')[0].trim();
-          items.push(cleanText);
-        }
+      const link = menuItemLinks.nth(i);
+      const text = await link.innerText();
+      if (text) {
+        // Extract just the first line to avoid badges/extra text
+        const cleanText = text.trim().split('\n')[0].trim();
+        items.push(cleanText);
       }
     }
 

--- a/playwright/e2e/pages/chrome-topbar.ts
+++ b/playwright/e2e/pages/chrome-topbar.ts
@@ -176,8 +176,9 @@ export class ChromeTopbar {
     await this.openSettings();
 
     // Target menu items by OUIA component ID for more reliable selection
-    // This is more stable than DOM structure selectors
-    const menuItems = this.settingsButton.locator('[data-ouia-component-id]');
+    // Use :not(:has()) to exclude wrapper elements that contain nested OUIA elements
+    // This ensures we only match leaf nodes (one node per logical menu entry)
+    const menuItems = this.settingsButton.locator('[data-ouia-component-id]:not(:has([data-ouia-component-id]))');
     await menuItems.first().waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
 
     const count = await menuItems.count();

--- a/playwright/e2e/release-gate/logout.spec.ts
+++ b/playwright/e2e/release-gate/logout.spec.ts
@@ -1,6 +1,7 @@
 import { test as base, expect } from '@playwright/test';
 import { ChromeTopbar } from '../pages/chrome-topbar';
 import { createAuthenticatedPage } from '../../helpers/isolated-auth';
+import { AUTH_TIMEOUT } from '../../setup/constants';
 
 /**
  * Test: Logout functionality
@@ -23,16 +24,19 @@ import { createAuthenticatedPage } from '../../helpers/isolated-auth';
 
 // Create a custom test that doesn't use shared auth state
 const test = base.extend<{ authenticatedPage: any }>({
-  authenticatedPage: async ({ browser, baseURL }, use) => {
-    // Create an authenticated page in an isolated context
-    const page = await createAuthenticatedPage(browser, baseURL);
+  authenticatedPage: [
+    async ({ browser, baseURL }, use) => {
+      // Create an authenticated page in an isolated context
+      const page = await createAuthenticatedPage(browser, baseURL);
 
-    // Provide the authenticated page to the test
-    await use(page);
+      // Provide the authenticated page to the test
+      await use(page);
 
-    // Cleanup
-    await page.context().close();
-  },
+      // Cleanup
+      await page.context().close();
+    },
+    { timeout: AUTH_TIMEOUT },
+  ],
 });
 
 test.describe('Logout Functionality', () => {

--- a/playwright/e2e/release-gate/settings.spec.ts
+++ b/playwright/e2e/release-gate/settings.spec.ts
@@ -47,52 +47,31 @@ test.describe('Settings Gear and Navigation', () => {
   test('should contain expected settings menu items', async ({ page }) => {
     const topbar = new ChromeTopbar(page);
 
-    // Get the menu items
-    const menuItems = await topbar.getSettingsMenuItems();
-
-    // Verify expected items are present (updated to match current UI)
-    const expectedItems = [
-      'Integrations',
-      'Notifications',
-      'User Access',
-      'Identity Provider Integration',
-      'Authentication Factors',
-      'Service Accounts',
+    // Verify expected items are present by OUIA ID (more stable than text matching)
+    // These OUIA IDs are independent of text content, localization, and UI changes
+    const expectedOuiaIds = [
+      'settings-menu-integrations',
+      'settings-menu-notifications',
+      'UserAccess',
+      'settings-menu-identity-provider',
+      'settings-menu-auth-factors',
+      'settings-menu-service-accounts',
     ];
 
-    for (const expectedItem of expectedItems) {
-      // Check if any menu item contains the expected text (handles badges/extra text)
-      const found = menuItems.some(item => item.includes(expectedItem));
-      expect(found, `Expected to find "${expectedItem}" in menu items: ${JSON.stringify(menuItems)}`).toBe(true);
+    for (const ouiaId of expectedOuiaIds) {
+      const isVisible = await topbar.hasSettingsMenuItem(ouiaId);
+      expect(isVisible, `Expected settings menu item with OUIA ID "${ouiaId}" to be visible`).toBe(true);
     }
   });
 
   test('should select IAM menu item', async ({ page }) => {
     const topbar = new ChromeTopbar(page);
 
-    // Get menu items to determine which IAM option is available
-    const menuItems = await topbar.getSettingsMenuItems();
-
-    // Determine which IAM item to select (matches IQE's choose_iam logic)
-    // Use partial match since items may have badges/extra text
-    let iamItem: string | undefined;
-
-    const userAccessItem = menuItems.find(item => item.includes('User Access'));
-    const iamManagementItem = menuItems.find(item => item.includes('Identity & Access Management'));
-
-    if (userAccessItem) {
-      iamItem = userAccessItem;
-    } else if (iamManagementItem) {
-      iamItem = iamManagementItem;
-    } else {
-      throw new Error(`No IAM menu item found. Available items: ${JSON.stringify(menuItems)}`);
-    }
-
-    // Select the IAM item
-    await topbar.selectSettingsItem(iamItem);
+    // Select the User Access item by OUIA ID (more stable than text-based selection)
+    await topbar.selectSettingsItemByOuiaId('UserAccess');
 
     // Verify navigation occurred (URL should change)
-    // The exact URL depends on which option was selected
+    // The exact URL depends on user permissions and feature flags
     await page.waitForURL(/\/(iam|settings\/rbac|access-management)/, { timeout: 10000 });
   });
 });

--- a/playwright/helpers/isolated-auth.ts
+++ b/playwright/helpers/isolated-auth.ts
@@ -1,5 +1,6 @@
 import { Browser, Page } from '@playwright/test';
 import { login } from './auth';
+import { AUTH_TIMEOUT } from '../setup/constants';
 
 /**
  * Creates an authenticated page in an isolated browser context.
@@ -17,6 +18,9 @@ export async function createAuthenticatedPage(browser: Browser, baseURL?: string
   });
 
   const page = await context.newPage();
+
+  // Set higher timeout for CI environments where network/SSO may be slower
+  page.setDefaultTimeout(AUTH_TIMEOUT);
 
   try {
     // Use the existing login helper which handles all the auth details

--- a/playwright/helpers/isolated-auth.ts
+++ b/playwright/helpers/isolated-auth.ts
@@ -28,7 +28,12 @@ export async function createAuthenticatedPage(browser: Browser, baseURL?: string
     return page;
   } catch (error) {
     // Clean up context on login failure to avoid leaking resources
-    await context.close();
+    // Safely close context - it may already be closed if test timed out
+    try {
+      await context.close();
+    } catch (closeError) {
+      // Context already closed - this is fine, suppress the error
+    }
     throw error;
   }
 }

--- a/playwright/setup/constants.ts
+++ b/playwright/setup/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Timeout constants for Playwright test setup and authentication
+ */
+
+/**
+ * Default timeout for authentication operations in CI environments.
+ * CI environments may have slower network/SSO response times than local development.
+ *
+ * Used for:
+ * - SSO redirects and login flows
+ * - Form submissions during authentication
+ * - Waiting for authenticated state
+ */
+export const AUTH_TIMEOUT = 90000; // 90 seconds
+
+/**
+ * Timeout for initial page navigation during global setup.
+ * Should be sufficient for application bootstrap and initial render.
+ */
+export const NAVIGATION_TIMEOUT = 60000; // 60 seconds

--- a/playwright/setup/global-setup.ts
+++ b/playwright/setup/global-setup.ts
@@ -1,6 +1,7 @@
 import { chromium } from 'playwright';
 import type { FullConfig } from '@playwright/test';
 import { disableCookiePrompt, login } from '@redhat-cloud-services/playwright-test-auth';
+import { AUTH_TIMEOUT, NAVIGATION_TIMEOUT } from './constants';
 
 async function globalSetup(config: FullConfig) {
   const { storageState, baseURL } = config.projects[0].use;
@@ -16,12 +17,15 @@ async function globalSetup(config: FullConfig) {
   });
   const page = await context.newPage();
 
+  // Set higher timeout for CI environments where network/SSO may be slower
+  page.setDefaultTimeout(AUTH_TIMEOUT);
+
   try {
     // Disable cookie prompts before navigation
     await disableCookiePrompt(page);
 
     // Navigate to the application
-    await page.goto(baseURL || '/', { waitUntil: 'load', timeout: 60000 });
+    await page.goto(baseURL || '/', { waitUntil: 'load', timeout: NAVIGATION_TIMEOUT });
 
     const user = process.env.E2E_USER;
     const password = process.env.E2E_PASSWORD;

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -22,6 +22,7 @@ interface MockDropdownItem {
   title: React.ReactNode;
   description?: React.ReactNode;
   isHidden?: boolean;
+  ouiaId?: string;
 }
 
 interface MockDropdownGroup {
@@ -41,7 +42,7 @@ jest.mock('./SettingsToggle', () => ({
             {group.items
               ?.filter((item) => !item.isHidden)
               .map((item, j: number) => (
-                <div key={j}>
+                <div key={j} data-ouia-component-id={item.ouiaId}>
                   {item.title}
                   {item.description && <p>{item.description}</p>}
                 </div>
@@ -165,6 +166,46 @@ describe('Tools - dark mode system feature flag', () => {
 
       expect(screen.getAllByText('Settings').length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText('Identity and Access Management')).toBeInTheDocument();
+    });
+  });
+
+  describe('settings menu OUIA IDs', () => {
+    it('should have OUIA ID on preview toggle', () => {
+      const { container } = renderTools();
+      expect(container.querySelector('[data-ouia-component-id="PreviewSwitcher"]')).toBeInTheDocument();
+    });
+
+    it('should have OUIA IDs on color scheme options when dark mode is enabled', () => {
+      const { container } = renderTools({
+        'platform.chrome.dark-mode': true,
+        'platform.chrome.dark-mode_system': true,
+      });
+
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-color-system"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-color-light"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-color-dark"]')).toBeInTheDocument();
+    });
+
+    it('should have OUIA IDs on Settings menu items', () => {
+      const { container } = renderTools();
+
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-integrations"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-notifications"]')).toBeInTheDocument();
+    });
+
+    it('should have OUIA IDs on IAM menu items', () => {
+      const { container } = renderTools();
+
+      expect(container.querySelector('[data-ouia-component-id="UserAccess"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-identity-provider"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-auth-factors"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-service-accounts"]')).toBeInTheDocument();
+    });
+
+    it('should not render integrations OUIA ID when ITLess is enabled', () => {
+      const { container } = renderTools({ 'platform.chrome.itless': true });
+
+      expect(container.querySelector('[data-ouia-component-id="settings-menu-integrations"]')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, configure } from '@testing-library/react';
 import { Provider } from 'jotai';
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
@@ -7,6 +7,10 @@ import Tools from './Tools';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
 import InternalChromeContext from '../../utils/internalChromeContext';
 import { useFlag } from '@unleash/proxy-client-react';
+
+// Configure data-ouia-component-id as the test ID attribute
+// This allows using screen.getByTestId/queryByTestId for OUIA IDs
+configure({ testIdAttribute: 'data-ouia-component-id' });
 
 jest.mock('@unleash/proxy-client-react', () => ({
   useFlag: jest.fn(() => false),
@@ -171,41 +175,41 @@ describe('Tools - dark mode system feature flag', () => {
 
   describe('settings menu OUIA IDs', () => {
     it('should have OUIA ID on preview toggle', () => {
-      const { container } = renderTools();
-      expect(container.querySelector('[data-ouia-component-id="PreviewSwitcher"]')).toBeInTheDocument();
+      renderTools();
+      expect(screen.getByTestId('PreviewSwitcher')).toBeInTheDocument();
     });
 
     it('should have OUIA IDs on color scheme options when dark mode is enabled', () => {
-      const { container } = renderTools({
+      renderTools({
         'platform.chrome.dark-mode': true,
         'platform.chrome.dark-mode_system': true,
       });
 
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-color-system"]')).toBeInTheDocument();
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-color-light"]')).toBeInTheDocument();
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-color-dark"]')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-color-system')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-color-light')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-color-dark')).toBeInTheDocument();
     });
 
     it('should have OUIA IDs on Settings menu items', () => {
-      const { container } = renderTools();
+      renderTools();
 
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-integrations"]')).toBeInTheDocument();
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-notifications"]')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-integrations')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-notifications')).toBeInTheDocument();
     });
 
     it('should have OUIA IDs on IAM menu items', () => {
-      const { container } = renderTools();
+      renderTools();
 
-      expect(container.querySelector('[data-ouia-component-id="UserAccess"]')).toBeInTheDocument();
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-identity-provider"]')).toBeInTheDocument();
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-auth-factors"]')).toBeInTheDocument();
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-service-accounts"]')).toBeInTheDocument();
+      expect(screen.getByTestId('UserAccess')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-identity-provider')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-auth-factors')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-service-accounts')).toBeInTheDocument();
     });
 
     it('should not render integrations OUIA ID when ITLess is enabled', () => {
-      const { container } = renderTools({ 'platform.chrome.itless': true });
+      renderTools({ 'platform.chrome.itless': true });
 
-      expect(container.querySelector('[data-ouia-component-id="settings-menu-integrations"]')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('settings-menu-integrations')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, configure } from '@testing-library/react';
+import { configure, render, screen } from '@testing-library/react';
 import { Provider } from 'jotai';
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -116,6 +116,7 @@ const Tools = () => {
         ...(isDarkModeSystemEnabled
           ? [
               {
+                ouiaId: 'settings-menu-color-system',
                 title: (
                   <>
                     <AdjustIcon /> System {themeMode === ThemeVariants.system && <CheckIcon />}
@@ -128,6 +129,7 @@ const Tools = () => {
             ]
           : []),
         {
+          ouiaId: 'settings-menu-color-light',
           title: (
             <>
               <OutlinedSunIcon /> Light {themeMode === ThemeVariants.light && <CheckIcon />}
@@ -138,6 +140,7 @@ const Tools = () => {
           url: '#',
         },
         {
+          ouiaId: 'settings-menu-color-dark',
           title: (
             <>
               <OutlinedMoonIcon /> Dark {themeMode === ThemeVariants.dark && <CheckIcon />}
@@ -153,11 +156,13 @@ const Tools = () => {
       title: 'Settings',
       items: [
         {
+          ouiaId: 'settings-menu-integrations',
           url: '/settings/integrations',
           title: 'Integrations',
           isHidden: isITLessEnv,
         },
         {
+          ouiaId: 'settings-menu-notifications',
           url: '/settings/notifications',
           title: 'Notifications',
         },
@@ -178,16 +183,19 @@ const Tools = () => {
             ) : null,
         },
         {
+          ouiaId: 'settings-menu-identity-provider',
           url: '/iam/authentication-policy/identity-provider-integration',
           title: 'Identity Provider Integration',
           isHidden: isITLessEnv,
         },
         {
+          ouiaId: 'settings-menu-auth-factors',
           url: '/iam/authentication-policy/authentication-factors',
           title: 'Authentication Factors',
           isHidden: isITLessEnv,
         },
         {
+          ouiaId: 'settings-menu-service-accounts',
           url: '/iam/service-accounts',
           title: 'Service Accounts',
           isHidden: isITLessEnv,


### PR DESCRIPTION
## Summary
Improves settings menu test automation reliability through better selectors, explicit OUIA IDs, comprehensive test coverage (both unit and E2E), increased authentication timeouts for CI, Testing Library best practices, and prevention of duplicate matches from nested OUIA IDs.

## Changes

### 1. Fixed Immediate Test Failure (First Commit)
The test was failing with duplicate/missing menu items. Changed selector from `'li'` to `'li > a, li > button'` to:
- Target only direct child links/buttons of `<li>` elements
- Avoid nested structural elements
- Prevent duplicates from nested lists

### 2. Added OUIA IDs for Long-term Stability (Second Commit)
Added explicit `ouiaId` attributes to all settings menu items that were missing them:
- Color scheme options: `settings-menu-color-system`, `settings-menu-color-light`, `settings-menu-color-dark`
- Settings items: `settings-menu-integrations`, `settings-menu-notifications`
- IAM items: `settings-menu-identity-provider`, `settings-menu-auth-factors`, `settings-menu-service-accounts`

Preserved existing `ouiaId` values (`PreviewSwitcher`, `UserAccess`) to avoid breaking existing automation.

Updated page object to extract menu items using OUIA component IDs instead of DOM structure selectors.

### 3. Refactored E2E Tests to Use OUIA IDs (Third Commit)
Updated tests to use OUIA IDs instead of text-based matching:

**New page object methods:**
- `selectSettingsItemByOuiaId()` - Select menu item by OUIA ID
- `hasSettingsMenuItem()` - Check if menu item with OUIA ID exists

**Test improvements:**
- "should contain expected settings menu items" now checks for OUIA IDs instead of text content
- "should select IAM menu item" uses `UserAccess` OUIA ID directly instead of text search
- Tests are now independent of text changes, localization, and UI formatting

### 4. Increased Authentication Timeout for CI (Fourth Commit)
Fixed login timeout failures in CI by increasing authentication timeouts:

**Created `playwright/setup/constants.ts`:**
- `AUTH_TIMEOUT` (90s) - For SSO redirects and login flows
- `NAVIGATION_TIMEOUT` (60s) - For initial page navigation

**Updated `global-setup.ts`:**
- Use symbolic constants instead of hardcoded timeout values
- Set page default timeout to `AUTH_TIMEOUT` for all authentication operations
- Addresses slower network/SSO response times in CI environments

### 5. Added Unit Test Coverage (Fifth Commit)
Added comprehensive unit tests for OUIA IDs in `Tools.test.tsx`:

**Tests verify:**
- Preview toggle has `PreviewSwitcher` OUIA ID
- Color scheme options have correct OUIA IDs (system, light, dark)
- Settings items have correct OUIA IDs (integrations, notifications)
- IAM items have correct OUIA IDs (UserAccess, identity-provider, auth-factors, service-accounts)
- Hidden items (e.g., integrations in ITLess) don't render

**Updated mock:**
- SettingsToggle mock now renders `ouiaId` as `data-ouia-component-id` attribute

### 6. Applied AUTH_TIMEOUT to Isolated Auth Helper (Sixth Commit)
Extended the authentication timeout fix to `isolated-auth.ts`:

**Updated `playwright/helpers/isolated-auth.ts`:**
- Apply same `AUTH_TIMEOUT` used in global setup
- Fixes timeout in logout tests that use isolated browser contexts
- Logout tests perform fresh login in isolated contexts, need same timeout buffer

**Fixes error:**
```
Test timeout of 30000ms exceeded while setting up "authenticatedPage"
```

### 7. Refactored Unit Tests to Use Testing Library Best Practices (Seventh Commit)
Improved unit tests to follow Testing Library recommended patterns:

**Changes:**
- Configure `testIdAttribute: 'data-ouia-component-id'` at module level
- Replace `container.querySelector('[data-ouia-component-id="..."]')` with `screen.getByTestId('...')`
- Use `screen.queryByTestId` for negative assertions (ITLess case)
- Remove unnecessary `container` destructuring

**Benefits:**
- Follows Testing Library best practices
- More idiomatic and readable test code
- Better alignment with user-facing queries
- Simpler test assertions

### 8. Prevent Duplicate Matches from Nested OUIA IDs (Eighth Commit)
Fixed potential duplicate menu items from nested OUIA ID attributes:

**Problem:**
In `SettingsToggle.tsx`, `ouiaId` is spread via `{...rest}` to both:
- `DropdownItem` wrapper component
- Nested `ChromeLink` component

This creates nested elements with the same `data-ouia-component-id`, causing the selector to match multiple elements per menu item.

**Solution:**
Updated selector in `getSettingsMenuItems()`:
```typescript
'[data-ouia-component-id]:not(:has([data-ouia-component-id]))'
```

Uses `:not(:has())` pseudo-class to exclude wrapper elements, only matching leaf nodes (elements that don't contain other elements with `data-ouia-component-id`).

**Result:**
Ensures exactly one match per logical menu entry, preventing duplicates.

## Benefits
- **Immediate**: Fixes failing test and authentication timeouts
- **Long-term**: More stable selectors that won't break if:
  - Menu text changes
  - Localization is added
  - Icons or badges are added to titles
  - DOM structure changes
- **Maintainable**: OUIA-based assertions follow OpenShift best practices, symbolic constants avoid magic numbers
- **Complete coverage**: Both unit and E2E tests verify OUIA IDs
- **Best practices**: Uses Testing Library recommended query patterns
- **Robust**: Prevents duplicate matches from nested OUIA ID forwarding

## Testing
Fixes: 
- `playwright/e2e/release-gate/settings.spec.ts >> Settings Gear and Navigation >> should contain expected settings menu items`
- Global setup authentication timeout in CI
- Logout test authentication timeout in CI
- Potential duplicate menu items from nested OUIA IDs

Unit tests: ✅ 10/10 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)