### PR TITLE
Example of using two different test users for tests in a single pipeline

### DIFF
--- a/.tekton/insights-chrome-pull-request.yaml
+++ b/.tekton/insights-chrome-pull-request.yaml
@@ -312,17 +312,10 @@ spec:
               memory: "8Gi"
           image: mcr.microsoft.com/playwright:v1.59.1-jammy
           name: e2e-tests
+          envFrom:
+          - secretRef:
+              name: chrome-credentials-secret
           env:
-          - name: CHROME_ACCOUNT
-            valueFrom:
-              secretKeyRef:
-                name: chrome-credentials-secret
-                key: username
-          - name: CHROME_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: chrome-credentials-secret
-                key: password
           - name: NODE_TLS_REJECT_UNAUTHORIZED
             value: "0"
           - name: CI
@@ -346,7 +339,12 @@ spec:
             echo "Dev server is ready! Running tests."
 
             echo "Running Playwright e2e tests"
-            E2E_USER="$CHROME_ACCOUNT" E2E_PASSWORD="$CHROME_PASSWORD" npx playwright test
+            # All credentials from chrome-credentials-secret are automatically available as env vars via envFrom:
+            #   $username, $password - Default admin user
+            #   $E2E_NON_ADMIN_USER, $E2E_NON_ADMIN_PASSWORD - Non-admin user
+            # Playwright tests can access these directly via process.env.username, process.env.E2E_NON_ADMIN_USER, etc.
+
+            npx playwright test
             echo "Tests finished. Killing dev server (PID: $DEV_SERVER_PID)..."
             kill $DEV_SERVER_PID
           securityContext:

--- a/.tekton/insights-chrome-pull-request.yaml
+++ b/.tekton/insights-chrome-pull-request.yaml
@@ -340,9 +340,13 @@ spec:
 
             echo "Running Playwright e2e tests"
             # All credentials from chrome-credentials-secret are automatically available as env vars via envFrom:
-            #   $username, $password - Default admin user
-            #   $E2E_NON_ADMIN_USER, $E2E_NON_ADMIN_PASSWORD - Non-admin user
-            # Playwright tests can access these directly via process.env.username, process.env.E2E_NON_ADMIN_USER, etc.
+            #   $username, $password - Default admin user (mapped to E2E_USER/E2E_PASSWORD below)
+            #   $E2E_NON_ADMIN_USER, $E2E_NON_ADMIN_PASSWORD - Non-admin user (used directly)
+
+            # Map secret keys to expected Playwright env vars
+            export E2E_USER="$username"
+            export E2E_PASSWORD="$password"
+            # E2E_NON_ADMIN_USER and E2E_NON_ADMIN_PASSWORD are already correctly named in the secret
 
             npx playwright test
             echo "Tests finished. Killing dev server (PID: $DEV_SERVER_PID)..."

--- a/playwright/e2e/release-gate/multiuser.spec.ts
+++ b/playwright/e2e/release-gate/multiuser.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '../../setup/test-setup';
+import { loginAsNonAdmin } from '../../helpers/auth';
+
+test.describe('Multi-user support', () => {
+  // Override storage state to start unauthenticated for login flow tests
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('should NOT show Org Admin option for non-admin users', async ({ page }) => {
+    // Login as non-admin user
+    await loginAsNonAdmin(page);
+
+    // Verify we're on the dashboard
+    await expect(page).toHaveURL('/');
+
+    // Open the user menu in the upper-right corner
+    const userMenu = page.getByRole('button', { name: /User Avatar/ });
+    await expect(userMenu).toBeVisible();
+    await userMenu.click();
+
+    // Verify standard menu items are present
+    await expect(page.getByText('Username')).toBeVisible();
+    await expect(page.getByText(/My (user )?access/i)).toBeVisible();
+    await expect(page.getByText('User preferences')).toBeVisible();
+    await expect(page.getByText('Log out')).toBeVisible();
+
+    // Verify 'Org Admin' is NOT shown for non-admin users
+    await expect(page.getByText('Org Admin')).not.toBeVisible();
+  });
+});

--- a/playwright/helpers/auth.ts
+++ b/playwright/helpers/auth.ts
@@ -18,13 +18,17 @@ import {
  *
  * IMPORTANT: Most tests should NOT call this directly. Global setup handles authentication
  * automatically via storage state. Use this only for tests that specifically test login flows.
+ *
+ * @param page - Playwright Page object
+ * @param user - Optional username (defaults to E2E_USER env var)
+ * @param password - Optional password (defaults to E2E_PASSWORD env var)
  */
-export async function login(page: Page) {
-  const user = process.env.E2E_USER;
-  const password = process.env.E2E_PASSWORD;
+export async function login(page: Page, user?: string, password?: string) {
+  const username = user ?? process.env.E2E_USER;
+  const userPassword = password ?? process.env.E2E_PASSWORD;
 
-  if (!user || !password) {
-    throw new Error('E2E_USER and E2E_PASSWORD environment variables must be set');
+  if (!username || !userPassword) {
+    throw new Error('E2E_USER and E2E_PASSWORD environment variables must be set or passed as parameters');
   }
 
   // Block TrustArc consent requests
@@ -34,7 +38,7 @@ export async function login(page: Page) {
   await page.goto('/');
 
   // Perform login using shared package
-  await sharedLogin(page, user, password);
+  await sharedLogin(page, username, userPassword);
 
   // Disable analytics integrations (insights-chrome specific)
   await page.evaluate(() => {
@@ -47,6 +51,22 @@ export async function login(page: Page) {
     state: 'visible',
     timeout: 60000
   });
+}
+
+/**
+ * Performs Red Hat SSO login as the non-admin test user.
+ *
+ * Convenience wrapper around login() that uses E2E_NON_ADMIN_USER credentials.
+ */
+export async function loginAsNonAdmin(page: Page) {
+  const user = process.env.E2E_NON_ADMIN_USER;
+  const password = process.env.E2E_NON_ADMIN_PASSWORD;
+
+  if (!user || !password) {
+    throw new Error('E2E_NON_ADMIN_USER and E2E_NON_ADMIN_PASSWORD environment variables must be set');
+  }
+
+  await login(page, user, password);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Refactors PR pipeline to use `envFrom` instead of individual `env` entries for test credentials
- Enables support for multiple test users (admin and non-admin) in Playwright E2E tests
- Credentials are now automatically injected from `chrome-credentials-secret` via External Secrets Operator

## Changes
- Replace individual `env.valueFrom.secretKeyRef` blocks with `envFrom.secretRef`
- Remove inline environment variable assignment in test script
- Document available credentials for Playwright tests

## Available Credentials
All credentials from `chrome-credentials-secret` are now available as environment variables:
- `username`, `password` - Default admin test user
- `E2E_NON_ADMIN_USER`, `E2E_NON_ADMIN_PASSWORD` - Non-admin test user

Playwright tests can access these via `process.env.username`, `process.env.E2E_NON_ADMIN_USER`, etc.

## Test Plan
- [ ] PR pipeline runs successfully
- [ ] Playwright E2E tests pass with existing credentials
- [ ] Multi-user tests can access both admin and non-admin credentials

## Dependencies
- ✅ ExternalSecret updated in `konflux-release-data` (merged and synced)
- ✅ Vault credentials added: `E2E_NON_ADMIN_USER`, `E2E_NON_ADMIN_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test configuration to streamline credential handling for test execution.

* **Tests**
  * Added a new end-to-end test validating multi-user UI behavior for non-admin accounts (menu items, preferences, and logout visibility).
  * Improved test helpers to allow credential overrides for more flexible test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->