### PR TITLE
RHCLOUD-44391: test: migrate browser title validation tests from IQE

### DIFF
--- a/playwright/e2e/browser-titles.spec.ts
+++ b/playwright/e2e/browser-titles.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '../setup/test-setup';
+import { ChromeNavigation } from './pages/chrome-navigation';
+
+/**
+ * Browser Title Validation Tests
+ *
+ * Migrated from IQE: iqe_platform_ui/tests/test_browser_titles.py
+ *
+ * These tests verify that browser page titles are correctly set when navigating
+ * to different pages in the console. Proper titles are important for:
+ * - SEO and search engine indexing
+ * - Browser tab identification
+ * - User experience and navigation
+ * - Accessibility (screen readers announce page titles)
+ *
+ * Requirements: PLATFORM_UI-BROWSER_TITLES
+ */
+
+test.describe('Browser Titles - Settings Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to Settings page before each test
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+  });
+
+  const settingsTestCases = [
+    {
+      navItems: ['Integrations'],
+      expectedTitle: 'Integrations | Settings',
+    },
+    {
+      navItems: ['Notifications', 'Overview'],
+      expectedTitle: 'Notifications | Settings',
+    },
+    {
+      navItems: ['Notifications', 'Configure Events'],
+      expectedTitle: 'Red Hat Enterprise Linux - Notifications | Settings',
+    },
+    {
+      navItems: ['Notifications', 'Event Log'],
+      expectedTitle: 'Notifications | Settings',
+    },
+    {
+      navItems: ['Notifications', 'Notification Preferences'],
+      expectedTitle: 'Notification Preferences | Hybrid Cloud Console',
+    },
+    {
+      navItems: ['Learning Resources'],
+      expectedTitle: 'Learning Resources | Settings',
+    },
+  ];
+
+  for (const { navItems, expectedTitle } of settingsTestCases) {
+    test(`should display "${expectedTitle}" for ${navItems.join(' → ')}`, async ({ page }) => {
+      const navigation = new ChromeNavigation(page);
+
+      // Navigate through the menu items
+      await navigation.navigateToPage(navItems);
+
+      // Wait for the page to fully load
+      await page.waitForLoadState('networkidle');
+
+      // Verify the browser title
+      await expect(page).toHaveTitle(expectedTitle);
+    });
+  }
+});

--- a/playwright/e2e/browser-titles.spec.ts
+++ b/playwright/e2e/browser-titles.spec.ts
@@ -20,7 +20,6 @@ test.describe('Browser Titles - Settings Navigation', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to Settings page before each test
     await page.goto('/settings');
-    await page.waitForLoadState('networkidle');
   });
 
   const settingsTestCases = [
@@ -57,10 +56,7 @@ test.describe('Browser Titles - Settings Navigation', () => {
       // Navigate through the menu items
       await navigation.navigateToPage(navItems);
 
-      // Wait for the page to fully load
-      await page.waitForLoadState('networkidle');
-
-      // Verify the browser title
+      // Verify the browser title (built-in retry handles timing)
       await expect(page).toHaveTitle(expectedTitle);
     });
   }

--- a/playwright/e2e/pages/chrome-navigation.ts
+++ b/playwright/e2e/pages/chrome-navigation.ts
@@ -86,6 +86,9 @@ export class ChromeNavigation {
       const linkItem = this.sidebar.getByRole('link', { name: itemName, exact: true });
       const buttonItem = this.sidebar.getByRole('button', { name: itemName, exact: true });
 
+      // Wait for the navigation item to appear in the sidebar before attempting to click
+      await linkItem.or(buttonItem).first().waitFor({ state: 'visible', timeout: 10000 });
+
       // Check which one exists and verify uniqueness before clicking
       const linkCount = await linkItem.count();
       const buttonCount = await buttonItem.count();

--- a/playwright/e2e/pages/chrome-navigation.ts
+++ b/playwright/e2e/pages/chrome-navigation.ts
@@ -67,4 +67,39 @@ export class ChromeNavigation {
 
     return selectedItems;
   }
+
+  /**
+   * Navigates to a page by clicking through navigation items
+   * Handles both flat navigation (single item) and nested navigation (multiple items)
+   *
+   * @param navItems Array of navigation item names to click in sequence
+   * @example
+   * // Single level navigation
+   * await navigation.navigateToPage(['Integrations']);
+   *
+   * // Nested navigation
+   * await navigation.navigateToPage(['Notifications', 'Configure Events']);
+   */
+  async navigateToPage(navItems: string[]): Promise<void> {
+    for (const itemName of navItems) {
+      // Try to find the item as either a link or button
+      const linkItem = this.sidebar.getByRole('link', { name: itemName, exact: true });
+      const buttonItem = this.sidebar.getByRole('button', { name: itemName, exact: true });
+
+      // Check which one exists and click it
+      const linkCount = await linkItem.count();
+      const buttonCount = await buttonItem.count();
+
+      if (linkCount > 0) {
+        await linkItem.click();
+      } else if (buttonCount > 0) {
+        await buttonItem.click();
+      } else {
+        throw new Error(`Navigation item "${itemName}" not found in sidebar`);
+      }
+
+      // Wait for navigation to settle after each click
+      await this.page.waitForLoadState('domcontentloaded');
+    }
+  }
 }

--- a/playwright/e2e/pages/chrome-navigation.ts
+++ b/playwright/e2e/pages/chrome-navigation.ts
@@ -86,13 +86,17 @@ export class ChromeNavigation {
       const linkItem = this.sidebar.getByRole('link', { name: itemName, exact: true });
       const buttonItem = this.sidebar.getByRole('button', { name: itemName, exact: true });
 
-      // Check which one exists and click it
+      // Check which one exists and verify uniqueness before clicking
       const linkCount = await linkItem.count();
       const buttonCount = await buttonItem.count();
 
-      if (linkCount > 0) {
+      if (linkCount > 1) {
+        throw new Error(`Multiple link matches found for "${itemName}" (${linkCount} matches). Navigation is ambiguous.`);
+      } else if (linkCount === 1) {
         await linkItem.click();
-      } else if (buttonCount > 0) {
+      } else if (buttonCount > 1) {
+        throw new Error(`Multiple button matches found for "${itemName}" (${buttonCount} matches). Navigation is ambiguous.`);
+      } else if (buttonCount === 1) {
         await buttonItem.click();
       } else {
         throw new Error(`Navigation item "${itemName}" not found in sidebar`);


### PR DESCRIPTION
## Summary

Migrates `test_browser_titles.py` from iqe-platform-ui-plugin to Playwright.

## Changes

- ✅ New test file: `playwright/e2e/browser-titles.spec.ts`
- ✅ Enhanced `ChromeNavigation` page object with `navigateToPage()` method for nested navigation

## Test Coverage (6 test cases)

Tests verify that browser page titles are correctly set when navigating to different Settings pages:

- Integrations → "Integrations | Settings"
- Notifications → Overview → "Notifications | Settings"
- Notifications → Configure Events → "Red Hat Enterprise Linux - Notifications | Settings"
- Notifications → Event Log → "Notifications | Settings"
- Notifications → Notification Preferences → "Notification Preferences | Hybrid Cloud Console"
- Learning Resources → "Learning Resources | Settings"

## Notes

- User Access navigation tests were not migrated as that navigation path no longer exists from the Console Settings page
- Browser titles are important for SEO, browser tab identification, UX, and accessibility (screen readers)

## Requirements

- PLATFORM_UI-BROWSER_TITLES

## Related

- JIRA: RHCLOUD-44391
- IQE Source: `iqe_platform_ui/tests/test_browser_titles.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests that verify browser tab titles across Settings console subpages.
  * Added a navigation helper for the test suite to traverse sequential menu items.
  * Tests now ensure each page fully loads between navigation steps, improving reliability of title and navigation verifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->