### PR TITLE
fix: skeleton loaders lack accessible text

### DIFF
--- a/playwright/e2e/release-gate/accessibility.spec.ts
+++ b/playwright/e2e/release-gate/accessibility.spec.ts
@@ -21,7 +21,7 @@ const APP_INIT_TIMEOUT = 30000;
 // Chrome pages to test for accessibility (not tenant applications)
 const ACCESSIBILITY_TEST_TARGETS = [
   { url: '/' },
-  { url: '/settings', skipReason: 'RHCLOUD-47549 - skeleton loaders lack accessible text' },
+  { url: '/settings'},
   { url: '/allservices', skipReason: 'RHCLOUD-47753 - aria-prohibited-attr on favorite service buttons' },
 ] as const;
 

--- a/src/components/Navigation/Loader.tsx
+++ b/src/components/Navigation/Loader.tsx
@@ -11,7 +11,7 @@ const NavLoader = () => (
       <NavList>
         {[...new Array(4)].map((_i, key) => (
           <NavItem key={key} preventDefault>
-            <a href="#" aria-label="Loading..." aria-busy="true">
+            <a href="#" aria-label="Loading..." aria-busy="true" tabIndex={-1}>
               <Skeleton isDark={Array.from(document?.documentElement?.classList).includes('pf-v6-theme-dark')} size={SkeletonSize.lg} />
             </a>
           </NavItem>

--- a/src/components/Navigation/Loader.tsx
+++ b/src/components/Navigation/Loader.tsx
@@ -11,7 +11,7 @@ const NavLoader = () => (
       <NavList>
         {[...new Array(4)].map((_i, key) => (
           <NavItem key={key} preventDefault>
-            <a href="#">
+            <a href="#" aria-label="Loading..." aria-busy="true">
               <Skeleton isDark={Array.from(document?.documentElement?.classList).includes('pf-v6-theme-dark')} size={SkeletonSize.lg} />
             </a>
           </NavItem>

--- a/src/components/Navigation/__snapshots__/Navigation.test.js.snap
+++ b/src/components/Navigation/__snapshots__/Navigation.test.js.snap
@@ -53,8 +53,11 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
         data-ouia-safe="true"
       >
         <a
+          aria-busy="true"
+          aria-label="Loading..."
           class="pf-v6-c-nav__link"
           href="#"
+          tabindex="-1"
         >
           <div
             class="pf-v6-c-skeleton ins-c-skeleton ins-c-skeleton__lg"
@@ -72,8 +75,11 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
         data-ouia-safe="true"
       >
         <a
+          aria-busy="true"
+          aria-label="Loading..."
           class="pf-v6-c-nav__link"
           href="#"
+          tabindex="-1"
         >
           <div
             class="pf-v6-c-skeleton ins-c-skeleton ins-c-skeleton__lg"
@@ -91,8 +97,11 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
         data-ouia-safe="true"
       >
         <a
+          aria-busy="true"
+          aria-label="Loading..."
           class="pf-v6-c-nav__link"
           href="#"
+          tabindex="-1"
         >
           <div
             class="pf-v6-c-skeleton ins-c-skeleton ins-c-skeleton__lg"
@@ -110,8 +119,11 @@ exports[`ChromeNavItem should render navigation loader if schema was not loaded 
         data-ouia-safe="true"
       >
         <a
+          aria-busy="true"
+          aria-label="Loading..."
           class="pf-v6-c-nav__link"
           href="#"
+          tabindex="-1"
         >
           <div
             class="pf-v6-c-skeleton ins-c-skeleton ins-c-skeleton__lg"


### PR DESCRIPTION
### Description

Skeleton loaders in the `/settings` page navigation links lack accessible text and are incorrectly keyboard-focusable during loading, causing serious WCAG 2.4.4 (Level A) `link-name` violations detected by axe-core. This adds `aria-label="Loading..."` and `aria-busy="true"` to the skeleton loader links so screen reader users can identify the loading state, and adds `tabIndex={-1}` to remove the inert loading links from the keyboard tab order.

[RHCLOUD-47549](https://issues.redhat.com/browse/RHCLOUD-47549)

---

### Screenshots

N/A — non-visual change (accessibility attributes on existing skeleton loaders).

---

### Anything reviewers should know?

Two changes to `Loader.tsx`:
- `aria-label="Loading..."` and `aria-busy="true"` satisfy the `link-name` axe rule for screen readers.
- `tabIndex={-1}` removes the loading placeholders from the keyboard tab order since they are non-interactive and activating them does nothing.

The accessibility Playwright test (`accessibility.spec.ts`) was also updated to cover the `/settings` page.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude

[RHCLOUD-47549]: https://redhat.atlassian.net/browse/RHCLOUD-47549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for the navigation loader with proper ARIA attributes for loading states.

* **Tests**
  * Enabled accessibility checks for the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->