### PR TITLE
feat: add glass theme toggle gated by feature flag, add tests

### DIFF
--- a/cypress/component/GlassTheme/GlassThemeToggle.cy.tsx
+++ b/cypress/component/GlassTheme/GlassThemeToggle.cy.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { Card, CardBody, CardFooter, CardTitle, Switch } from '@patternfly/react-core';
+import { useGlassTheme } from '../../../src/hooks/useGlassTheme';
+import { FeatureFlagsProvider } from '../../../src/components/FeatureFlags';
+import ChromeAuthContext from '../../../src/auth/ChromeAuthContext';
+import { useFlag } from '@unleash/proxy-client-react';
+
+function GlassTheme() {
+  const isGlassModeEnabled = useFlag('platform.chrome.glass-theme');
+  const { isGlassTheme, toggleGlassTheme } = useGlassTheme(isGlassModeEnabled);
+
+  return (
+    <>
+      {isGlassModeEnabled && <Switch id="glass-theme-switch" label="Frosted glass effect" isChecked={isGlassTheme} hasCheckIcon onChange={toggleGlassTheme} />}
+      <Card>
+        <CardTitle component="h4">Glass theme test card</CardTitle>
+        <CardBody>Body</CardBody>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    </>
+  );
+}
+
+function Wrapper() {
+  return (
+    <ChromeAuthContext.Provider
+      value={
+        {
+          user: {
+            identity: {
+              user: { email: 'test@example.com' },
+              account_number: '123456',
+              internal: { account_id: '13579', org_id: '7890' },
+            },
+          },
+        } as any
+      }
+    >
+      <FeatureFlagsProvider>
+        <GlassTheme />
+      </FeatureFlagsProvider>
+    </ChromeAuthContext.Provider>
+  );
+}
+
+describe('GlassTheme Component', () => {
+  describe('With glass theme flag enabled', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/featureflags/*', {
+        toggles: [
+          {
+            name: 'platform.chrome.glass-theme',
+            enabled: true,
+            variant: { name: 'disabled', enabled: true },
+          },
+        ],
+      }).as('featureFlags');
+    });
+
+    describe('Initial State', () => {
+      it('defaults to glass off when no preference saved', () => {
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-glass');
+      });
+
+      it('restores glass on from localStorage', () => {
+        cy.setLocalStorage('chrome:glass-theme', 'true');
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.get('html').should('have.class', 'pf-v6-theme-glass');
+      });
+
+      it('restores glass off from localStorage', () => {
+        cy.setLocalStorage('chrome:glass-theme', 'false');
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-glass');
+      });
+
+      it('renders the switch toggle', () => {
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.get('.pf-v6-c-switch').should('exist').should('be.visible');
+      });
+    });
+
+    describe('User Interactions', () => {
+      it('toggles glass on', () => {
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.get('.pf-v6-c-switch').click();
+        cy.get('html').should('have.class', 'pf-v6-theme-glass');
+        cy.getLocalStorage('chrome:glass-theme').should('equal', 'true');
+      });
+
+      it('toggles glass off', () => {
+        cy.setLocalStorage('chrome:glass-theme', 'true');
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.get('.pf-v6-c-switch').click();
+        cy.get('html').should('not.have.class', 'pf-v6-theme-glass');
+        cy.getLocalStorage('chrome:glass-theme').should('equal', 'false');
+      });
+    });
+  });
+
+  describe('With glass theme flag disabled', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/featureflags/*', {
+        toggles: [
+          {
+            name: 'platform.chrome.glass-theme',
+            enabled: false,
+            variant: { name: 'disabled', enabled: false },
+          },
+        ],
+      }).as('featureFlagsDisabled');
+    });
+
+    it('does not render the switch', () => {
+      cy.mount(<Wrapper />);
+      cy.wait('@featureFlagsDisabled');
+      cy.get('.pf-v6-c-switch').should('not.exist');
+    });
+
+    it('removes glass class even if localStorage has it enabled', () => {
+      cy.setLocalStorage('chrome:glass-theme', 'true');
+      cy.mount(<Wrapper />);
+      cy.wait('@featureFlagsDisabled');
+      cy.get('html').should('not.have.class', 'pf-v6-theme-glass');
+    });
+  });
+});

--- a/src/components/Header/HeaderTests/Tools.test.js
+++ b/src/components/Header/HeaderTests/Tools.test.js
@@ -19,11 +19,13 @@ jest.mock('../SettingsToggle', () => {
         <div>
           {props.dropdownItems.map((group, groupIndex) => (
             <div key={groupIndex}>
-              {group.items.map((item, itemIndex) => (
-                <a key={itemIndex} href={item.url} data-testid={item.ouiaId}>
-                  {item.title}
-                </a>
-              ))}
+              {group.customContent
+                ? group.customContent
+                : group.items?.map((item, itemIndex) => (
+                    <a key={itemIndex} href={item.url} data-testid={item.ouiaId}>
+                      {item.title}
+                    </a>
+                  ))}
             </div>
           ))}
         </div>

--- a/src/components/Header/SettingsToggle.tsx
+++ b/src/components/Header/SettingsToggle.tsx
@@ -10,9 +10,8 @@ import { isPreviewAtom } from '../../state/atoms/releaseAtom';
 
 export type SettingsToggleDropdownGroup = {
   title?: string;
-  items: SettingsToggleDropdownItem[];
   isHidden?: boolean;
-};
+} & ({ items: SettingsToggleDropdownItem[]; customContent?: never } | { customContent: ReactNode; items?: never });
 
 export type SettingsToggleDropdownItem = {
   url?: string;
@@ -41,37 +40,38 @@ const SettingsToggle = (props: SettingsToggleProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const isPreview = useAtomValue(isPreviewAtom);
 
-  const dropdownItems = props.dropdownItems
-    .filter((group) => !group.isHidden)
-    .map(({ title, items }, groupIndex) => (
-      <DropdownGroup key={`${groupIndex}-${title}`} label={title}>
-        {items.map(({ url, title, description, onClick, isHidden, isDisabled, rel = 'noopener noreferrer', ...rest }, itemIndex) =>
-          !isHidden ? (
-            <DropdownItem
-              onClick={onClick}
-              key={typeof title === 'string' ? title : itemIndex}
-              ouiaId={rest.ouiaId ?? (typeof title === 'string' ? title : itemIndex)}
-              isDisabled={isDisabled}
-              component={
-                !onClick && url
-                  ? ({ className: itemClassName, children }) => (
-                      <ChromeLink {...rest} className={itemClassName} href={url} rel={rel} isBeta={isPreview}>
-                        {children}
-                      </ChromeLink>
-                    )
-                  : undefined
-              }
-              description={description}
-            >
-              {title}
-            </DropdownItem>
-          ) : (
-            <React.Fragment key={`fragment-${itemIndex}`} />
-          )
-        )}
-        {groupIndex < props.dropdownItems.length - 1 && <Divider key="divider" />}
-      </DropdownGroup>
-    ));
+  const visibleGroups = props.dropdownItems.filter((group) => !group.isHidden);
+  const dropdownItems = visibleGroups.map(({ title, items, customContent }, groupIndex) => (
+    <DropdownGroup key={`${groupIndex}-${title}`} label={title}>
+      {customContent
+        ? customContent
+        : items?.map(({ url, title, description, onClick, isHidden, isDisabled, rel = 'noopener noreferrer', ...rest }, itemIndex) =>
+            !isHidden ? (
+              <DropdownItem
+                onClick={onClick}
+                key={typeof title === 'string' ? title : itemIndex}
+                ouiaId={rest.ouiaId ?? (typeof title === 'string' ? title : itemIndex)}
+                isDisabled={isDisabled}
+                component={
+                  onClick || !url
+                    ? undefined
+                    : ({ className: itemClassName, children }) => (
+                        <ChromeLink {...rest} className={itemClassName} href={url} rel={rel} isBeta={isPreview}>
+                          {children}
+                        </ChromeLink>
+                      )
+                }
+                description={description}
+              >
+                {title}
+              </DropdownItem>
+            ) : (
+              <React.Fragment key={`fragment-${itemIndex}`} />
+            )
+          )}
+      {groupIndex < visibleGroups.length - 1 && <Divider key="divider" />}
+    </DropdownGroup>
+  ));
 
   return (
     <Dropdown

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -33,6 +33,7 @@ interface MockDropdownGroup {
   title?: string;
   isHidden?: boolean;
   items?: MockDropdownItem[];
+  customContent?: React.ReactNode;
 }
 
 interface MockDropdownItemWithClick extends MockDropdownItem {
@@ -51,14 +52,16 @@ jest.mock('./SettingsToggle', () => ({
         group.isHidden ? null : (
           <div key={i}>
             {group.title && <h3>{group.title}</h3>}
-            {group.items
-              ?.filter((item) => !item.isHidden)
-              .map((item, j: number) => (
-                <div key={j} data-ouia-component-id={item.ouiaId} onClick={item.onClick} role={item.onClick ? 'button' : undefined}>
-                  {item.title}
-                  {item.description && <p>{item.description}</p>}
-                </div>
-              ))}
+            {group.customContent
+              ? group.customContent
+              : group.items
+                  ?.filter((item) => !item.isHidden)
+                  .map((item, j: number) => (
+                    <div key={j} data-ouia-component-id={item.ouiaId} onClick={item.onClick} role={item.onClick ? 'button' : undefined}>
+                      {item.title}
+                      {item.description && <p>{item.description}</p>}
+                    </div>
+                  ))}
           </div>
         )
       )}
@@ -249,11 +252,14 @@ describe('Tools - dark mode system feature flag', () => {
         scope: 'schedulerUi',
         module: './SchedulerPanelContent',
       });
+    });
+  });
+
   describe('glass theme toggle', () => {
     it('should render glass effect section when flag is enabled', () => {
       renderTools({ 'platform.chrome.glass-theme': true });
       expect(screen.getByText('Glass effect')).toBeInTheDocument();
-      expect(screen.getByTestId('settings-menu-glass-theme')).toBeInTheDocument();
+      expect(document.getElementById('glass-theme-switch')).toBeInTheDocument();
     });
 
     it('should not render glass effect section when flag is disabled', () => {

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -74,6 +74,12 @@ jest.mock('../../hooks/useTheme', () => ({
   }),
   ThemeVariants: { light: 0, dark: 1, system: 2 },
 }));
+jest.mock('../../hooks/useGlassTheme', () => ({
+  useGlassTheme: () => ({
+    isGlassTheme: false,
+    toggleGlassTheme: jest.fn(),
+  }),
+}));
 jest.mock('../../hooks/useSupportCaseData', () => ({
   __esModule: true,
   default: () => ({}),
@@ -100,6 +106,7 @@ const defaultFlags: Record<string, boolean> = {
   'platform.chrome.itless': false,
   'platform.chrome.dark-mode': false,
   'platform.chrome.dark-mode_system': false,
+  'platform.chrome.glass-theme': false,
   'platform.chrome.notifications-drawer': false,
   'console.chrome-scheduler_drawer': false,
 };
@@ -242,6 +249,16 @@ describe('Tools - dark mode system feature flag', () => {
         scope: 'schedulerUi',
         module: './SchedulerPanelContent',
       });
+  describe('glass theme toggle', () => {
+    it('should render glass effect section when flag is enabled', () => {
+      renderTools({ 'platform.chrome.glass-theme': true });
+      expect(screen.getByText('Glass effect')).toBeInTheDocument();
+      expect(screen.getByTestId('settings-menu-glass-theme')).toBeInTheDocument();
+    });
+
+    it('should not render glass effect section when flag is disabled', () => {
+      renderTools({ 'platform.chrome.glass-theme': false });
+      expect(screen.queryByText('Glass effect')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -158,16 +158,19 @@ const Tools = () => {
       ],
     },
     {
-      title: 'Glass effect',
+      title: intl.formatMessage(messages.glassEffect),
       isHidden: !isGlassModeEnabled,
-      items: [
-        {
-          ouiaId: 'settings-menu-glass-theme',
-          title: <Switch id="glass-theme-switch" label="Frosted glass effect" isChecked={isGlassTheme} hasCheckIcon onChange={toggleGlassTheme} />,
-          onClick: (e: MouseEvent | React.MouseEvent | React.KeyboardEvent) => e.stopPropagation(),
-          url: '#',
-        },
-      ],
+      customContent: (
+        <div className="pf-v6-u-mx-md pf-v6-u-my-sm">
+          <Switch
+            id="glass-theme-switch"
+            label={intl.formatMessage(messages.glassEffectDescription)}
+            isChecked={isGlassTheme}
+            hasCheckIcon
+            onChange={toggleGlassTheme}
+          />
+        </div>
+      ),
     },
     {
       title: 'Settings',

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, memo, useContext, useEffect, useState } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider';
+import { Switch } from '@patternfly/react-core/dist/dynamic/components/Switch';
 import { DropdownItem } from '@patternfly/react-core/dist/dynamic/components/Dropdown';
 import { ToolbarItem } from '@patternfly/react-core/dist/dynamic/components/Toolbar';
 import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip';
@@ -31,6 +32,7 @@ import OutlinedMoonIcon from '@patternfly/react-icons/dist/dynamic/icons/outline
 import OutlinedSunIcon from '@patternfly/react-icons/dist/dynamic/icons/outlined-sun-icon';
 import InternalChromeContext from '../../utils/internalChromeContext';
 import { ThemeVariants, useTheme } from '../../hooks/useTheme';
+import { useGlassTheme } from '../../hooks/useGlassTheme';
 import './Tools.scss';
 
 const InternalButton = () => (
@@ -87,6 +89,7 @@ const Tools = () => {
   const isITLessEnv = useFlag('platform.chrome.itless');
   const isDarkModeEnabled = useFlag('platform.chrome.dark-mode');
   const isDarkModeSystemEnabled = useFlag('platform.chrome.dark-mode_system');
+  const isGlassModeEnabled = useFlag('platform.chrome.glass-theme');
   const { user, token } = useContext(ChromeAuthContext);
   const intl = useIntl();
   const isOrgAdmin = user?.identity?.user?.is_org_admin;
@@ -101,6 +104,7 @@ const Tools = () => {
   const {
     drawerActions: { toggleDrawerContent },
   } = useContext(InternalChromeContext);
+  const { isGlassTheme, toggleGlassTheme } = useGlassTheme(isGlassModeEnabled);
 
   /* list out the items for the settings menu */
   const settingsMenuDropdownGroups = [
@@ -150,6 +154,18 @@ const Tools = () => {
           ),
           description: 'Always use dark mode',
           onClick: setDarkMode,
+        },
+      ],
+    },
+    {
+      title: 'Glass effect',
+      isHidden: !isGlassModeEnabled,
+      items: [
+        {
+          ouiaId: 'settings-menu-glass-theme',
+          title: <Switch id="glass-theme-switch" label="Frosted glass effect" isChecked={isGlassTheme} hasCheckIcon onChange={toggleGlassTheme} />,
+          onClick: (e: MouseEvent | React.MouseEvent | React.KeyboardEvent) => e.stopPropagation(),
+          url: '#',
         },
       ],
     },

--- a/src/hooks/useGlassTheme.test.ts
+++ b/src/hooks/useGlassTheme.test.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { useGlassTheme } from './useGlassTheme';
+
+const mockEvent = {} as React.FormEvent<HTMLInputElement>;
+
+describe('useGlassTheme hook', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('pf-v6-theme-glass');
+  });
+
+  it('should default to glass off when no preference saved', () => {
+    const { result } = renderHook(() => useGlassTheme(true));
+    expect(result.current.isGlassTheme).toBe(false);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(false);
+  });
+
+  it('should restore glass on from localStorage', () => {
+    localStorage.setItem('chrome:glass-theme', 'true');
+    const { result } = renderHook(() => useGlassTheme(true));
+    expect(result.current.isGlassTheme).toBe(true);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(true);
+  });
+
+  it('should restore glass off from localStorage', () => {
+    localStorage.setItem('chrome:glass-theme', 'false');
+    const { result } = renderHook(() => useGlassTheme(true));
+    expect(result.current.isGlassTheme).toBe(false);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(false);
+  });
+
+  it('should toggle glass on', () => {
+    const { result } = renderHook(() => useGlassTheme(true));
+    act(() => result.current.toggleGlassTheme(mockEvent, true));
+    expect(result.current.isGlassTheme).toBe(true);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(true);
+    expect(localStorage.getItem('chrome:glass-theme')).toBe('true');
+  });
+
+  it('should toggle glass off', () => {
+    localStorage.setItem('chrome:glass-theme', 'true');
+    const { result } = renderHook(() => useGlassTheme(true));
+    act(() => result.current.toggleGlassTheme(mockEvent, false));
+    expect(result.current.isGlassTheme).toBe(false);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(false);
+    expect(localStorage.getItem('chrome:glass-theme')).toBe('false');
+  });
+
+  it('should ignore localStorage and disable glass when flag is off', () => {
+    localStorage.setItem('chrome:glass-theme', 'true');
+    const { result } = renderHook(() => useGlassTheme(false));
+    expect(result.current.isGlassTheme).toBe(false);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(false);
+  });
+
+  it('should remove glass class when flag changes from true to false', () => {
+    localStorage.setItem('chrome:glass-theme', 'true');
+    const { result, rerender } = renderHook(({ enabled }) => useGlassTheme(enabled), {
+      initialProps: { enabled: true },
+    });
+    expect(result.current.isGlassTheme).toBe(true);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(true);
+
+    rerender({ enabled: false });
+    expect(result.current.isGlassTheme).toBe(false);
+    expect(document.documentElement.classList.contains('pf-v6-theme-glass')).toBe(false);
+  });
+});

--- a/src/hooks/useGlassTheme.ts
+++ b/src/hooks/useGlassTheme.ts
@@ -3,6 +3,22 @@ import React, { useEffect, useState } from 'react';
 const GLASS_THEME_KEY = 'chrome:glass-theme';
 const GLASS_THEME_CLASS = 'pf-v6-theme-glass';
 
+const readGlassThemePreference = (): boolean => {
+  try {
+    return localStorage.getItem(GLASS_THEME_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+const writeGlassThemePreference = (checked: boolean): void => {
+  try {
+    localStorage.setItem(GLASS_THEME_KEY, String(checked));
+  } catch {
+    // no-op: persistence unavailable
+  }
+};
+
 const applyGlassTheme = (enabled: boolean) => {
   if (enabled) {
     document.documentElement.classList.add(GLASS_THEME_CLASS);
@@ -16,8 +32,7 @@ const getInitialGlassTheme = (isEnabled: boolean): boolean => {
     applyGlassTheme(false);
     return false;
   }
-  const saved = localStorage.getItem(GLASS_THEME_KEY);
-  const enabled = saved === 'true';
+  const enabled = readGlassThemePreference();
   applyGlassTheme(enabled);
   return enabled;
 };
@@ -30,7 +45,7 @@ export const useGlassTheme = (isEnabled: boolean) => {
       setIsGlassTheme(false);
       applyGlassTheme(false);
     } else {
-      const saved = localStorage.getItem(GLASS_THEME_KEY) === 'true';
+      const saved = readGlassThemePreference();
       setIsGlassTheme(saved);
       applyGlassTheme(saved);
     }
@@ -39,7 +54,7 @@ export const useGlassTheme = (isEnabled: boolean) => {
   const toggleGlassTheme = (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
     setIsGlassTheme(checked);
     applyGlassTheme(checked);
-    localStorage.setItem(GLASS_THEME_KEY, String(checked));
+    writeGlassThemePreference(checked);
   };
 
   return { isGlassTheme, toggleGlassTheme };

--- a/src/hooks/useGlassTheme.ts
+++ b/src/hooks/useGlassTheme.ts
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+
+const GLASS_THEME_KEY = 'chrome:glass-theme';
+const GLASS_THEME_CLASS = 'pf-v6-theme-glass';
+
+const applyGlassTheme = (enabled: boolean) => {
+  if (enabled) {
+    document.documentElement.classList.add(GLASS_THEME_CLASS);
+  } else {
+    document.documentElement.classList.remove(GLASS_THEME_CLASS);
+  }
+};
+
+const getInitialGlassTheme = (isEnabled: boolean): boolean => {
+  if (!isEnabled) {
+    applyGlassTheme(false);
+    return false;
+  }
+  const saved = localStorage.getItem(GLASS_THEME_KEY);
+  const enabled = saved === 'true';
+  applyGlassTheme(enabled);
+  return enabled;
+};
+
+export const useGlassTheme = (isEnabled: boolean) => {
+  const [isGlassTheme, setIsGlassTheme] = useState<boolean>(() => getInitialGlassTheme(isEnabled));
+
+  useEffect(() => {
+    if (!isEnabled) {
+      setIsGlassTheme(false);
+      applyGlassTheme(false);
+    } else {
+      const saved = localStorage.getItem(GLASS_THEME_KEY) === 'true';
+      setIsGlassTheme(saved);
+      applyGlassTheme(saved);
+    }
+  }, [isEnabled]);
+
+  const toggleGlassTheme = (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+    setIsGlassTheme(checked);
+    applyGlassTheme(checked);
+    localStorage.setItem(GLASS_THEME_KEY, String(checked));
+  };
+
+  return { isGlassTheme, toggleGlassTheme };
+};

--- a/src/locales/Messages.ts
+++ b/src/locales/Messages.ts
@@ -598,4 +598,14 @@ export default defineMessages({
     description: 'Ask Red Hat',
     defaultMessage: 'Ask Red Hat',
   },
+  glassEffect: {
+    id: 'glassEffect',
+    description: 'Glass effect',
+    defaultMessage: 'Glass effect',
+  },
+  glassEffectDescription: {
+    id: 'glassEffectDescription',
+    description: 'Frosted glass effect',
+    defaultMessage: 'Frosted glass effect',
+  },
 });


### PR DESCRIPTION
### Description

  Adds a **glass theme** toggle to the Settings dropdown menu, applying PatternFly 6's built-in `pf-v6-theme-glass` CSS class to the document root. 

The glass theme is an additive modifier that works **alongside** both light and dark themes.

  - The toggle uses a PatternFly `Switch` component 
  - Persists state via `chrome:glass-theme` in localStorage
  - Is gated behind the `platform.chrome.glass-theme` Unleash feature flag. When the flag is disabled, the glass class is automatically removed even if previously enabled.

[RHCLOUD-47432](https://redhat.atlassian.net/browse/RHCLOUD-47432)

[RHCLOUD-47432]: https://redhat.atlassian.net/browse/RHCLOUD-47432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


### Sreenshots:
<img width="271" height="402" alt="Screenshot 2026-05-26 at 15 52 29" src="https://github.com/user-attachments/assets/8b388b7a-fc6e-41d4-ad9e-1a8ae91a33c4" />
<img width="262" height="93" alt="Screenshot 2026-05-26 at 15 52 37" src="https://github.com/user-attachments/assets/762a5dd1-3134-4953-9c2c-34bda8ce054f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Glass effect" toggle in Settings → Color scheme (visibility gated by a feature flag). The toggle has localized label/description, persists across sessions, restores saved state on load, and applies/removes the frosted glass styling to the UI. When the feature is disabled the styling is not applied.

* **Tests**
  * Added component and hook tests covering visibility, persistence, DOM styling changes, and flag-enabled/disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->