### PR TITLE
fix: report original errors to Sentry from DefaultErrorComponent

### DIFF
--- a/src/components/ErrorComponents/DefaultErrorComponent.test.tsx
+++ b/src/components/ErrorComponents/DefaultErrorComponent.test.tsx
@@ -89,21 +89,26 @@ describe('DefaultErrorComponent', () => {
       });
     });
 
-    it('reports string errors to Sentry without wrapping in a new Error', async () => {
+    it('reports string errors to Sentry with a Something went wrong prefix', async () => {
       const error = 'Cannot destructure property future of useContext as it is null';
 
       renderWithProviders(<DefaultErrorComponent error={error} />);
 
       await waitFor(() => {
-        expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-          contexts: {
-            react: { componentStack: undefined },
-          },
-          extra: {
-            bundle: 'insights',
-            app: 'insights',
-          },
-        });
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'Something went wrong: Cannot destructure property future of useContext as it is null',
+          }),
+          {
+            contexts: {
+              react: { componentStack: undefined },
+            },
+            extra: {
+              bundle: 'insights',
+              app: 'insights',
+            },
+          }
+        );
       });
     });
 

--- a/src/components/ErrorComponents/DefaultErrorComponent.test.tsx
+++ b/src/components/ErrorComponents/DefaultErrorComponent.test.tsx
@@ -112,6 +112,34 @@ describe('DefaultErrorComponent', () => {
       });
     });
 
+    it('reports plain object errors with message property', async () => {
+      const error = { message: 'cross-frame error' };
+
+      renderWithProviders(<DefaultErrorComponent error={error} />);
+
+      await waitFor(() => {
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'Something went wrong: cross-frame error',
+          }),
+          expect.any(Object)
+        );
+      });
+    });
+
+    it('reports non-standard error types with fallback message', async () => {
+      renderWithProviders(<DefaultErrorComponent error={42} />);
+
+      await waitFor(() => {
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'Something went wrong: Unhandled UI runtime error',
+          }),
+          expect.any(Object)
+        );
+      });
+    });
+
     it('does not report to Sentry when no error is provided', async () => {
       renderWithProviders(<DefaultErrorComponent />);
 

--- a/src/components/ErrorComponents/DefaultErrorComponent.test.tsx
+++ b/src/components/ErrorComponents/DefaultErrorComponent.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { Provider, createStore } from 'jotai';
+import * as Sentry from '@sentry/react';
 import DefaultErrorComponent from './DefaultErrorComponent';
 import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 import { chunkLoadErrorRefreshKey } from '../../utils/common';
@@ -66,6 +67,54 @@ describe('DefaultErrorComponent', () => {
     _testHooks.reload = originalReload;
     jest.clearAllMocks();
     localStorage.clear();
+  });
+
+  describe('Sentry error reporting', () => {
+    it('reports the original error to Sentry with react componentStack and extra context', async () => {
+      const error = new Error('router context is null');
+      const componentStack = '\n    in NavLink\n    in SegmentProvider\n    in ScalprumRoot';
+
+      renderWithProviders(<DefaultErrorComponent error={error} errorInfo={{ componentStack }} />);
+
+      await waitFor(() => {
+        expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+          contexts: {
+            react: { componentStack },
+          },
+          extra: {
+            bundle: 'insights',
+            app: 'insights',
+          },
+        });
+      });
+    });
+
+    it('reports string errors to Sentry without wrapping in a new Error', async () => {
+      const error = 'Cannot destructure property future of useContext as it is null';
+
+      renderWithProviders(<DefaultErrorComponent error={error} />);
+
+      await waitFor(() => {
+        expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+          contexts: {
+            react: { componentStack: undefined },
+          },
+          extra: {
+            bundle: 'insights',
+            app: 'insights',
+          },
+        });
+      });
+    });
+
+    it('does not report to Sentry when no error is provided', async () => {
+      renderWithProviders(<DefaultErrorComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Something went wrong', { exact: false })).toBeInTheDocument();
+      });
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
   });
 
   describe('renders error page', () => {

--- a/src/components/ErrorComponents/DefaultErrorComponent.tsx
+++ b/src/components/ErrorComponents/DefaultErrorComponent.tsx
@@ -39,17 +39,17 @@ const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
   const [sentryId, setSentryId] = useState<string | undefined>();
 
   const activeModule = useAtomValue(activeModuleAtom);
-  const exceptionMessage = `Something Went Wrong: ${(props.error as Error)?.message || 'Unhandled UI runtime error'}`;
   useEffect(() => {
     const sentryId =
       props.error &&
-      Sentry.captureException(new Error(exceptionMessage), {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        bundle: getUrl('bundle'),
-        app: getUrl('app'),
-        error: (props.error instanceof Error && props.error?.message) || props.error,
-        trace: props.errorInfo?.componentStack || (props.error instanceof Error && props.error?.stack) || props.error,
+      Sentry.captureException(props.error, {
+        contexts: {
+          react: { componentStack: props.errorInfo?.componentStack },
+        },
+        extra: {
+          bundle: getUrl('bundle'),
+          app: getUrl('app'),
+        },
       });
     setSentryId(sentryId);
     // When a chunk error occurs, save it with sentry and reload the page.
@@ -77,7 +77,7 @@ const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
         chunkLoadErrorUtils.reloadPage();
       }
     }
-  }, [props.error, activeModule]);
+  }, [props.error, props.errorInfo, activeModule]);
 
   // second level of error capture if xhr/fetch interceptor fails
   const gatewayError = get3scaleError(props.error as any, props.auth);

--- a/src/components/ErrorComponents/DefaultErrorComponent.tsx
+++ b/src/components/ErrorComponents/DefaultErrorComponent.tsx
@@ -16,14 +16,14 @@ import * as chunkLoadErrorUtils from '../../utils/chunkLoadErrorUtils';
 import { useIntl } from 'react-intl';
 import messages from '../../locales/Messages';
 import './ErrorComponent.scss';
-import { get3scaleError } from '../../utils/responseInterceptors';
+import { ThreeScaleError, get3scaleError } from '../../utils/responseInterceptors';
 import GatewayErrorComponent from './GatewayErrorComponent';
 import { getUrl } from '../../hooks/useBundle';
 import { useAtomValue } from 'jotai';
 import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 
 export type DefaultErrorComponentProps = {
-  error?: any | Error;
+  error?: unknown;
   errorInfo?: {
     componentStack?: string;
   };
@@ -34,6 +34,19 @@ export type DefaultErrorComponentProps = {
   onReset?: () => void;
 };
 
+const getErrorMessage = (error: unknown): string => {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return 'Unhandled UI runtime error';
+};
+
 const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
   const intl = useIntl();
   const [sentryId, setSentryId] = useState<string | undefined>();
@@ -41,16 +54,17 @@ const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
   const activeModule = useAtomValue(activeModuleAtom);
   useEffect(() => {
     const sentryId =
-      props.error &&
-      Sentry.captureException(props.error, {
-        contexts: {
-          react: { componentStack: props.errorInfo?.componentStack },
-        },
-        extra: {
-          bundle: getUrl('bundle'),
-          app: getUrl('app'),
-        },
-      });
+      props.error != null
+        ? Sentry.captureException(props.error instanceof Error ? props.error : new Error(`Something went wrong: ${getErrorMessage(props.error)}`), {
+            contexts: {
+              react: { componentStack: props.errorInfo?.componentStack },
+            },
+            extra: {
+              bundle: getUrl('bundle'),
+              app: getUrl('app'),
+            },
+          })
+        : undefined;
     setSentryId(sentryId);
     // When a chunk error occurs, save it with sentry and reload the page.
     // After ten seconds, the key will be removed from localStorage
@@ -58,12 +72,7 @@ const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
     if (activeModule && chunkLoadErrorUtils.isChunkLoadError(props.error)) {
       const moduleStorageKey = `${chunkLoadErrorRefreshKey}-${activeModule}`;
       // explicitly track chunk loading errors
-      const errorMessage =
-        typeof props.error === 'string'
-          ? props.error
-          : typeof props.error === 'object' && props.error !== null && 'message' in props.error
-            ? String((props.error as { message: unknown }).message)
-            : undefined;
+      const errorMessage = getErrorMessage(props.error);
       window?.segment?.track('chunk-loading-error', {
         bundle: getUrl('bundle'),
         app: getUrl(),
@@ -80,7 +89,12 @@ const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
   }, [props.error, props.errorInfo, activeModule]);
 
   // second level of error capture if xhr/fetch interceptor fails
-  const gatewayError = get3scaleError(props.error as any, props.auth);
+  const gatewayError =
+    typeof props.error === 'string'
+      ? get3scaleError(props.error, props.auth)
+      : typeof props.error === 'object' && props.error !== null && 'errors' in props.error
+        ? get3scaleError(props.error as { errors: ThreeScaleError[] }, props.auth)
+        : undefined;
   if (gatewayError) {
     return <GatewayErrorComponent error={gatewayError} />;
   }
@@ -118,7 +132,7 @@ const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {
                       {props.error}
                     </Content>
                   )}
-                  {typeof props?.error === 'object' && typeof props?.error?.message === 'string' && (
+                  {typeof props.error === 'object' && props.error !== null && 'message' in props.error && typeof props.error.message === 'string' && (
                     <Content component="p" className="error-text">
                       {props.error.message}
                     </Content>

--- a/src/components/ErrorComponents/DefaultErrorComponent.tsx
+++ b/src/components/ErrorComponents/DefaultErrorComponent.tsx
@@ -9,7 +9,7 @@ import { Content } from '@patternfly/react-core/dist/dynamic/components/Content'
 import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
 
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/dynamic/icons/exclamation-circle-icon';
-import { chunkLoadErrorRefreshKey } from '../../utils/common';
+import { chunkLoadErrorRefreshKey, getErrorMessage } from '../../utils/common';
 // Import as namespace to access isChunkLoadError and reloadPage.
 // reloadPage routes through _testHooks.reload() for Cypress stubbability.
 import * as chunkLoadErrorUtils from '../../utils/chunkLoadErrorUtils';
@@ -32,19 +32,6 @@ export type DefaultErrorComponentProps = {
     loginRedirect: () => Promise<void>;
   };
   onReset?: () => void;
-};
-
-const getErrorMessage = (error: unknown): string => {
-  if (typeof error === 'string') {
-    return error;
-  }
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (typeof error === 'object' && error !== null && 'message' in error) {
-    return String((error as { message: unknown }).message);
-  }
-  return 'Unhandled UI runtime error';
 };
 
 const DefaultErrorComponent = (props: DefaultErrorComponentProps) => {

--- a/src/utils/chunkLoadErrorUtils.ts
+++ b/src/utils/chunkLoadErrorUtils.ts
@@ -1,15 +1,5 @@
 import React from 'react';
-
-/**
- * Extracts a message string from an unknown error value.
- */
-function getErrorMessage(error: unknown): string {
-  if (typeof error === 'string') return error;
-  if (typeof error === 'object' && error !== null && 'message' in error) {
-    return String((error as { message: unknown }).message);
-  }
-  return '';
-}
+import { getErrorMessage } from './common';
 
 /**
  * Detects whether an error is a chunk/module loading failure.
@@ -30,7 +20,7 @@ function getErrorMessage(error: unknown): string {
 export function isChunkLoadError(error: unknown): boolean {
   if (!error) return false;
 
-  const message = getErrorMessage(error);
+  const message = getErrorMessage(error, '');
 
   // Standard webpack 5 chunk load errors
   // e.g. "Loading chunk 123 failed.\n(error: https://cdn.example.com/chunk.123.js)"

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -1,0 +1,38 @@
+import { getErrorMessage } from './common';
+
+describe('getErrorMessage', () => {
+  it('extracts string errors', () => {
+    expect(getErrorMessage('simple error')).toBe('simple error');
+  });
+
+  it('extracts message from Error instances', () => {
+    expect(getErrorMessage(new Error('standard error'))).toBe('standard error');
+  });
+
+  it('extracts message from plain objects', () => {
+    expect(getErrorMessage({ message: 'cross-frame error' })).toBe('cross-frame error');
+  });
+
+  it('returns fallback for null/undefined', () => {
+    expect(getErrorMessage(null)).toBe('Unhandled UI runtime error');
+    expect(getErrorMessage(undefined)).toBe('Unhandled UI runtime error');
+  });
+
+  it('returns fallback for non-error types', () => {
+    expect(getErrorMessage(42)).toBe('Unhandled UI runtime error');
+    expect(getErrorMessage(true)).toBe('Unhandled UI runtime error');
+    expect(getErrorMessage({})).toBe('Unhandled UI runtime error');
+  });
+
+  it('returns fallback for non-string message properties', () => {
+    expect(getErrorMessage({ message: 123 })).toBe('Unhandled UI runtime error');
+    expect(getErrorMessage({ message: { nested: 'x' } })).toBe('Unhandled UI runtime error');
+    expect(getErrorMessage({ message: null })).toBe('Unhandled UI runtime error');
+  });
+
+  it('uses custom fallback when provided', () => {
+    expect(getErrorMessage(null, '')).toBe('');
+    expect(getErrorMessage(undefined, 'custom')).toBe('custom');
+    expect(getErrorMessage({ message: 456 }, 'default')).toBe('default');
+  });
+});

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -67,6 +67,25 @@ export const LOGIN_SCOPES_STORAGE_KEY = '@chrome/login-scopes';
 export const chunkLoadErrorRefreshKey = 'ChunkLoadErrorRefreshed';
 export const BLOCK_CLEAR_GATEWAY_ERROR = 'BLOCK_CLEAR_GATEWAY_ERROR';
 
+/**
+ * Extracts a message string from an unknown error value.
+ * @param error - The error value to extract a message from
+ * @param fallback - Optional fallback message (default: 'Unhandled UI runtime error')
+ * @returns A human-readable error message string
+ */
+export function getErrorMessage(error: unknown, fallback = 'Unhandled UI runtime error'): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+  return fallback;
+}
+
 export function getWindow() {
   return window;
 }


### PR DESCRIPTION
### Description
Pass props.error directly to captureException instead of wrapping it in a new Error, which replaced the real stack trace with the error boundary's. Use Sentry's contexts.react.componentStack and extra fields so bundle, app, and the React component tree are actually recorded instead of being dropped.

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for error-message extraction and for error-reporting behavior across various error types, including no-report when no error exists.

* **Bug Fixes**
  * More robust error-to-string handling, consistent "Something went wrong:" messaging, improved chunk-load detection and safer gateway error checks, and stricter rendering of error details.

* **Refactor**
  * Centralized error-message logic and updated error reporting to include React component stack and structured extra metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->