### PR TITLE
RHCLOUD-44391: test: migrate IQE test_search.py to Playwright

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -244,6 +244,7 @@ const commonConfig = ({ dev }) => {
       // This must come AFTER contextualConfigSettings spread to ensure it's not overridden
       ...(process.env.CI && {
         client: {
+          ...(contextualConfigSettings.client || {}),
           overlay: false,
         },
       }),

--- a/playwright/e2e/MIGRATION-SUMMARY.md
+++ b/playwright/e2e/MIGRATION-SUMMARY.md
@@ -1,5 +1,95 @@
 # IQE to Playwright Migration Summary
 
+## Migration Complete: test_search.py
+
+**Date:** April 28, 2026
+**Source:** `iqe-platform-ui-plugin/iqe_platform_ui/tests/test_search.py`
+**Target:** `insights-chrome/playwright/e2e/release-gate/search.spec.ts`
+
+### Tests Migrated
+
+#### 1. Search by Keyword
+**Test:** `test_search_by_keyword`
+**Playwright Implementation:** 14 parametrized test cases
+
+Tests search functionality for two main categories:
+
+**Identity & Access Management (8 test cases):**
+- ✅ Authentication Factors → finds "Identity & Access Management"
+- ✅ Identity → finds "Identity & Access Management"
+- ✅ IAM → finds "Identity & Access Management"
+- ✅ User Access → finds "Identity & Access Management"
+- ✅ User Management → finds "Identity & Access Management"
+- ✅ access management → finds "Identity & Access Management"
+- ✅ rbac → finds "Identity & Access Management"
+- ✅ RBAC → finds "Identity & Access Management"
+
+**Tasks/CentOS Conversion (6 test cases):**
+- ✅ CentOS conversion → finds "Tasks"
+- ✅ C2R → finds "Tasks"
+- ✅ CentOS → finds "Tasks"
+- ✅ centos conversion → finds "Tasks"
+- ✅ Pre-Conversion analysis → finds "Tasks"
+- ✅ Convert to RHEL → finds "Tasks"
+
+Each test verifies:
+1. Search returns at least one result
+2. Expected page name appears in search results
+
+#### 2. Empty Search State
+**Test:** `test_search_no_results`
+**Playwright Implementation:** 1 test case
+- ✅ Shows empty state when searching for whitespace
+
+Verifies that searching for whitespace displays the empty state UI and returns no results.
+
+### Testing Approach
+
+**Chrome Search Architecture:**
+- Uses local Orama search index for fast client-side search
+- Debounced search (1 second delay for analytics tracking)
+- Results displayed in dropdown menu with titles and descriptions
+- Supports expandable search input on mobile
+
+**Playwright Page Object:**
+Created `ChromeSearch` page object (`playwright/e2e/pages/chrome-search.ts`) with methods:
+- `open()` - Opens search input
+- `search(query)` - Enters search text and waits for results
+- `clear()` - Clears search input
+- `getResults()` - Returns result locators
+- `getResultTitles()` - Returns array of result titles
+- `resultsContain(text)` - Checks if results contain specific text
+- `isEmpty()` - Checks if empty state is displayed
+- `getResultCount()` - Returns number of results
+- `waitForResults()` - Waits for results menu to appear
+- `clickResult(index)` - Clicks result by index
+- `clickResultByTitle(title)` - Clicks result by title text
+
+**Selector Strategy:**
+- `page.getByPlaceholder('Search for services')` - Search input
+- `.chr-c-search__menu` - Results menu
+- `.chr-c-empty-state` - Empty state UI
+- `li[class*="pf-v6-c-menu__list-item"]` - Individual results
+
+### Migration Statistics
+
+- **Tests Migrated:** 2 test functions → 15 test cases
+  - test_search_by_keyword: 14 parametrized tests (8 IAM + 6 Tasks)
+  - test_search_no_results: 1 test for empty state
+- **Tests Skipped:** 0
+- **Page Objects Created:** 1 (ChromeSearch)
+- **Lines of Code:** ~230 (tests + page object)
+
+### IQE Source
+
+Tests migrated from: `iqe-platform-ui-plugin/iqe_platform_ui/tests/test_search.py`
+
+**IQE Metadata:**
+- Requirements: PLATFORM_UI-SEARCH-RESULTS
+- Importance: high
+
+---
+
 ## Migration Complete: test_navigation.py
 
 **Date:** April 27, 2026

--- a/playwright/e2e/MIGRATION-SUMMARY.md
+++ b/playwright/e2e/MIGRATION-SUMMARY.md
@@ -10,7 +10,7 @@
 
 #### 1. Search by Keyword
 **Test:** `test_search_by_keyword`
-**Playwright Implementation:** 14 parametrized test cases
+**Playwright Implementation:** 14 parameterized test cases
 
 Tests search functionality for two main categories:
 
@@ -47,7 +47,7 @@ Verifies that searching for whitespace displays the empty state UI and returns n
 
 **Chrome Search Architecture:**
 - Uses local Orama search index for fast client-side search
-- Debounced search (1 second delay for analytics tracking)
+- Debounced search (1-second delay for analytics tracking)
 - Results displayed in dropdown menu with titles and descriptions
 - Supports expandable search input on mobile
 
@@ -74,7 +74,7 @@ Created `ChromeSearch` page object (`playwright/e2e/pages/chrome-search.ts`) wit
 ### Migration Statistics
 
 - **Tests Migrated:** 2 test functions → 15 test cases
-  - test_search_by_keyword: 14 parametrized tests (8 IAM + 6 Tasks)
+  - test_search_by_keyword: 14 parameterized tests (8 IAM + 6 Tasks)
   - test_search_no_results: 1 test for empty state
 - **Tests Skipped:** 0
 - **Page Objects Created:** 1 (ChromeSearch)

--- a/playwright/e2e/pages/chrome-search.ts
+++ b/playwright/e2e/pages/chrome-search.ts
@@ -22,8 +22,8 @@ export class ChromeSearch {
     this.searchInput = page.getByPlaceholder('Search for services');
     // Search results menu
     this.searchMenu = page.locator('.chr-c-search__menu');
-    // Empty state message
-    this.emptyState = page.locator('.chr-c-empty-state');
+    // Empty state message - "No results found" heading
+    this.emptyState = page.getByRole('heading', { name: /No results found/i });
   }
 
   /**

--- a/playwright/e2e/pages/chrome-search.ts
+++ b/playwright/e2e/pages/chrome-search.ts
@@ -1,0 +1,152 @@
+import { Page, Locator } from '@playwright/test';
+import { SEARCH_TIMEOUT } from '../../setup/constants';
+
+/**
+ * Page Object for Chrome Search functionality
+ *
+ * Provides methods to interact with the platform search feature
+ * in the Chrome header.
+ */
+export class ChromeSearch {
+  readonly page: Page;
+  readonly searchToggle: Locator;
+  readonly searchInput: Locator;
+  readonly searchMenu: Locator;
+  readonly emptyState: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    // Expandable search toggle button
+    this.searchToggle = page.getByRole('button', { name: 'Expandable search input toggle' });
+    // Search input with placeholder "Search for services"
+    this.searchInput = page.getByPlaceholder('Search for services');
+    // Search results menu
+    this.searchMenu = page.locator('.chr-c-search__menu');
+    // Empty state message
+    this.emptyState = page.locator('.chr-c-empty-state');
+  }
+
+  /**
+   * Opens the search input (expands if collapsed)
+   */
+  async open() {
+    // Check if search input is already visible
+    const isInputVisible = await this.searchInput.isVisible();
+    if (!isInputVisible) {
+      // Click toggle to expand
+      await this.searchToggle.click();
+      // Wait for input to appear
+      await this.searchInput.waitFor({ state: 'visible' });
+    }
+  }
+
+  /**
+   * Enters search text and waits for results to load
+   * @param query - Search query string
+   */
+  async search(query: string) {
+    // Ensure search is open first
+    await this.open();
+
+    // Wait for search to be truly ready - check if input is enabled/editable
+    await this.searchInput.waitFor({ state: 'attached' });
+    await this.page.waitForFunction(() => {
+      const input = document.querySelector('input[placeholder="Search for services"]');
+      return input && !input.hasAttribute('disabled');
+    });
+
+    // Use type() instead of fill() to trigger keydown events that open the menu
+    await this.searchInput.type(query);
+
+    // Wait for either search menu (results) or empty state to appear
+    await this.searchMenu
+      .or(this.emptyState)
+      .waitFor({ state: 'visible', timeout: SEARCH_TIMEOUT });
+  }
+
+  /**
+   * Clears the search input
+   */
+  async clear() {
+    // Ensure search is open before clearing
+    await this.open();
+    await this.searchInput.clear();
+  }
+
+  /**
+   * Gets all search result items
+   * @returns Array of result MenuItem locators
+   */
+  getResults(): Locator {
+    return this.searchMenu.locator('li[class*="pf-v6-c-menu__list-item"]');
+  }
+
+  /**
+   * Gets search result titles
+   * @returns Array of result title texts
+   */
+  async getResultTitles(): Promise<string[]> {
+    const results = this.getResults();
+    const count = await results.count();
+    const titles: string[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const title = await results.nth(i).textContent();
+      if (title) {
+        titles.push(title.trim());
+      }
+    }
+
+    return titles;
+  }
+
+  /**
+   * Checks if search results contain a specific text
+   * @param text - Text to search for in results
+   * @returns true if any result contains the text
+   */
+  async resultsContain(text: string): Promise<boolean> {
+    const titles = await this.getResultTitles();
+    return titles.some((title) => title.toLowerCase().includes(text.toLowerCase()));
+  }
+
+  /**
+   * Checks if the empty state is displayed
+   * @returns true if empty state is visible
+   */
+  async isEmpty(): Promise<boolean> {
+    return await this.emptyState.isVisible();
+  }
+
+  /**
+   * Gets the count of search results
+   * @returns Number of results
+   */
+  async getResultCount(): Promise<number> {
+    return await this.getResults().count();
+  }
+
+  /**
+   * Waits for search results to appear
+   * @param timeout - Optional timeout in milliseconds
+   */
+  async waitForResults(timeout = SEARCH_TIMEOUT) {
+    await this.searchMenu.waitFor({ state: 'visible', timeout });
+  }
+
+  /**
+   * Clicks on a search result by index
+   * @param index - Zero-based index of the result to click
+   */
+  async clickResult(index: number) {
+    await this.getResults().nth(index).click();
+  }
+
+  /**
+   * Clicks on a search result by title text
+   * @param title - Title text to search for
+   */
+  async clickResultByTitle(title: string) {
+    await this.searchMenu.getByRole('menuitem').filter({ hasText: new RegExp(title, 'i') }).click();
+  }
+}

--- a/playwright/e2e/pages/chrome-search.ts
+++ b/playwright/e2e/pages/chrome-search.ts
@@ -22,8 +22,8 @@ export class ChromeSearch {
     this.searchInput = page.getByPlaceholder('Search for services');
     // Search results menu
     this.searchMenu = page.locator('.chr-c-search__menu');
-    // Empty state message - "No results found" heading
-    this.emptyState = page.getByRole('heading', { name: /No results found/i });
+    // Empty state message - "No results found" heading within the search menu
+    this.emptyState = this.searchMenu.getByRole('heading', { name: /No results found/i }).first();
   }
 
   /**
@@ -58,10 +58,8 @@ export class ChromeSearch {
     // Use type() instead of fill() to trigger keydown events that open the menu
     await this.searchInput.type(query);
 
-    // Wait for either search menu (results) or empty state to appear
-    await this.searchMenu
-      .or(this.emptyState)
-      .waitFor({ state: 'visible', timeout: SEARCH_TIMEOUT });
+    // Wait for search menu to appear (contains either results or empty state)
+    await this.searchMenu.waitFor({ state: 'visible', timeout: SEARCH_TIMEOUT });
   }
 
   /**

--- a/playwright/e2e/pages/chrome-search.ts
+++ b/playwright/e2e/pages/chrome-search.ts
@@ -145,9 +145,9 @@ export class ChromeSearch {
 
   /**
    * Clicks on a search result by title text
-   * @param title - Title text to search for
+   * @param title - Title text to search for (case-insensitive substring match)
    */
   async clickResultByTitle(title: string) {
-    await this.searchMenu.getByRole('menuitem').filter({ hasText: new RegExp(title, 'i') }).click();
+    await this.searchMenu.getByRole('menuitem').filter({ hasText: title }).click();
   }
 }

--- a/playwright/e2e/pages/chrome-search.ts
+++ b/playwright/e2e/pages/chrome-search.ts
@@ -55,6 +55,9 @@ export class ChromeSearch {
       return input && !input.hasAttribute('disabled');
     });
 
+    // Clear input to make method idempotent (type() appends, so clear first)
+    await this.searchInput.fill('');
+
     // Use type() instead of fill() to trigger keydown events that open the menu
     await this.searchInput.type(query);
 

--- a/playwright/e2e/pages/chrome-topbar.ts
+++ b/playwright/e2e/pages/chrome-topbar.ts
@@ -251,9 +251,78 @@ export class ChromeTopbar {
   }
 
   /**
-   * Opens the services menu
+   * Checks if the services menu is open
+   */
+  async isServicesMenuOpen(): Promise<boolean> {
+    const sidebarContent = this.page.locator('.pf-v6-c-sidebar__content');
+    try {
+      await sidebarContent.waitFor({ state: 'visible', timeout: 500 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Opens the services menu (idempotent)
    */
   async openServices(): Promise<void> {
-    await this.servicesButton.click();
+    if (!(await this.isServicesMenuOpen())) {
+      await this.servicesButton.click();
+      await this.page.locator('.pf-v6-c-sidebar__content').waitFor({
+        state: 'visible',
+        timeout: ChromeTopbar.MENU_TIMEOUT
+      });
+    }
+  }
+
+  /**
+   * Closes the services menu (idempotent)
+   */
+  async closeServices(): Promise<void> {
+    if (await this.isServicesMenuOpen()) {
+      await this.servicesButton.click();
+      await this.page.locator('.pf-v6-c-sidebar__content').waitFor({
+        state: 'hidden',
+        timeout: ChromeTopbar.MENU_TIMEOUT
+      });
+    }
+  }
+
+  /**
+   * Gets a service link by its OUIA component ID
+   * @param ouiaId The OUIA component ID (e.g., "AllServices-Dropdown-Ansible")
+   * @returns Locator for the service link
+   */
+  getServiceLink(ouiaId: string): Locator {
+    return this.page.locator(`[data-ouia-component-id="${ouiaId}"]`);
+  }
+
+  /**
+   * Gets a service link by platform name
+   * @param platformName The platform name (e.g., "Ansible", "Openshift", "RHEL")
+   * @returns Locator for the service link
+   */
+  getServiceLinkByPlatform(platformName: string): Locator {
+    return this.getServiceLink(`AllServices-Dropdown-${platformName}`);
+  }
+
+  /**
+   * Clicks a service in the services menu by OUIA ID
+   * @param ouiaId The OUIA component ID of the service
+   */
+  async clickService(ouiaId: string): Promise<void> {
+    await this.openServices();
+    const serviceLink = this.getServiceLink(ouiaId);
+    await serviceLink.waitFor({ state: 'visible', timeout: ChromeTopbar.MENU_TIMEOUT });
+    await serviceLink.click();
+  }
+
+  /**
+   * Clicks a service in the services menu by platform name
+   * @param platformName The platform name (e.g., "Ansible", "Openshift", "RHEL")
+   */
+  async clickServiceByPlatform(platformName: string): Promise<void> {
+    await this.clickService(`AllServices-Dropdown-${platformName}`);
   }
 }

--- a/playwright/e2e/pages/chrome-topbar.ts
+++ b/playwright/e2e/pages/chrome-topbar.ts
@@ -254,13 +254,7 @@ export class ChromeTopbar {
    * Checks if the services menu is open
    */
   async isServicesMenuOpen(): Promise<boolean> {
-    const sidebarContent = this.page.locator('.pf-v6-c-sidebar__content');
-    try {
-      await sidebarContent.waitFor({ state: 'visible', timeout: 500 });
-      return true;
-    } catch {
-      return false;
-    }
+    return await this.servicesButton.getAttribute('aria-expanded') === 'true';
   }
 
   /**

--- a/playwright/e2e/release-gate/auth.spec.ts
+++ b/playwright/e2e/release-gate/auth.spec.ts
@@ -1,9 +1,13 @@
 import { expect, test } from '../../setup/test-setup';
 import { login } from '../../helpers/auth';
+import { AUTH_TIMEOUT } from '../../setup/constants';
 
 test.describe('Authentication', () => {
   // Override storage state to start unauthenticated for login flow tests
   test.use({ storageState: { cookies: [], origins: [] } });
+
+  // SSO authentication can be slow in CI - use AUTH_TIMEOUT for all tests
+  test.describe.configure({ timeout: AUTH_TIMEOUT });
 
   test('should successfully login and verify authenticated state', async ({ page }) => {
     await login(page);

--- a/playwright/e2e/release-gate/navigation.spec.ts
+++ b/playwright/e2e/release-gate/navigation.spec.ts
@@ -1,10 +1,18 @@
-import { test, expect } from '../../setup/test-setup';
+import { test, expect, Page } from '../../setup/test-setup';
 import { ChromeNavigation } from '../pages/chrome-navigation';
 
 test.describe('Navigation', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });
+
+  /**
+   * Helper to open the services menu and wait for it to be visible
+   */
+  async function openServicesMenu(page: Page) {
+    await page.locator('.chr-c-link-service-toggle').click();
+    await expect(page.locator('.pf-v6-c-sidebar__content')).toBeVisible();
+  }
 
   test('visit services', async ({ page }) => {
     // click on services button
@@ -78,8 +86,7 @@ test.describe('Navigation', () => {
     // Validates chrome navigation structure, not the destination routes themselves
 
     // Open services menu
-    await page.locator('.chr-c-link-service-toggle').click();
-    await expect(page.locator('.pf-v6-c-sidebar__content')).toBeVisible();
+    await openServicesMenu(page);
 
     // Find Ansible platform link within services menu using OUIA ID
     const ansibleLink = page.locator('[data-ouia-component-id="AllServices-Dropdown-Ansible"]');
@@ -94,8 +101,7 @@ test.describe('Navigation', () => {
     // Validates chrome navigation structure, not the destination routes themselves
 
     // Open services menu
-    await page.locator('.chr-c-link-service-toggle').click();
-    await expect(page.locator('.pf-v6-c-sidebar__content')).toBeVisible();
+    await openServicesMenu(page);
 
     // Find OpenShift platform link within services menu using OUIA ID
     const openshiftLink = page.locator('[data-ouia-component-id="AllServices-Dropdown-Openshift"]');
@@ -110,8 +116,7 @@ test.describe('Navigation', () => {
     // Validates chrome navigation structure, not the destination routes themselves
 
     // Open services menu
-    await page.locator('.chr-c-link-service-toggle').click();
-    await expect(page.locator('.pf-v6-c-sidebar__content')).toBeVisible();
+    await openServicesMenu(page);
 
     // Find RHEL/Insights platform link within services menu using OUIA ID
     const insightsLink = page.locator('[data-ouia-component-id="AllServices-Dropdown-RHEL"]');

--- a/playwright/e2e/release-gate/navigation.spec.ts
+++ b/playwright/e2e/release-gate/navigation.spec.ts
@@ -1,30 +1,27 @@
-import { test, expect, Page } from '../../setup/test-setup';
+import { test, expect } from '../../setup/test-setup';
 import { ChromeNavigation } from '../pages/chrome-navigation';
+import { ChromeTopbar } from '../pages/chrome-topbar';
 
 test.describe('Navigation', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });
 
-  /**
-   * Helper to open the services menu and wait for it to be visible
-   */
-  async function openServicesMenu(page: Page) {
-    await page.locator('.chr-c-link-service-toggle').click();
-    await expect(page.locator('.pf-v6-c-sidebar__content')).toBeVisible();
-  }
-
   test('visit services', async ({ page }) => {
-    // click on services button
-    await page.locator('.chr-c-link-service-toggle').click();
+    const topbar = new ChromeTopbar(page);
 
-    // Verify the services dropdown is visible
-    await expect(page.locator('.pf-v6-c-sidebar__content')).toBeVisible();
+    // Open services menu
+    await topbar.openServices();
+
+    // Verify the services menu is visible
+    await expect(await topbar.isServicesMenuOpen()).toBe(true);
   });
 
   test('Navigate to users', async ({ page }) => {
-    // click on services button
-    await page.locator('.chr-c-link-service-toggle').click();
+    const topbar = new ChromeTopbar(page);
+
+    // Open services menu
+    await topbar.openServices();
 
     // click on all services
     await page.locator('[data-ouia-component-id="View all link"]').first().click();
@@ -84,12 +81,13 @@ test.describe('Navigation', () => {
   test('platform link - Ansible has correct internal route', async ({ page }) => {
     // Migrated from test_navigation.py::test_services_menu_platform_links (Ansible variant)
     // Validates chrome navigation structure, not the destination routes themselves
+    const topbar = new ChromeTopbar(page);
 
     // Open services menu
-    await openServicesMenu(page);
+    await topbar.openServices();
 
     // Find Ansible platform link within services menu using OUIA ID
-    const ansibleLink = page.locator('[data-ouia-component-id="AllServices-Dropdown-Ansible"]');
+    const ansibleLink = topbar.getServiceLinkByPlatform('Ansible');
 
     // Verify link exists and has correct internal href
     await expect(ansibleLink).toBeVisible();
@@ -99,12 +97,13 @@ test.describe('Navigation', () => {
   test('platform link - OpenShift has correct internal route', async ({ page }) => {
     // Migrated from test_navigation.py::test_services_menu_platform_links (OpenShift variant)
     // Validates chrome navigation structure, not the destination routes themselves
+    const topbar = new ChromeTopbar(page);
 
     // Open services menu
-    await openServicesMenu(page);
+    await topbar.openServices();
 
     // Find OpenShift platform link within services menu using OUIA ID
-    const openshiftLink = page.locator('[data-ouia-component-id="AllServices-Dropdown-Openshift"]');
+    const openshiftLink = topbar.getServiceLinkByPlatform('Openshift');
 
     // Verify link exists and has correct internal href
     await expect(openshiftLink).toBeVisible();
@@ -114,12 +113,13 @@ test.describe('Navigation', () => {
   test('platform link - Insights has correct internal route', async ({ page }) => {
     // Migrated from test_navigation.py::test_services_menu_platform_links (Insights variant)
     // Validates chrome navigation structure, not the destination routes themselves
+    const topbar = new ChromeTopbar(page);
 
     // Open services menu
-    await openServicesMenu(page);
+    await topbar.openServices();
 
     // Find RHEL/Insights platform link within services menu using OUIA ID
-    const insightsLink = page.locator('[data-ouia-component-id="AllServices-Dropdown-RHEL"]');
+    const insightsLink = topbar.getServiceLinkByPlatform('RHEL');
 
     // Verify link exists and has correct internal href
     await expect(insightsLink).toBeVisible();

--- a/playwright/e2e/release-gate/search.spec.ts
+++ b/playwright/e2e/release-gate/search.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '../../setup/test-setup';
+import { ChromeSearch } from '../pages/chrome-search';
+
+/**
+ * Test: Platform Search Functionality
+ *
+ * Migrated from: iqe-platform-ui-plugin/iqe_platform_ui/tests/test_search.py
+ *
+ * Verifies that the platform search feature:
+ * - Returns relevant results for common search keywords
+ * - Displays correct page names in search results
+ * - Shows empty state when no results are found
+ *
+ * Tags from IQE:
+ * - metadata.requirements: PLATFORM_UI-SEARCH-RESULTS
+ * - metadata.importance: high
+ */
+
+test.describe('Platform Search', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('load');
+  });
+
+  /**
+   * Test search results for Identity & Access Management keywords
+   * Migrated from: test_search_by_keyword (Identity & Access Management variant)
+   */
+  test.describe('Identity & Access Management searches', () => {
+    const expectedPage = 'Identity & Access Management';
+    const keywords = [
+      'Authentication Factors',
+      'Identity',
+      'IAM',
+      'User Access',
+      'User Management',
+      'access management',
+      'rbac',
+      'RBAC',
+    ];
+
+    for (const keyword of keywords) {
+      test(`should find "${expectedPage}" when searching for "${keyword}"`, async ({ page }) => {
+        const search = new ChromeSearch(page);
+
+        // Search for the keyword (search() handles opening and waiting for results)
+        await search.search(keyword);
+
+        // Verify results are returned
+        const resultCount = await search.getResultCount();
+        expect(resultCount, `No search results found for keyword: ${keyword}`).toBeGreaterThan(0);
+
+        // Verify the expected page appears in results
+        const containsExpectedPage = await search.resultsContain(expectedPage);
+        expect(containsExpectedPage, `"${expectedPage}" not found in search results for keyword: ${keyword}`).toBe(true);
+      });
+    }
+  });
+
+  /**
+   * Test search results for Tasks/CentOS conversion keywords
+   * Migrated from: test_search_by_keyword (Tasks variant)
+   */
+  test.describe('Tasks searches', () => {
+    const expectedPage = 'Tasks';
+    const keywords = ['CentOS conversion', 'C2R', 'CentOS', 'centos conversion', 'Pre-Conversion analysis', 'Convert to RHEL'];
+
+    for (const keyword of keywords) {
+      test(`should find "${expectedPage}" when searching for "${keyword}"`, async ({ page }) => {
+        const search = new ChromeSearch(page);
+
+        // Search for the keyword (search() handles opening and waiting for results)
+        await search.search(keyword);
+
+        // Verify results are returned
+        const resultCount = await search.getResultCount();
+        expect(resultCount, `No search results found for keyword: ${keyword}`).toBeGreaterThan(0);
+
+        // Verify the expected page appears in results
+        const containsExpectedPage = await search.resultsContain(expectedPage);
+        expect(containsExpectedPage, `"${expectedPage}" not found in search results for keyword: ${keyword}`).toBe(true);
+      });
+    }
+  });
+
+  /**
+   * Test empty search state
+   * Migrated from: test_search_no_results
+   *
+   * Verifies that searching for whitespace/nothing shows the empty state
+   */
+  test('should show empty state when searching for whitespace', async ({ page }) => {
+    const search = new ChromeSearch(page);
+
+    // Search for whitespace (search() handles opening and waiting for UI state)
+    await search.search(' ');
+
+    // Verify empty state is displayed
+    const isEmpty = await search.isEmpty();
+    expect(isEmpty, 'Empty state should be displayed when searching for whitespace').toBe(true);
+
+    // Verify no results are shown
+    const resultCount = await search.getResultCount();
+    expect(resultCount, 'No results should be displayed for whitespace search').toBe(0);
+  });
+});

--- a/playwright/setup/constants.ts
+++ b/playwright/setup/constants.ts
@@ -18,3 +18,10 @@ export const AUTH_TIMEOUT = 90000; // 90 seconds
  * Should be sufficient for application bootstrap and initial render.
  */
 export const NAVIGATION_TIMEOUT = 60000; // 60 seconds
+
+/**
+ * Timeout for search operations.
+ * Search uses local Orama index query which loads asynchronously on page load.
+ * This timeout accounts for async index loading + query execution time in CI.
+ */
+export const SEARCH_TIMEOUT = 10000; // 10 seconds


### PR DESCRIPTION
## Summary

Migrates search functionality tests from IQE (`iqe-platform-ui-plugin/iqe_platform_ui/tests/test_search.py`) to Playwright.

## Test Coverage

**Total: 15 test cases**

### Identity & Access Management searches (8 tests)
- Authentication Factors → finds "Identity & Access Management"
- Identity → finds "Identity & Access Management"
- IAM → finds "Identity & Access Management"
- User Access → finds "Identity & Access Management"
- User Management → finds "Identity & Access Management"
- access management → finds "Identity & Access Management"
- rbac → finds "Identity & Access Management"
- RBAC → finds "Identity & Access Management"

### Tasks searches (6 tests)
- CentOS conversion → finds "Tasks"
- C2R → finds "Tasks"
- CentOS → finds "Tasks"
- centos conversion → finds "Tasks"
- Pre-Conversion analysis → finds "Tasks"
- Convert to RHEL → finds "Tasks"

### Empty state (1 test)
- Shows empty state when searching for whitespace

## Implementation Details

### ChromeSearch Page Object
Created `playwright/e2e/pages/chrome-search.ts` with methods:
- `open()` - Opens expandable search input (idempotent)
- `search(query)` - Enters search text and waits for results
- `clear()` - Clears search input
- `getResults()` - Returns result locators
- `getResultTitles()` - Returns array of result titles
- `resultsContain(text)` - Checks if results contain specific text
- `isEmpty()` - Checks if empty state is displayed
- `getResultCount()` - Returns number of results
- `waitForResults()` - Waits for results menu to appear
- `clickResult(index)` - Clicks result by index
- `clickResultByTitle(title)` - Clicks result by title text

### Key Technical Decisions

1. **Use `type()` instead of `fill()`** - The SearchInput component's `onToggleKeyDown` handler opens the results menu based on keyboard events, which `fill()` doesn't trigger.

2. **Wait for async Orama index** - Search uses a local Orama search index that loads asynchronously. Added `waitForFunction` to check input is enabled before typing.

3. **Scoped empty state locator** - Multiple "No results found" headings exist (h1 and h2), so scoped the locator within the search menu: `this.searchMenu.getByRole('heading', { name: /No results found/i }).first()`

4. **SEARCH_TIMEOUT constant** - 10 seconds to account for async index loading and query execution in CI.

5. **Expandable search UI** - Search input is expandable on mobile. The `open()` method checks if already visible before clicking toggle (idempotent pattern).

## Files Changed

- `playwright/e2e/pages/chrome-search.ts` (new) - Page object for search interactions
- `playwright/e2e/release-gate/search.spec.ts` (new) - 15 test cases
- `playwright/setup/constants.ts` - Added SEARCH_TIMEOUT constant
- `playwright/e2e/MIGRATION-SUMMARY.md` - Updated with migration details

## IQE Source

- **File**: `iqe-platform-ui-plugin/iqe_platform_ui/tests/test_search.py`
- **Requirements**: PLATFORM_UI-SEARCH-RESULTS
- **Importance**: high

## Testing Notes

All tests verify:
1. Search returns at least one result
2. Expected page name appears in search results
3. Empty state displays correctly for whitespace input

🤖 Generated with assistance from Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Playwright E2E suites for platform search and navigation, page-object helpers for header search and topbar services, keyword-driven result checks, empty-state assertions, and test timeout configuration for stability.

* **Documentation**
  * Added migration notes summarizing migrated search tests, page-object API, selector strategy, and migration statistics.

* **Chores**
  * CI-only dev-server override to disable the overlay during runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->