### PR TITLE
Small styling tweaks for the help panel toggle

### DIFF
--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -1,9 +1,10 @@
-.chr-c-ask-redhat-icon {
-  width: 1.25em;
-  height: 1.25em;
-  vertical-align: middle;
-}
-
 .chr-c-ai-experience-icon {
   vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+
+.chr-c-help-panel-toggle {
+  --pf-v6-c-button--m-primary--m-display-lg--Gap: 0.25rem;
+  --pf-v6-c-button--Gap: 0.25rem;
 }

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -328,7 +328,7 @@ const Tools = () => {
       <img
         src="/apps/frontend-assets/technology-icons/rh-ui-icon-ai-experience.svg"
         alt="AI Experience"
-        className="pf-v6-c-icon pf-v6-c-icon--m-heading-2xl chr-c-ai-experience-icon"
+        className="pf-v6-c-icon pf-m-lg chr-c-ai-experience-icon"
       />
     );
 
@@ -348,7 +348,7 @@ const Tools = () => {
           aria-label="Toggle help panel"
           onClick={handleToggle}
           isClicked={isHelpPanelOpen}
-          className="tooltip-button-help-cy"
+          className="tooltip-button-help-cy chr-c-help-panel-toggle"
         >
           Help
         </Button>


### PR DESCRIPTION
Requested by UX

Before:
<img width="137" height="68" alt="Screenshot 2026-05-29 at 2 04 10 PM" src="https://github.com/user-attachments/assets/f0a56d4a-a2f4-42b8-9e08-21a946c6fb7b" />

After:
<img width="137" height="68" alt="Screenshot 2026-05-29 at 2 04 46 PM" src="https://github.com/user-attachments/assets/b42020d3-2114-4ba6-a379-8fcb45b45e99" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined AI Experience icon positioning and alignment in the header
  * Updated Help panel toggle button styling for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->