### PR TITLE
Add correct sizing css for the new help panel toggle

### DIFF
--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -3,3 +3,9 @@
   height: 1.25em;
   vertical-align: middle;
 }
+
+.chr-c-ai-experience-icon {
+  width: 1.3em;
+  height: 1.3em;
+  vertical-align: middle;
+}

--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -5,7 +5,5 @@
 }
 
 .chr-c-ai-experience-icon {
-  width: 1.3em;
-  height: 1.3em;
   vertical-align: middle;
 }

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -325,7 +325,11 @@ const Tools = () => {
     };
 
     const AIExperienceIcon = () => (
-      <img src="/apps/frontend-assets/technology-icons/rh-ui-icon-ai-experience.svg" alt="AI Experience" className="chr-c-ai-experience-icon" />
+      <img
+        src="/apps/frontend-assets/technology-icons/rh-ui-icon-ai-experience.svg"
+        alt="AI Experience"
+        className="pf-v6-c-icon pf-v6-c-icon--m-heading-2xl chr-c-ai-experience-icon"
+      />
     );
 
     return (


### PR DESCRIPTION
Fix the sizing issue on stage

<img width="158" height="67" alt="image" src="https://github.com/user-attachments/assets/3a170ac3-2de3-41b5-b5fb-e192d728c9d0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the AI experience icon’s appearance—adjusted alignment and sizing to better match surrounding header icons for more consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->