### PR TITLE
feat: add high contrast toggle, add tests

### DIFF
--- a/cypress/component/HighContrast/HighContrastToggle.cy.tsx
+++ b/cypress/component/HighContrast/HighContrastToggle.cy.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { Button, Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
+import { useHighContrast } from '../../../src/hooks/useHighContrast';
+import { FeatureFlagsProvider } from '../../../src/components/FeatureFlags';
+import ChromeAuthContext from '../../../src/auth/ChromeAuthContext';
+
+function HighContrast() {
+  const { setSystemContrast, setDefaultContrast, setHighContrast } = useHighContrast();
+
+  return (
+    <>
+      <Button variant="primary" size="lg" id="system-button" onClick={setSystemContrast}>
+        System
+      </Button>
+      <Button variant="primary" size="lg" id="default-button" onClick={setDefaultContrast}>
+        Default
+      </Button>
+      <Button variant="primary" size="lg" id="high-button" onClick={setHighContrast}>
+        High contrast
+      </Button>
+      <Card>
+        <CardTitle component="h4">Title within an {'<h4>'} element</CardTitle>
+        <CardBody>Body</CardBody>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+      <Card>
+        <CardTitle component="h4">Title within an {'<h4>'} element</CardTitle>
+        <CardBody>Body</CardBody>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    </>
+  );
+}
+
+function Wrapper() {
+  return (
+    <ChromeAuthContext.Provider
+      value={
+        {
+          user: {
+            identity: {
+              user: { email: 'test@example.com' },
+              account_number: '123456',
+              internal: { account_id: '13579', org_id: '7890' },
+            },
+          },
+        } as any
+      }
+    >
+      <FeatureFlagsProvider>
+        <HighContrast />
+      </FeatureFlagsProvider>
+    </ChromeAuthContext.Provider>
+  );
+}
+
+describe('HighContrastToggle Component', () => {
+  describe('With high contrast enabled', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/featureflags/*', {
+        toggles: [
+          {
+            name: 'platform.chrome.high-contrast',
+            enabled: true,
+            variant: { name: 'disabled', enabled: true },
+          },
+        ],
+      }).as('featureFlags');
+    });
+
+    describe('Initial State', () => {
+      it('uses localStorage high preference', () => {
+        cy.setLocalStorage('chrome:high-contrast', 'high');
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'high');
+        cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('uses localStorage default preference', () => {
+        cy.setLocalStorage('chrome:high-contrast', 'default');
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'default');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('falls back to system with high contrast preference', () => {
+        cy.window().then((win) => {
+          cy.stub(win, 'matchMedia').returns({
+            matches: true,
+            media: '(prefers-contrast: more)',
+            addEventListener: cy.stub(),
+            removeEventListener: cy.stub(),
+          });
+        });
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
+        cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('falls back to system with no contrast preference', () => {
+        cy.window().then((win) => {
+          cy.stub(win, 'matchMedia').returns({
+            matches: false,
+            media: '(prefers-contrast: more)',
+            addEventListener: cy.stub(),
+            removeEventListener: cy.stub(),
+          });
+        });
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+      });
+    });
+
+    describe('User Interactions', () => {
+      it('toggles from default to high', () => {
+        localStorage.setItem('chrome:high-contrast', 'default');
+        cy.mount(<Wrapper />).get('html');
+        cy.get('#high-button').click();
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'high');
+        cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('toggles from high to default', () => {
+        localStorage.setItem('chrome:high-contrast', 'high');
+        cy.mount(<Wrapper />).get('html');
+        cy.get('#default-button').click();
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'default');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('toggles from high to system without contrast preference', () => {
+        localStorage.setItem('chrome:high-contrast', 'high');
+        cy.window().then((win) => {
+          cy.stub(win, 'matchMedia').returns({
+            matches: false,
+            media: '(prefers-contrast: more)',
+            addEventListener: cy.stub(),
+            removeEventListener: cy.stub(),
+          });
+        });
+        cy.mount(<Wrapper />).get('html');
+        cy.get('#system-button').click();
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('toggles from system to high', () => {
+        localStorage.setItem('chrome:high-contrast', 'system');
+        cy.window().then((win) => {
+          cy.stub(win, 'matchMedia').returns({
+            matches: false,
+            media: '(prefers-contrast: more)',
+            addEventListener: cy.stub(),
+            removeEventListener: cy.stub(),
+          });
+        });
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+        cy.get('#high-button').click();
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'high');
+        cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('toggles from default to system with contrast preference', () => {
+        localStorage.setItem('chrome:high-contrast', 'default');
+        cy.window().then((win) => {
+          cy.stub(win, 'matchMedia').returns({
+            matches: true,
+            media: '(prefers-contrast: more)',
+            addEventListener: cy.stub(),
+            removeEventListener: cy.stub(),
+          });
+        });
+        cy.mount(<Wrapper />).get('html');
+        cy.get('#system-button').click();
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
+        cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('system button should be available', () => {
+        cy.mount(<Wrapper />);
+        cy.get('#system-button').should('exist').should('be.visible');
+      });
+    });
+  });
+
+  describe('With high contrast disabled', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/featureflags/*', {
+        toggles: [
+          {
+            name: 'platform.chrome.high-contrast',
+            enabled: false,
+            variant: { name: 'disabled', enabled: false },
+          },
+        ],
+      }).as('featureFlagsDisabled');
+    });
+
+    describe('Initial State', () => {
+      it('ignores localStorage high preference', () => {
+        cy.setLocalStorage('chrome:high-contrast', 'high');
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlagsDisabled');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+      });
+
+      it('ignores localStorage system preference', () => {
+        cy.setLocalStorage('chrome:high-contrast', 'system');
+        cy.window().then((win) => {
+          cy.stub(win, 'matchMedia').returns({
+            matches: true,
+            media: '(prefers-contrast: more)',
+            addEventListener: cy.stub(),
+            removeEventListener: cy.stub(),
+          });
+        });
+        cy.mount(<Wrapper />);
+        cy.wait('@featureFlagsDisabled');
+        cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+      });
+    });
+  });
+});

--- a/cypress/component/HighContrast/HighContrastToggle.cy.tsx
+++ b/cypress/component/HighContrast/HighContrastToggle.cy.tsx
@@ -96,8 +96,8 @@ describe('HighContrastToggle Component', () => {
         });
         cy.mount(<Wrapper />);
         cy.wait('@featureFlags');
-        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
         cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
       });
 
       it('falls back to system with no contrast preference', () => {
@@ -111,8 +111,8 @@ describe('HighContrastToggle Component', () => {
         });
         cy.mount(<Wrapper />);
         cy.wait('@featureFlags');
-        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
         cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
+        cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
       });
     });
 
@@ -120,6 +120,7 @@ describe('HighContrastToggle Component', () => {
       it('toggles from default to high', () => {
         localStorage.setItem('chrome:high-contrast', 'default');
         cy.mount(<Wrapper />).get('html');
+        cy.wait('@featureFlags');
         cy.get('#high-button').click();
         cy.getLocalStorage('chrome:high-contrast').should('equal', 'high');
         cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
@@ -128,6 +129,7 @@ describe('HighContrastToggle Component', () => {
       it('toggles from high to default', () => {
         localStorage.setItem('chrome:high-contrast', 'high');
         cy.mount(<Wrapper />).get('html');
+        cy.wait('@featureFlags');
         cy.get('#default-button').click();
         cy.getLocalStorage('chrome:high-contrast').should('equal', 'default');
         cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
@@ -144,6 +146,7 @@ describe('HighContrastToggle Component', () => {
           });
         });
         cy.mount(<Wrapper />).get('html');
+        cy.wait('@featureFlags');
         cy.get('#system-button').click();
         cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
         cy.get('html').should('not.have.class', 'pf-v6-theme-high-contrast');
@@ -179,6 +182,7 @@ describe('HighContrastToggle Component', () => {
           });
         });
         cy.mount(<Wrapper />).get('html');
+        cy.wait('@featureFlags');
         cy.get('#system-button').click();
         cy.getLocalStorage('chrome:high-contrast').should('equal', 'system');
         cy.get('html').should('have.class', 'pf-v6-theme-high-contrast');
@@ -186,6 +190,7 @@ describe('HighContrastToggle Component', () => {
 
       it('system button should be available', () => {
         cy.mount(<Wrapper />);
+        cy.wait('@featureFlags');
         cy.get('#system-button').should('exist').should('be.visible');
       });
     });

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -83,6 +83,15 @@ jest.mock('../../hooks/useGlassTheme', () => ({
     toggleGlassTheme: jest.fn(),
   }),
 }));
+jest.mock('../../hooks/useHighContrast', () => ({
+  useHighContrast: () => ({
+    contrastMode: 0,
+    setDefaultContrast: jest.fn(),
+    setHighContrast: jest.fn(),
+    setSystemContrast: jest.fn(),
+  }),
+  HighContrastVariants: { default: 0, high: 1, system: 2 },
+}));
 jest.mock('../../hooks/useSupportCaseData', () => ({
   __esModule: true,
   default: () => ({}),
@@ -109,6 +118,7 @@ const defaultFlags: Record<string, boolean> = {
   'platform.chrome.dark-mode': false,
   'platform.chrome.dark-mode_system': false,
   'platform.chrome.glass-theme': false,
+  'platform.chrome.high-contrast': false,
   'platform.chrome.notifications-drawer': false,
   'console.chrome-scheduler_drawer': false,
 };
@@ -264,6 +274,28 @@ describe('Tools - dark mode system feature flag', () => {
     it('should not render glass effect section when flag is disabled', () => {
       renderTools({ 'platform.chrome.glass-theme': false });
       expect(screen.queryByText('Glass effect')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Tools - high contrast feature flag', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('when high contrast is disabled', () => {
+    it('should not render contrast section', () => {
+      renderTools({ 'platform.chrome.high-contrast': false });
+      expect(screen.queryByText('Contrast')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when high contrast is enabled', () => {
+    it('should render contrast section with toggle group', () => {
+      renderTools({ 'platform.chrome.high-contrast': true });
+
+      expect(screen.getByText('Contrast')).toBeInTheDocument();
+      expect(screen.getByText('System')).toBeInTheDocument();
+      expect(screen.getByText('Default')).toBeInTheDocument();
+      expect(screen.getByText('High contrast')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -83,12 +83,15 @@ jest.mock('../../hooks/useGlassTheme', () => ({
     toggleGlassTheme: jest.fn(),
   }),
 }));
+const mockSetDefaultContrast = jest.fn();
+const mockSetHighContrast = jest.fn();
+const mockSetSystemContrast = jest.fn();
 jest.mock('../../hooks/useHighContrast', () => ({
   useHighContrast: () => ({
     contrastMode: 0,
-    setDefaultContrast: jest.fn(),
-    setHighContrast: jest.fn(),
-    setSystemContrast: jest.fn(),
+    setDefaultContrast: mockSetDefaultContrast,
+    setHighContrast: mockSetHighContrast,
+    setSystemContrast: mockSetSystemContrast,
   }),
   HighContrastVariants: { default: 0, high: 1, system: 2 },
 }));
@@ -296,6 +299,24 @@ describe('Tools - high contrast feature flag', () => {
       expect(screen.getByText('System')).toBeInTheDocument();
       expect(screen.getByText('Default')).toBeInTheDocument();
       expect(screen.getByText('High contrast')).toBeInTheDocument();
+    });
+
+    it('should call setSystemContrast when System is clicked', () => {
+      renderTools({ 'platform.chrome.high-contrast': true });
+      fireEvent.click(screen.getByText('System'));
+      expect(mockSetSystemContrast).toHaveBeenCalled();
+    });
+
+    it('should call setDefaultContrast when Default is clicked', () => {
+      renderTools({ 'platform.chrome.high-contrast': true });
+      fireEvent.click(screen.getByText('Default'));
+      expect(mockSetDefaultContrast).toHaveBeenCalled();
+    });
+
+    it('should call setHighContrast when High contrast is clicked', () => {
+      renderTools({ 'platform.chrome.high-contrast': true });
+      fireEvent.click(screen.getByText('High contrast'));
+      expect(mockSetHighContrast).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -177,30 +177,30 @@ const Tools = () => {
       ),
     },
     {
-      title: 'Contrast',
+      title: intl.formatMessage(messages.contrast),
       isHidden: !isHighContrastEnabled,
       customContent: (
-        <ToggleGroup aria-label="Contrast mode" className="pf-v6-u-mx-md pf-v6-u-my-sm">
+        <ToggleGroup aria-label={intl.formatMessage(messages.contrast)} className="pf-v6-u-mx-md pf-v6-u-my-sm">
           <ToggleGroupItem
-            text="System"
+            text={intl.formatMessage(messages.contrastSystem)}
             buttonId="contrast-system"
             isSelected={contrastMode === HighContrastVariants.system}
             onChange={() => setSystemContrast()}
-            aria-label="System contrast"
+            aria-label={intl.formatMessage(messages.contrastSystem)}
           />
           <ToggleGroupItem
-            text="Default"
+            text={intl.formatMessage(messages.contrastDefault)}
             buttonId="contrast-default"
             isSelected={contrastMode === HighContrastVariants.default}
             onChange={() => setDefaultContrast()}
-            aria-label="Default contrast"
+            aria-label={intl.formatMessage(messages.contrastDefault)}
           />
           <ToggleGroupItem
-            text="High contrast"
+            text={intl.formatMessage(messages.contrastHigh)}
             buttonId="contrast-high"
             isSelected={contrastMode === HighContrastVariants.high}
             onChange={() => setHighContrast()}
-            aria-label="High contrast"
+            aria-label={intl.formatMessage(messages.contrastHigh)}
           />
         </ToggleGroup>
       ),

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -6,6 +6,8 @@ import { Switch } from '@patternfly/react-core/dist/dynamic/components/Switch';
 import { DropdownItem } from '@patternfly/react-core/dist/dynamic/components/Dropdown';
 import { ToolbarItem } from '@patternfly/react-core/dist/dynamic/components/Toolbar';
 import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip';
+import { ToggleGroup } from '@patternfly/react-core/dist/dynamic/components/ToggleGroup';
+import { ToggleGroupItem } from '@patternfly/react-core/dist/dynamic/components/ToggleGroup';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/dynamic/icons/question-circle-icon';
 import CogIcon from '@patternfly/react-icons/dist/dynamic/icons/cog-icon';
 import RedhatIcon from '@patternfly/react-icons/dist/dynamic/icons/redhat-icon';
@@ -33,6 +35,7 @@ import OutlinedSunIcon from '@patternfly/react-icons/dist/dynamic/icons/outlined
 import InternalChromeContext from '../../utils/internalChromeContext';
 import { ThemeVariants, useTheme } from '../../hooks/useTheme';
 import { useGlassTheme } from '../../hooks/useGlassTheme';
+import { HighContrastVariants, useHighContrast } from '../../hooks/useHighContrast';
 import './Tools.scss';
 
 const InternalButton = () => (
@@ -89,6 +92,7 @@ const Tools = () => {
   const isDarkModeEnabled = useFlag('platform.chrome.dark-mode');
   const isDarkModeSystemEnabled = useFlag('platform.chrome.dark-mode_system');
   const isGlassModeEnabled = useFlag('platform.chrome.glass-theme');
+  const isHighContrastEnabled = useFlag('platform.chrome.high-contrast');
   const { user, token } = useContext(ChromeAuthContext);
   const intl = useIntl();
   const isOrgAdmin = user?.identity?.user?.is_org_admin;
@@ -98,6 +102,7 @@ const Tools = () => {
     messages.betaRelease
   )}`;
   const { themeMode, setLightMode, setDarkMode, setSystemMode } = useTheme();
+  const { contrastMode, setDefaultContrast, setHighContrast, setSystemContrast } = useHighContrast();
   const schedulerDrawerEnabled = useFlag('console.chrome-scheduler_drawer');
 
   const {
@@ -169,6 +174,35 @@ const Tools = () => {
             onChange={toggleGlassTheme}
           />
         </div>
+      ),
+    },
+    {
+      title: 'Contrast',
+      isHidden: !isHighContrastEnabled,
+      customContent: (
+        <ToggleGroup aria-label="Contrast mode" className="pf-v6-u-mx-md pf-v6-u-my-sm">
+          <ToggleGroupItem
+            text="System"
+            buttonId="contrast-system"
+            isSelected={contrastMode === HighContrastVariants.system}
+            onChange={() => setSystemContrast()}
+            aria-label="System contrast"
+          />
+          <ToggleGroupItem
+            text="Default"
+            buttonId="contrast-default"
+            isSelected={contrastMode === HighContrastVariants.default}
+            onChange={() => setDefaultContrast()}
+            aria-label="Default contrast"
+          />
+          <ToggleGroupItem
+            text="High contrast"
+            buttonId="contrast-high"
+            isSelected={contrastMode === HighContrastVariants.high}
+            onChange={() => setHighContrast()}
+            aria-label="High contrast"
+          />
+        </ToggleGroup>
       ),
     },
     {

--- a/src/hooks/useHighContrast.test.ts
+++ b/src/hooks/useHighContrast.test.ts
@@ -1,0 +1,184 @@
+import { act, renderHook } from '@testing-library/react';
+import { HighContrastVariants, useHighContrast } from './useHighContrast';
+import { useFlag } from '@unleash/proxy-client-react';
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: jest.fn(() => false),
+}));
+
+const mockedUseFlag = useFlag as unknown as jest.Mock;
+
+describe('useHighContrast hook', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('pf-v6-theme-high-contrast');
+    originalMatchMedia = window.matchMedia;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  const mockMatchMedia = (prefersHighContrast: boolean) => {
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: prefersHighContrast,
+      media: '(prefers-contrast: more)',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    });
+  };
+
+  const setFlag = (enabled: boolean) => {
+    mockedUseFlag.mockImplementation((flag: string) => {
+      if (flag === 'platform.chrome.high-contrast') return enabled;
+      return false;
+    });
+  };
+
+  describe('when high contrast is disabled', () => {
+    beforeEach(() => setFlag(false));
+
+    it('should default to default mode', () => {
+      const { result } = renderHook(() => useHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.default);
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+
+    it('should ignore saved high preference', () => {
+      localStorage.setItem('chrome:high-contrast', 'high');
+      const { result } = renderHook(() => useHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.default);
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+
+    it('should ignore saved system preference', () => {
+      localStorage.setItem('chrome:high-contrast', 'system');
+      mockMatchMedia(true);
+      const { result } = renderHook(() => useHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.default);
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+  });
+
+  describe('when high contrast is enabled', () => {
+    beforeEach(() => setFlag(true));
+
+    it('should default to system mode when no preference saved', () => {
+      mockMatchMedia(false);
+      const { result } = renderHook(() => useHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.system);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('system');
+    });
+
+    it('should apply high contrast when system prefers more contrast', () => {
+      mockMatchMedia(true);
+      renderHook(() => useHighContrast());
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(true);
+    });
+
+    it('should not apply high contrast when system has no contrast preference', () => {
+      mockMatchMedia(false);
+      renderHook(() => useHighContrast());
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+
+    it('should respect saved system preference', () => {
+      localStorage.setItem('chrome:high-contrast', 'system');
+      mockMatchMedia(true);
+      const { result } = renderHook(() => useHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.system);
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(true);
+    });
+
+    it('should respect saved high preference', () => {
+      localStorage.setItem('chrome:high-contrast', 'high');
+      const { result } = renderHook(() => useHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.high);
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(true);
+    });
+
+    it('should respect saved default preference', () => {
+      localStorage.setItem('chrome:high-contrast', 'default');
+      const { result } = renderHook(() => useHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.default);
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+
+    it('should allow setting system mode', () => {
+      localStorage.setItem('chrome:high-contrast', 'default');
+      mockMatchMedia(true);
+      const { result } = renderHook(() => useHighContrast());
+
+      act(() => result.current.setSystemContrast());
+
+      expect(result.current.contrastMode).toBe(HighContrastVariants.system);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('system');
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(true);
+    });
+  });
+
+  describe('mode switching', () => {
+    beforeEach(() => setFlag(true));
+
+    it('should switch from default to high', () => {
+      localStorage.setItem('chrome:high-contrast', 'default');
+      const { result } = renderHook(() => useHighContrast());
+      act(() => result.current.setHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.high);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('high');
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(true);
+    });
+
+    it('should switch from high to default', () => {
+      localStorage.setItem('chrome:high-contrast', 'high');
+      const { result } = renderHook(() => useHighContrast());
+      act(() => result.current.setDefaultContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.default);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('default');
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+
+    it('should switch from system to high', () => {
+      localStorage.setItem('chrome:high-contrast', 'system');
+      mockMatchMedia(false);
+      const { result } = renderHook(() => useHighContrast());
+      act(() => result.current.setHighContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.high);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('high');
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(true);
+    });
+
+    it('should switch from system to default', () => {
+      localStorage.setItem('chrome:high-contrast', 'system');
+      mockMatchMedia(true);
+      const { result } = renderHook(() => useHighContrast());
+      act(() => result.current.setDefaultContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.default);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('default');
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+
+    it('should switch from high to system', () => {
+      localStorage.setItem('chrome:high-contrast', 'high');
+      mockMatchMedia(false);
+      const { result } = renderHook(() => useHighContrast());
+      act(() => result.current.setSystemContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.system);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('system');
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(false);
+    });
+
+    it('should switch from default to system', () => {
+      localStorage.setItem('chrome:high-contrast', 'default');
+      mockMatchMedia(true);
+      const { result } = renderHook(() => useHighContrast());
+      act(() => result.current.setSystemContrast());
+      expect(result.current.contrastMode).toBe(HighContrastVariants.system);
+      expect(localStorage.getItem('chrome:high-contrast')).toBe('system');
+      expect(document.documentElement.classList.contains('pf-v6-theme-high-contrast')).toBe(true);
+    });
+  });
+});

--- a/src/hooks/useHighContrast.ts
+++ b/src/hooks/useHighContrast.ts
@@ -7,49 +7,46 @@ export enum HighContrastVariants {
   system,
 }
 
+const applyHighContrast = (isHigh: boolean) => {
+  if (isHigh) {
+    document.documentElement.classList.add('pf-v6-theme-high-contrast');
+  } else {
+    document.documentElement.classList.remove('pf-v6-theme-high-contrast');
+  }
+};
+
+const getInitialMode = (isHighContrastEnabled: boolean): HighContrastVariants => {
+  if (!isHighContrastEnabled) {
+    return HighContrastVariants.default;
+  }
+
+  const saved = localStorage.getItem('chrome:high-contrast');
+
+  if (saved === 'high') return HighContrastVariants.high;
+  if (saved === 'default') return HighContrastVariants.default;
+  return HighContrastVariants.system;
+};
+
+const applyContrastMode = (mode: HighContrastVariants) => {
+  if (mode === HighContrastVariants.high) {
+    applyHighContrast(true);
+  } else if (mode === HighContrastVariants.system) {
+    localStorage.setItem('chrome:high-contrast', 'system');
+    applyHighContrast(window.matchMedia('(prefers-contrast: more)').matches);
+  } else {
+    applyHighContrast(false);
+  }
+};
+
 export const useHighContrast = () => {
   const isHighContrastEnabled = useFlag('platform.chrome.high-contrast');
 
-  const applyHighContrast = (isHigh: boolean) => {
-    if (isHigh) {
-      document.documentElement.classList.add('pf-v6-theme-high-contrast');
-    } else {
-      document.documentElement.classList.remove('pf-v6-theme-high-contrast');
-    }
-  };
-
-  const getInitialMode = (): HighContrastVariants => {
-    if (!isHighContrastEnabled) {
-      applyHighContrast(false);
-      return HighContrastVariants.default;
-    }
-
-    const saved = localStorage.getItem('chrome:high-contrast');
-
-    if (saved === 'high') {
-      applyHighContrast(true);
-      return HighContrastVariants.high;
-    } else if (saved === 'default') {
-      applyHighContrast(false);
-      return HighContrastVariants.default;
-    } else if (saved === 'system') {
-      const prefersHighContrast = window.matchMedia('(prefers-contrast: more)').matches;
-      applyHighContrast(prefersHighContrast);
-      return HighContrastVariants.system;
-    }
-
-    // Default to system mode when no preference is saved
-    localStorage.setItem('chrome:high-contrast', 'system');
-    const prefersHighContrast = window.matchMedia('(prefers-contrast: more)').matches;
-    applyHighContrast(prefersHighContrast);
-    return HighContrastVariants.system;
-  };
-
-  const [contrastMode, setContrastMode] = useState<HighContrastVariants>(getInitialMode);
+  const [contrastMode, setContrastMode] = useState<HighContrastVariants>(() => getInitialMode(isHighContrastEnabled));
 
   useEffect(() => {
-    const newMode = getInitialMode();
-    setContrastMode(newMode);
+    const mode = getInitialMode(isHighContrastEnabled);
+    setContrastMode(mode);
+    applyContrastMode(mode);
   }, [isHighContrastEnabled]);
 
   const setDefaultContrast = () => {

--- a/src/hooks/useHighContrast.ts
+++ b/src/hooks/useHighContrast.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useFlag } from '@unleash/proxy-client-react';
+
+export enum HighContrastVariants {
+  default,
+  high,
+  system,
+}
+
+export const useHighContrast = () => {
+  const isHighContrastEnabled = useFlag('platform.chrome.high-contrast');
+
+  const applyHighContrast = (isHigh: boolean) => {
+    if (isHigh) {
+      document.documentElement.classList.add('pf-v6-theme-high-contrast');
+    } else {
+      document.documentElement.classList.remove('pf-v6-theme-high-contrast');
+    }
+  };
+
+  const getInitialMode = (): HighContrastVariants => {
+    if (!isHighContrastEnabled) {
+      applyHighContrast(false);
+      return HighContrastVariants.default;
+    }
+
+    const saved = localStorage.getItem('chrome:high-contrast');
+
+    if (saved === 'high') {
+      applyHighContrast(true);
+      return HighContrastVariants.high;
+    } else if (saved === 'default') {
+      applyHighContrast(false);
+      return HighContrastVariants.default;
+    } else if (saved === 'system') {
+      const prefersHighContrast = window.matchMedia('(prefers-contrast: more)').matches;
+      applyHighContrast(prefersHighContrast);
+      return HighContrastVariants.system;
+    }
+
+    // Default to system mode when no preference is saved
+    localStorage.setItem('chrome:high-contrast', 'system');
+    const prefersHighContrast = window.matchMedia('(prefers-contrast: more)').matches;
+    applyHighContrast(prefersHighContrast);
+    return HighContrastVariants.system;
+  };
+
+  const [contrastMode, setContrastMode] = useState<HighContrastVariants>(getInitialMode);
+
+  useEffect(() => {
+    const newMode = getInitialMode();
+    setContrastMode(newMode);
+  }, [isHighContrastEnabled]);
+
+  const setDefaultContrast = () => {
+    setContrastMode(HighContrastVariants.default);
+    applyHighContrast(false);
+    localStorage.setItem('chrome:high-contrast', 'default');
+  };
+
+  const setHighContrast = () => {
+    setContrastMode(HighContrastVariants.high);
+    applyHighContrast(true);
+    localStorage.setItem('chrome:high-contrast', 'high');
+  };
+
+  const setSystemContrast = () => {
+    setContrastMode(HighContrastVariants.system);
+    const prefersHighContrast = window.matchMedia('(prefers-contrast: more)').matches;
+    applyHighContrast(prefersHighContrast);
+    localStorage.setItem('chrome:high-contrast', 'system');
+  };
+
+  return {
+    contrastMode,
+    setDefaultContrast,
+    setHighContrast,
+    setSystemContrast,
+  };
+};

--- a/src/locales/Messages.ts
+++ b/src/locales/Messages.ts
@@ -608,4 +608,24 @@ export default defineMessages({
     description: 'Frosted glass effect',
     defaultMessage: 'Frosted glass effect',
   },
+  contrast: {
+    id: 'contrast',
+    description: 'Contrast',
+    defaultMessage: 'Contrast',
+  },
+  contrastSystem: {
+    id: 'contrastSystem',
+    description: 'System',
+    defaultMessage: 'System',
+  },
+  contrastDefault: {
+    id: 'contrastDefault',
+    description: 'Default',
+    defaultMessage: 'Default',
+  },
+  contrastHigh: {
+    id: 'contrastHigh',
+    description: 'High contrast',
+    defaultMessage: 'High contrast',
+  },
 });


### PR DESCRIPTION
### Description
Adds high contrast mode support (`pf-v6-theme-high-contrast`) to the platform, gated behind the `platform.chrome.high-contrast` feature flag. 

When enabled, users can choose via a ToggleGroup in the settings dropdown between 
- **System** (follows `browser prefers-contrast: more` preference), 
- **Default** (no high contrast), 
- **High** contrast 

The preference is persisted in localStorage under `chrome:high-contrast.`

[RHCLOUD-47434](https://redhat.atlassian.net/browse/RHCLOUD-47434)

---

### Screenshots
<img width="321" height="411" alt="Screenshot 2026-05-27 at 10 48 51" src="https://github.com/user-attachments/assets/b028e389-7cd1-4700-946c-3ccb69e0bd8d" />
<img width="325" height="390" alt="Screenshot 2026-05-27 at 10 49 00" src="https://github.com/user-attachments/assets/36f077b9-c9e0-489f-89d3-5313b5044566" />



[RHCLOUD-47434]: https://redhat.atlassian.net/browse/RHCLOUD-47434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature-flagged high-contrast control in Settings with **System**, **Default**, and **High contrast** options, including persistence and system-preference handling.
  * Added localized strings for the contrast options.
  * Enhanced Settings dropdown groups to support mutually exclusive **custom group content** (vs items) and improved divider placement for visible groups.
* **Tests**
  * Added unit tests for high-contrast behavior and hook setters (including feature-flag gating and system preference).
  * Added component test coverage for the Settings contrast toggle, plus updated existing Tools/Settings mocks for custom group content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->