### PR TITLE
Increase help panel toggle icon size and center

### DIFF
--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -1,4 +1,5 @@
 .chr-c-ask-redhat-icon {
-  width: 1em;
-  height: 1em;
+  width: 1.25em;
+  height: 1.25em;
+  vertical-align: middle;
 }


### PR DESCRIPTION
For [RHCLOUD-47537](https://redhat.atlassian.net/browse/RHCLOUD-47537)

Before
<img width="95" height="46" alt="image" src="https://github.com/user-attachments/assets/8632650c-f3de-45d7-b41d-ec0d28e6d03b" />

After
<img width="95" height="46" alt="image" src="https://github.com/user-attachments/assets/1fbeff5a-4d6a-43d6-ae64-64eb22c76b53" />


[RHCLOUD-47537]: https://redhat.atlassian.net/browse/RHCLOUD-47537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the size of the header icon from 1em to 1.25em and adjusted its vertical alignment for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->