### PR TITLE
fix(pdf): send refresh token header in create request

### DIFF
--- a/src/chrome/create-chrome.ts
+++ b/src/chrome/create-chrome.ts
@@ -253,7 +253,7 @@ export const createChromeContext = ({
       forceAuthRefresh: chromeAuth.forceRefresh,
     },
     enablePackagesDebug: () => warnDuplicatePkg(),
-    requestPdf,
+    requestPdf: (options) => requestPdf(options, chromeAuth.getRefreshToken),
     drawerActions,
     search: searchAPI,
   };

--- a/src/pdf/requestPdf.ts
+++ b/src/pdf/requestPdf.ts
@@ -43,12 +43,17 @@ const pollStatus = async (statusID: string) => {
   });
 };
 
-const requestPdf = async (options: PDFRequestOptions) => {
+const requestPdf = async (options: PDFRequestOptions, getRefreshToken: () => Promise<string>) => {
   const { filename, payload } = options;
   try {
+    const refreshToken = await getRefreshToken();
     const {
       data: { statusID },
-    } = await axios.post<{ statusID: string }>(`/api/crc-pdf-generator/v2/create`, { payload });
+    } = await axios.post<{ statusID: string }>(
+      `/api/crc-pdf-generator/v2/create`,
+      { payload },
+      { headers: { 'x-rh-refresh-token': `Bearer ${refreshToken}` } }
+    );
     const { status } = await pollStatus(statusID);
     if (status === 'Generated') {
       return downloadPDF(`/api/crc-pdf-generator/v2/download/${statusID}`, filename);


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

Fixes the issue of generating extremely long PDF content. The new token refresh is used to get fresh tokens during the PDF generation process (tokens can expire before the PDF is finished, and all requests are completed)

[RHCLOUD-47965](https://issues.redhat.com/browse/RHCLOUD-47965)
---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Just me


[RHCLOUD-47965]: https://redhat.atlassian.net/browse/RHCLOUD-47965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF generation reliability by ensuring proper authentication token handling is included with all PDF requests to prevent request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->