### PR TITLE
refactor(playwright): migrate to hcc-page-objects package

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.2",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.1.1",
     "@redhat-cloud-services/frontend-components-config-utilities": "^4.9.1",
+    "@redhat-cloud-services/hcc-page-objects": "^0.0.0",
     "@redhat-cloud-services/playwright-test-auth": "^0.0.2",
     "@redhat-cloud-services/types": "^3.5.1",
     "@simonsmith/cypress-image-snapshot": "^10.0.3",

--- a/playwright/e2e/browser-titles.spec.ts
+++ b/playwright/e2e/browser-titles.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../setup/test-setup';
-import { ChromeNavigation } from './pages/chrome-navigation';
+import { ChromeNavigation } from '@redhat-cloud-services/hcc-page-objects';
 
 /**
  * Browser Title Validation Tests

--- a/playwright/e2e/release-gate/logout.spec.ts
+++ b/playwright/e2e/release-gate/logout.spec.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from '@playwright/test';
-import { ChromeTopbar } from '../pages/chrome-topbar';
+import { ChromeTopbar } from '@redhat-cloud-services/hcc-page-objects';
 import { createAuthenticatedPage } from '../../helpers/isolated-auth';
 import { AUTH_TIMEOUT } from '../../setup/constants';
 

--- a/playwright/e2e/release-gate/navigation.spec.ts
+++ b/playwright/e2e/release-gate/navigation.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '../../setup/test-setup';
-import { ChromeNavigation } from '../pages/chrome-navigation';
-import { ChromeTopbar } from '../pages/chrome-topbar';
+import { ChromeNavigation, ChromeTopbar } from '@redhat-cloud-services/hcc-page-objects';
 
 test.describe('Navigation', () => {
   test.beforeEach(async ({ page }) => {

--- a/playwright/e2e/release-gate/org-id-visibility.spec.ts
+++ b/playwright/e2e/release-gate/org-id-visibility.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../setup/test-setup';
-import { ChromeTopbar } from '../pages/chrome-topbar';
+import { ChromeTopbar } from '@redhat-cloud-services/hcc-page-objects';
 
 /**
  * Test: Org ID visibility in overflow actions

--- a/playwright/e2e/release-gate/search.spec.ts
+++ b/playwright/e2e/release-gate/search.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../setup/test-setup';
-import { ChromeSearch } from '../pages/chrome-search';
+import { ChromeSearch } from '@redhat-cloud-services/hcc-page-objects';
 
 /**
  * Test: Platform Search Functionality

--- a/playwright/e2e/release-gate/settings.spec.ts
+++ b/playwright/e2e/release-gate/settings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../setup/test-setup';
-import { ChromeTopbar } from '../pages/chrome-topbar';
+import { ChromeTopbar } from '@redhat-cloud-services/hcc-page-objects';
 
 /**
  * Settings Gear Menu Tests


### PR DESCRIPTION
## Summary
  Migrates Playwright tests from local page object files to the
  `@redhat-cloud-services/hcc-page-objects` package for better reusability across HCC test pipelines.

  ## Changes
  - Added `@redhat-cloud-services/hcc-page-objects` dependency
  - Updated 6 test files to import from package instead of local files:
    - `playwright/e2e/browser-titles.spec.ts`
    - `playwright/e2e/release-gate/logout.spec.ts`
    - `playwright/e2e/release-gate/navigation.spec.ts`
    - `playwright/e2e/release-gate/org-id-visibility.spec.ts`
    - `playwright/e2e/release-gate/search.spec.ts`
    - `playwright/e2e/release-gate/settings.spec.ts`

  ## Page Objects Migrated
  - **ChromeNavigation**: Sidebar navigation interactions
  - **ChromeSearch**: Platform search functionality
  - **ChromeTopbar**: Masthead components (user menu, settings, services)

  ## Verification
  - ✅ All 74 tests compile and load successfully
  - ✅ TypeScript resolves imports correctly
  - ✅ Local page object files remain in place for backward compatibility during transition

  ## Benefits
  - Enables page object sharing across multiple test repositories
  - Centralizes page object maintenance
  - Reduces code duplication
  - Follows established pattern from `playwright-test-auth`

  ## Migration Path
  1. This PR consumes the package while keeping local files
  2. Once package is published and stable, local page object files can be removed
  3. Other test repositories can adopt the same page objects

  ## Dependencies
  - Requires: `@redhat-cloud-services/hcc-page-objects@^0.0.0`
  - Companion PR: [frontend-test-utils PR link]

  ## Testing Notes
  The package is currently linked locally for testing. Once the frontend-test-utils PR is merged and
  published, this PR will use the published package version.