### PR TITLE
test: migrate progressive profile tests from IQE (RHCLOUD-44391)

### DIFF
--- a/playwright/e2e/MIGRATION-SUMMARY.md
+++ b/playwright/e2e/MIGRATION-SUMMARY.md
@@ -259,3 +259,66 @@ For questions about this migration:
 - **Test Cases Created:** 4 total (2 org ID + 2 logout variants)
 - **Page Objects Created:** 1 (ChromeTopbar)
 - **Lines of Code:** ~280 (tests + page object + documentation)
+
+---
+
+## Migration Complete: test_progressive_profile.py
+
+**Date:** May 1, 2026
+**Source:** `iqe-platform-ui-plugin/iqe_platform_ui/tests/test_progressive_profile.py`
+**Target:** `insights-chrome/playwright/e2e/release-gate/progressive-profile.spec.ts`
+
+### Tests Migrated
+
+#### 1. Thin Profile User Login
+**Test:** `test_thin_profile_login`
+**Playwright Implementation:** `thin profile user can login`
+
+Tests that a user with a thin profile (minimal registration information) can successfully log into the console. Uses isolated browser context to avoid affecting shared authentication state.
+
+**Requirements:**
+- Environment variables: `THIN_USER` and `THIN_PASSWORD` must be set
+- Tests are automatically skipped if credentials are not provided
+
+#### 2. Thick Profile Prompt
+**Test:** `test_thick_profile_prompt_from_my_profile`
+**Playwright Implementation:** `thin profile user sees thick profile prompt from my profile`
+
+Verifies that when a thin profile user navigates to "My Profile", they are prompted to complete their profile (transition from thin to thick profile).
+
+**Behavior tested:**
+- Login with thin user credentials
+- Navigate to My Profile via user menu
+- Verify presence of profile completion form or prompt
+
+### Tests NOT Migrated
+
+#### ❌ test_thin_profile_creation
+**Reason:** Manual test
+**Details:** This test is marked as `@pytest.mark.manual` in IQE and requires manual user registration steps that cannot be automated. Creating thin profile users is a manual process that involves account registration.
+
+### Implementation Details
+
+**Authentication Handling:**
+- Uses isolated browser contexts for thin user authentication
+- Does not reuse shared authentication state
+- Each test performs fresh login with thin user credentials
+
+**Environment Configuration:**
+- Thin user credentials must be provided via environment variables
+- Tests are conditionally skipped if credentials are not available
+- No hardcoded test user credentials
+
+**Progressive Profile Concept:**
+- **Thin Profile:** Basic user account with minimal information
+- **Thick Profile:** Complete user account with full profile details
+- Users start with thin profiles and are prompted to upgrade to thick profiles
+
+### Migration Statistics
+
+- **Tests Migrated:** 2 (thin profile login, thick profile prompt)
+- **Tests Skipped:** 1 (thin profile creation - manual test)
+- **Test Cases Created:** 2
+- **Lines of Code:** ~140 (tests + documentation)
+
+---

--- a/playwright/e2e/MIGRATION-SUMMARY.md
+++ b/playwright/e2e/MIGRATION-SUMMARY.md
@@ -268,6 +268,8 @@ For questions about this migration:
 **Source:** `iqe-platform-ui-plugin/iqe_platform_ui/tests/test_progressive_profile.py`
 **Target:** `insights-chrome/playwright/e2e/release-gate/progressive-profile.spec.ts`
 
+**Status:** ⚠️ **Tests currently skipped pending rework (RHCLOUD-47458)**
+
 ### Tests Migrated
 
 #### 1. Thin Profile User Login
@@ -277,8 +279,8 @@ For questions about this migration:
 Tests that a user with a thin profile (minimal registration information) can successfully log into the console. Uses isolated browser context to avoid affecting shared authentication state.
 
 **Requirements:**
-- Environment variables: `THIN_USER` and `THIN_PASSWORD` must be set
-- Tests are automatically skipped if credentials are not provided
+- Environment variables: `THIN_USER` and `THIN_PASSWORD` (not currently required while tests are skipped)
+- Tests will be reworked when updated profile flow requirements are defined
 
 #### 2. Thick Profile Prompt
 **Test:** `test_thick_profile_prompt_from_my_profile`
@@ -305,8 +307,8 @@ Verifies that when a thin profile user navigates to "My Profile", they are promp
 - Each test performs fresh login with thin user credentials
 
 **Environment Configuration:**
-- Thin user credentials must be provided via environment variables
-- Tests are conditionally skipped if credentials are not available
+- Thin user credentials will be provided via environment variables (`THIN_USER`, `THIN_PASSWORD`)
+- Tests are currently disabled pending rework (RHCLOUD-47458)
 - No hardcoded test user credentials
 
 **Progressive Profile Concept:**

--- a/playwright/e2e/release-gate/progressive-profile.spec.ts
+++ b/playwright/e2e/release-gate/progressive-profile.spec.ts
@@ -13,17 +13,18 @@ import { test, expect } from '../../setup/test-setup';
  * - PLATFORM_UI-THIN
  * - PLATFORM_UI-THICK
  *
- * Note: These tests require a thin profile user account to be available.
- * Set THIN_USER and THIN_PASSWORD environment variables to enable these tests.
+ * Environment Variables Required:
+ * - THIN_USER: Username for thin profile test account
+ * - THIN_PASSWORD: Password for thin profile test account
  */
 
 test.describe('Progressive Profile', () => {
-  // Skip all tests if thin user credentials are not provided
   const thinUser = process.env.THIN_USER;
   const thinPassword = process.env.THIN_PASSWORD;
-  const skipThinUserTests = !thinUser || !thinPassword;
 
-  test.skip(skipThinUserTests, 'Thin user credentials not provided');
+  if (!thinUser || !thinPassword) {
+    throw new Error('THIN_USER and THIN_PASSWORD environment variables must be set');
+  }
 
   test('thin profile user can login', async ({ browser, baseURL }) => {
     // Create isolated context for thin user login
@@ -47,10 +48,10 @@ test.describe('Progressive Profile', () => {
       // Fill in thin user credentials
       const usernameInput = page.getByLabel('Red Hat login').first();
       await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
-      await usernameInput.fill(thinUser!);
+      await usernameInput.fill(thinUser);
 
       const passwordInput = page.getByLabel('Password').first();
-      await passwordInput.fill(thinPassword!);
+      await passwordInput.fill(thinPassword);
 
       // Submit login form
       const loginButton = page.getByRole('button', { name: /log in|next/i });
@@ -88,10 +89,10 @@ test.describe('Progressive Profile', () => {
 
       const usernameInput = page.getByLabel('Red Hat login').first();
       await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
-      await usernameInput.fill(thinUser!);
+      await usernameInput.fill(thinUser);
 
       const passwordInput = page.getByLabel('Password').first();
-      await passwordInput.fill(thinPassword!);
+      await passwordInput.fill(thinPassword);
 
       const loginButton = page.getByRole('button', { name: /log in|next/i });
       await loginButton.click();

--- a/playwright/e2e/release-gate/progressive-profile.spec.ts
+++ b/playwright/e2e/release-gate/progressive-profile.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '../../setup/test-setup';
+
+/**
+ * Progressive Profile Tests
+ *
+ * Migrated from: iqe-platform-ui-plugin/iqe_platform_ui/tests/test_progressive_profile.py
+ *
+ * Tests the progressive profile functionality where users can have either:
+ * - Thin profile: Minimal user information (basic registration)
+ * - Thick profile: Complete user information (full profile form)
+ *
+ * Requirements:
+ * - PLATFORM_UI-THIN
+ * - PLATFORM_UI-THICK
+ *
+ * Note: These tests require a thin profile user account to be available.
+ * Set THIN_USER and THIN_PASSWORD environment variables to enable these tests.
+ */
+
+test.describe('Progressive Profile', () => {
+  // Skip all tests if thin user credentials are not provided
+  const thinUser = process.env.THIN_USER;
+  const thinPassword = process.env.THIN_PASSWORD;
+  const skipThinUserTests = !thinUser || !thinPassword;
+
+  test.skip(skipThinUserTests, 'Thin user credentials not provided');
+
+  test('thin profile user can login', async ({ browser, baseURL }) => {
+    // Create isolated context for thin user login
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      baseURL: baseURL,
+      // Don't use shared auth state - we need fresh login with thin user
+      storageState: undefined,
+    });
+
+    const page = await context.newPage();
+
+    try {
+      // Navigate to the application
+      await page.goto('/');
+      await page.waitForLoadState('load');
+
+      // Wait for SSO redirect
+      await page.waitForURL(/sso\..*\.redhat\.com/);
+
+      // Fill in thin user credentials
+      const usernameInput = page.getByLabel('Red Hat login').first();
+      await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
+      await usernameInput.fill(thinUser!);
+
+      const passwordInput = page.getByLabel('Password').first();
+      await passwordInput.fill(thinPassword!);
+
+      // Submit login form
+      const loginButton = page.getByRole('button', { name: /log in|next/i });
+      await loginButton.click();
+
+      // Wait for redirect back to console
+      await page.waitForURL(/console\..*\.redhat\.com/, { timeout: 30000 });
+
+      // Wait for page to be fully loaded
+      await page.waitForLoadState('networkidle');
+
+      // Verify user is logged in by checking for user menu
+      const userToggle = page.locator('#user-dropdown, [data-ouia-component-id="chrome-user-toggle"]');
+      await expect(userToggle).toBeVisible({ timeout: 10000 });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('thin profile user sees thick profile prompt from my profile', async ({ browser, baseURL }) => {
+    // Create isolated context for thin user
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      baseURL: baseURL,
+      storageState: undefined,
+    });
+
+    const page = await context.newPage();
+
+    try {
+      // Login as thin user
+      await page.goto('/');
+      await page.waitForLoadState('load');
+      await page.waitForURL(/sso\..*\.redhat\.com/);
+
+      const usernameInput = page.getByLabel('Red Hat login').first();
+      await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
+      await usernameInput.fill(thinUser!);
+
+      const passwordInput = page.getByLabel('Password').first();
+      await passwordInput.fill(thinPassword!);
+
+      const loginButton = page.getByRole('button', { name: /log in|next/i });
+      await loginButton.click();
+
+      await page.waitForURL(/console\..*\.redhat\.com/, { timeout: 30000 });
+      await page.waitForLoadState('networkidle');
+
+      // Navigate to My Profile
+      // Click user menu to open dropdown
+      const userToggle = page.locator('#user-dropdown, [data-ouia-component-id="chrome-user-toggle"]');
+      await userToggle.click();
+
+      // Click "My Profile" link
+      const myProfileLink = page.getByRole('link', { name: /my profile/i });
+      await myProfileLink.click();
+
+      // Wait for navigation to My Profile page or thick profile form
+      // Thin users should be prompted to complete their profile
+      await page.waitForLoadState('networkidle');
+
+      // The page should either show:
+      // 1. A thick profile form (for users who haven't completed profile)
+      // 2. My Profile page with a prompt to complete profile
+      // We verify that navigation succeeded by checking the URL
+      await expect(page).toHaveURL(/\/(iam|settings)\//, { timeout: 10000 });
+
+      // Check for profile-related content
+      // This could be a form or a link to complete the profile
+      const hasProfileForm = await page.locator('form, [role="form"]').count() > 0;
+      const hasProfileLink = await page.getByText(/complete.*profile|update.*profile/i).count() > 0;
+
+      // At least one of these should be present
+      expect(hasProfileForm || hasProfileLink).toBeTruthy();
+    } finally {
+      await context.close();
+    }
+  });
+});
+
+/**
+ * Note: test_thin_profile_creation from IQE is marked as @pytest.mark.manual
+ * and is not automated. This is a manual test for creating thin profile users
+ * through the registration process, which cannot be fully automated.
+ */

--- a/playwright/e2e/release-gate/progressive-profile.spec.ts
+++ b/playwright/e2e/release-gate/progressive-profile.spec.ts
@@ -22,6 +22,8 @@ test.describe('Progressive Profile', () => {
   const thinUser = process.env.THIN_USER;
   const thinPassword = process.env.THIN_PASSWORD;
 
+  test.skip(true, 'Progressive profile tests are out-of-date and will be reworked in RHCLOUD-47458');
+
   if (!thinUser || !thinPassword) {
     throw new Error('THIN_USER and THIN_PASSWORD environment variables must be set');
   }

--- a/playwright/e2e/release-gate/progressive-profile.spec.ts
+++ b/playwright/e2e/release-gate/progressive-profile.spec.ts
@@ -24,9 +24,11 @@ test.describe('Progressive Profile', () => {
 
   test.skip(true, 'Progressive profile tests are out-of-date and will be reworked in RHCLOUD-47458');
 
-  if (!thinUser || !thinPassword) {
-    throw new Error('THIN_USER and THIN_PASSWORD environment variables must be set');
-  }
+  // Environment variable check disabled while tests are skipped
+  // Re-enable when tests are reworked in RHCLOUD-47458
+  // if (!thinUser || !thinPassword) {
+  //   throw new Error('THIN_USER and THIN_PASSWORD environment variables must be set');
+  // }
 
   test('thin profile user can login', async ({ browser, baseURL }) => {
     // Create isolated context for thin user login


### PR DESCRIPTION
## Summary

Migrates progressive profile tests from IQE to Playwright.

**⚠️ Note: These tests are currently skipped and will be reworked in RHCLOUD-47458.**

## Migrated from IQE

`iqe_platform_ui/tests/test_progressive_profile.py`

## Tests Added (Currently Skipped)

All tests in this file are marked as skipped with:
```typescript
test.skip(true, 'Progressive profile tests are out-of-date and will be reworked in RHCLOUD-47458');
```

### Test 1: thin profile user can login
- Creates isolated browser context for thin user
- Logs in with THIN_USER credentials
- Verifies successful login by checking user menu visibility

**Status:** Skipped - Requires updated thin profile test account and current login flow

### Test 2: thin profile user sees thick profile prompt from my profile
- Logs in as thin user
- Navigates to My Profile via user dropdown
- Verifies navigation to profile page
- Checks for profile completion form or link

**Status:** Skipped - Profile flow has changed, needs rework

## What's NOT Migrated

- `test_thin_profile_creation` - Marked as @pytest.mark.manual in IQE, not automated

## Why Skipped?

The progressive profile tests are out-of-date due to:
- Changes in the profile completion flow
- Test account configuration needs update
- Requirements for thin/thick profiles need clarification

## Next Steps

These tests will be reworked as part of **RHCLOUD-47458** when:
- Updated thin/thick profile requirements are defined
- Test accounts are properly configured
- Current profile flow is documented

## Requirements
- PLATFORM_UI-THIN
- PLATFORM_UI-THICK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E test infrastructure for progressive profile login and profile management workflows
* **Documentation**
  * Documented test migration status for progressive profile test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->