### PR TITLE
Skip v1 RBAC permission calls for orgs migrated to v2

### DIFF
--- a/playwright/e2e/release-gate/rbac-v2-gating.spec.ts
+++ b/playwright/e2e/release-gate/rbac-v2-gating.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '../../setup/test-setup';
+
+test.describe('RBAC v2 feature flag gating', () => {
+  test('should not make v1 RBAC access calls after feature flags are initialized', async ({ page }) => {
+    // Intercept Unleash feature flags and inject platform.rbac.workspaces as enabled
+    await page.route('**/api/featureflags/v0**', async (route) => {
+      let toggles: object[] = [];
+      try {
+        const response = await route.fetch();
+        const body = await response.json();
+        toggles = body.toggles || [];
+      } catch {
+        // Feature flags endpoint may not return valid JSON in some environments
+      }
+
+      const filtered = toggles.filter((t: { name?: string }) => t.name !== 'platform.rbac.workspaces');
+      filtered.push({
+        name: 'platform.rbac.workspaces',
+        enabled: true,
+        impressionData: false,
+        variant: { name: 'disabled', enabled: false },
+      });
+
+      await route.fulfill({
+        json: { toggles: filtered },
+      });
+    });
+
+    // Initial load — v1 calls during bootstrap are expected (flags not ready yet)
+    await page.goto('/insights/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // After full initialization, track new v1 RBAC calls
+    const v1RbacCalls: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/api/rbac/v1/access')) {
+        v1RbacCalls.push(request.url());
+      }
+    });
+
+    // Trigger a fresh permission check via Chrome API (bypassCache=true)
+    // This exercises fetchPermissions after the Unleash client is initialized
+    await page.evaluate(async () => {
+      await (window as any).insights.chrome.getUserPermissions('rbac-v2-gating-test', true);
+    });
+
+    expect(v1RbacCalls).toHaveLength(0);
+  });
+});

--- a/src/auth/fetchPermissions.test.js
+++ b/src/auth/fetchPermissions.test.js
@@ -1,5 +1,10 @@
 import mockedRbac from '../../testdata/rbacAccess.json';
 
+jest.mock('../components/FeatureFlags/unleashClient', () => ({
+  unleashClientExists: jest.fn(() => false),
+  getUnleashClient: jest.fn(() => ({ isEnabled: jest.fn(() => false) })),
+}));
+
 jest.mock('./rbac', () => () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mockedRbac = require('../../testdata/rbacAccess.json');
@@ -12,6 +17,7 @@ jest.mock('./rbac', () => () => {
 });
 
 import { createFetchPermissionsWatcher } from './fetchPermissions';
+import { getUnleashClient, unleashClientExists } from '../components/FeatureFlags/unleashClient';
 
 describe('fetchPermissions', () => {
   let fetchPermissions;
@@ -74,5 +80,17 @@ describe('fetchPermissions', () => {
     await fetchPermissions('uSeRtOkEn', 'sources', bypasCache);
 
     expect(global.rbacApiCalled).toEqual(2);
+  });
+
+  it('should skip v1 RBAC call when platform.rbac.workspaces flag is enabled', async () => {
+    unleashClientExists.mockReturnValue(true);
+    getUnleashClient.mockReturnValue({ isEnabled: jest.fn(() => true) });
+
+    const result = await fetchPermissions('uSeRtOkEn', 'sources', true);
+
+    expect(result).toEqual([]);
+    expect(global.rbacApiCalled).toEqual(0);
+
+    unleashClientExists.mockReturnValue(false);
   });
 });

--- a/src/auth/fetchPermissions.ts
+++ b/src/auth/fetchPermissions.ts
@@ -2,6 +2,7 @@ import { Access } from '@redhat-cloud-services/rbac-client/types';
 import createRbacAPI from './rbac';
 import logger from './logger';
 import { ChromeUser } from '@redhat-cloud-services/types';
+import { getUnleashClient, unleashClientExists } from '../components/FeatureFlags/unleashClient';
 
 const log = logger('fetchPermissions.ts');
 
@@ -9,6 +10,10 @@ const perPage = 1000;
 const rbacApi = createRbacAPI();
 
 const fetchPermissions = async (_userToken: string, app = '') => {
+  if (unleashClientExists() && getUnleashClient().isEnabled('platform.rbac.workspaces')) {
+    return [];
+  }
+
   try {
     const resp = await rbacApi.getPrincipalAccess({
       limit: perPage,

--- a/src/components/GlobalFilter/GlobalFilter.test.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider as JotaiProvider } from 'jotai';
+import { useFlag } from '@unleash/proxy-client-react';
+import GlobalFilterWrapper from './GlobalFilter';
+import ChromeAuthContext from '../../auth/ChromeAuthContext';
+import InternalChromeContext from '../../utils/internalChromeContext';
+import { ChromeAPI } from '@redhat-cloud-services/types';
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: jest.fn(() => false),
+}));
+
+jest.mock('../../utils/common', () => ({
+  ...jest.requireActual('../../utils/common'),
+  isGlobalFilterAllowed: jest.fn(() => true),
+}));
+
+const mockedUseFlag = useFlag as jest.Mock;
+
+const mockGetUserPermissions = jest.fn(() => Promise.resolve([{ permission: 'inventory:hosts:read' }]));
+
+const mockChromeAuth = {
+  ready: true,
+  user: {
+    identity: {
+      user: { username: 'test', is_org_admin: false, is_internal: false },
+      org_id: '123',
+      account_number: '456',
+    },
+  },
+} as unknown as typeof ChromeAuthContext extends React.Context<infer T> ? T : never;
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <JotaiProvider>
+    <ChromeAuthContext.Provider value={mockChromeAuth}>
+      <InternalChromeContext.Provider value={{ getUserPermissions: mockGetUserPermissions } as unknown as ChromeAPI}>
+        <MemoryRouter initialEntries={['/insights/dashboard']}>{children}</MemoryRouter>
+      </InternalChromeContext.Provider>
+    </ChromeAuthContext.Provider>
+  </JotaiProvider>
+);
+
+describe('GlobalFilterWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseFlag.mockReturnValue(false);
+  });
+
+  it('should call getUserPermissions when rbac.workspaces flag is disabled', async () => {
+    mockedUseFlag.mockReturnValue(false);
+    render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(mockGetUserPermissions).toHaveBeenCalledWith('inventory'));
+  });
+
+  it('should skip getUserPermissions when rbac.workspaces flag is enabled', async () => {
+    mockedUseFlag.mockReturnValue(true);
+    render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
+  });
+});

--- a/src/components/GlobalFilter/GlobalFilter.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.tsx
@@ -11,6 +11,7 @@ import { getInitialFilterState } from './getInitialFilterState';
 import { isGlobalFilterAllowed } from '../../utils/common';
 import InternalChromeContext from '../../utils/internalChromeContext';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
+import { useFlag } from '@unleash/proxy-client-react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   globalFilterDataAtom,
@@ -175,6 +176,7 @@ const GlobalFilterWrapper = () => {
   const chromeAuth = useContext(ChromeAuthContext);
   const { pathname } = useLocation();
   const { getUserPermissions } = useContext(InternalChromeContext);
+  const isRbacV2 = useFlag('platform.rbac.workspaces');
 
   // FIXME: Clean up the global filter display flag
   const isLanding = pathname === '/';
@@ -190,6 +192,11 @@ const GlobalFilterWrapper = () => {
   }, [isLanding, isAllowed, isGlobalFilterDisabled]);
 
   useEffect(() => {
+    if (isRbacV2) {
+      setHasAccess(false);
+      return;
+    }
+
     let mounted = true;
     const fetchPermissions = async () => {
       const permissions = await getUserPermissions?.('inventory');
@@ -205,7 +212,7 @@ const GlobalFilterWrapper = () => {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [isRbacV2]);
   return isGlobalFilterEnabled && chromeAuth.ready ? <GlobalFilter hasAccess={hasAccess} /> : null;
 };
 


### PR DESCRIPTION
### Description
[RHCLOUD-47885](https://issues.redhat.com/browse/RHCLOUD-47885)

Organizations migrated to RBAC v2 (via `platform.rbac.workspaces` feature flag) were still receiving v1 RBAC API calls, resulting in 403 errors. This PR gates `getPrincipalAccess` in `fetchPermissions.ts` and the inventory permission check in `GlobalFilter.tsx` so they are skipped for v2 orgs.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [x] _(Optional) QE: OUIA changed, test impact, no coverage_
- [x] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude Code



[RHCLOUD-47885]: https://redhat.atlassian.net/browse/RHCLOUD-47885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-flag gating: when workspace RBAC is enabled, permission fetching short-circuits (can return empty results) and access-evaluation timing/refresh behavior is adjusted.

* **Tests**
  * Added and updated unit and end-to-end tests to validate workspace RBAC gating, confirm conditional permission calls, and ensure no legacy RBAC access requests occur when gated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->