### PR TITLE
fix(context-switcher): View Access To Customer Accounts Now Missing

### DIFF
--- a/cypress/component/ContextSwitcher/ContextSwitcher.cy.js
+++ b/cypress/component/ContextSwitcher/ContextSwitcher.cy.js
@@ -40,7 +40,7 @@ describe('<ContextSwithcer />', () => {
     const elem = cy
       .mount(
         <Wrapper>
-          <ContextSwitcher accountNumber={testUser.identity.account_number} isInternal={testUser.identity.user.is_internal} />
+          <ContextSwitcher accountNumber={testUser.identity.account_number} orgId={testUser.identity.org_id} isInternal={testUser.identity.user.is_internal} />
         </Wrapper>
       )
       .get('html');
@@ -63,11 +63,81 @@ describe('<ContextSwithcer />', () => {
     const elem = cy
       .mount(
         <Wrapper>
-          <ContextSwitcher accountNumber={testUser.identity.account_number} isInternal={testUser.identity.user.is_internal} />
+          <ContextSwitcher accountNumber={testUser.identity.account_number} orgId={testUser.identity.org_id} isInternal={testUser.identity.user.is_internal} />
         </Wrapper>
       )
       .get('html');
     cy.wait('@crossAccountRequests');
     elem.get('body').matchImageSnapshot();
+  });
+
+  it('should render cross-account entries when API response has no target_account field (RHCLOUD-48475)', () => {
+    cy.viewport(1280, 720);
+    cy.intercept('http://localhost:8080/api/rbac/v1/cross-account-requests/?status=approved&order_by=-created&query_by=user_id', {
+      data: [
+        {
+          request_id: 'req-aaa',
+          target_org: '17940001',
+          start_date: '29 Sep 2025',
+          end_date: '28 Sep 2026',
+          created: '25 Sep 2025, 13:34 UTC',
+          status: 'approved',
+          user_id: 'testuser',
+          email: 'jdoe@redhat.com',
+          first_name: 'Jane',
+          last_name: 'Doe',
+        },
+        {
+          request_id: 'req-bbb',
+          target_org: '17940002',
+          start_date: '11 Aug 2025',
+          end_date: '10 Aug 2026',
+          created: '08 Aug 2025, 16:52 UTC',
+          status: 'approved',
+          user_id: 'testuser',
+          email: 'jsmith@redhat.com',
+          first_name: 'John',
+          last_name: 'Smith',
+        },
+        {
+          request_id: 'req-ccc',
+          target_org: '17940003',
+          start_date: '11 Aug 2025',
+          end_date: '10 Aug 2026',
+          created: '08 Aug 2025, 16:50 UTC',
+          status: 'approved',
+          user_id: 'testuser',
+          email: 'bob@redhat.com',
+          first_name: 'Bob',
+          last_name: 'Jones',
+        },
+      ],
+    }).as('crossAccountRequests');
+
+    testUser.identity.user.is_internal = true;
+    cy.mount(
+      <Wrapper>
+        <ContextSwitcher accountNumber={testUser.identity.account_number} orgId={testUser.identity.org_id} isInternal={testUser.identity.user.is_internal} />
+      </Wrapper>
+    );
+    cy.wait('@crossAccountRequests');
+
+    // Component should render
+    cy.contains('Account:').should('exist');
+    cy.contains('Account:').click();
+
+    // Personal account should show
+    cy.contains('123456').should('exist');
+    cy.contains('Personal account').should('exist');
+
+    // All 3 cross-account entries should render with org IDs displayed
+    cy.get('.account-label').contains('17940001').should('exist');
+    cy.get('.account-label').contains('17940002').should('exist');
+    cy.get('.account-label').contains('17940003').should('exist');
+
+    // All 3 names should display
+    cy.contains('Jane Doe').should('exist');
+    cy.contains('John Smith').should('exist');
+    cy.contains('Bob Jones').should('exist');
   });
 });

--- a/src/components/ContextSwitcher/index.tsx
+++ b/src/components/ContextSwitcher/index.tsx
@@ -32,6 +32,7 @@ import { contextSwitcherOpenAtom } from '../../state/atoms/contextSwitcher';
 export type ContextSwitcherProps = {
   className?: string;
   accountNumber?: string;
+  orgId?: string;
   isInternal?: boolean;
 };
 
@@ -43,7 +44,21 @@ type CrossAccountRequestInternal = CrossAccountRequestByUserId & {
   email: string;
 };
 
-const ContextSwitcher = ({ accountNumber, className, isInternal }: ContextSwitcherProps) => {
+/**
+ * Resolve the display/dedup identifier for a cross-account request.
+ * The RBAC API stopped returning target_account (RHCLOUD-48475); target_org is now canonical.
+ *
+ * TEMPORARY BACKWARD COMPAT: Fall back to target_account for:
+ * 1. Old localStorage from users who previously used cross-account feature
+ * 2. Outdated @redhat-cloud-services/rbac-client@6.0.1 type still defines target_account
+ *
+ * TODO: Remove target_account fallback after:
+ * - Upgrading rbac-client to 9.x (separate ticket needed)
+ * - 90 days post-deploy (allows localStorage to rotate through TAM access expirations)
+ */
+const resolveAccountIdentifier = (request: CrossAccountRequestInternal): string | undefined => request.target_org ?? request.target_account;
+
+const ContextSwitcher = ({ accountNumber, orgId, className, isInternal }: ContextSwitcherProps) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useAtom(contextSwitcherOpenAtom);
   const [data, setData] = useState<CrossAccountRequestInternal[]>([]);
@@ -54,14 +69,15 @@ const ContextSwitcher = ({ accountNumber, className, isInternal }: ContextSwitch
   };
 
   const handleItemClick = (target_account?: string, request_id?: string, end_date?: Date, target_org?: string) => {
-    if (!target_org || !target_account || target_account === selectedAccountNumber) {
+    const accountIdentifier = target_org ?? target_account;
+    if (!target_org || !accountIdentifier || accountIdentifier === selectedAccountNumber) {
       return;
     }
     localStorage.removeItem(ACTIVE_ACCOUNT_SWITCH_NOTIFICATION);
     localStorage.removeItem(REQUESTS_COUNT);
     localStorage.removeItem(REQUESTS_DATA);
-    setSelectedAccountNumber(target_account);
-    Cookies.set(CROSS_ACCESS_ACCOUNT_NUMBER, target_account);
+    setSelectedAccountNumber(accountIdentifier);
+    Cookies.set(CROSS_ACCESS_ACCOUNT_NUMBER, accountIdentifier);
     Cookies.set(CROSS_ACCESS_ORG_ID, target_org);
 
     /**
@@ -73,7 +89,7 @@ const ContextSwitcher = ({ accountNumber, className, isInternal }: ContextSwitch
       ACTIVE_REMOTE_REQUEST,
       JSON.stringify({
         request_id,
-        target_account,
+        target_account: accountIdentifier, // TEMPORARY: Keep key name for backward compat (RHCLOUD-48475)
         end_date,
       })
     );
@@ -99,7 +115,10 @@ const ContextSwitcher = ({ accountNumber, className, isInternal }: ContextSwitch
       const initialAccount = localStorage.getItem(ACTIVE_REMOTE_REQUEST);
       if (initialAccount) {
         try {
-          setSelectedAccountNumber(JSON.parse(initialAccount).target_account);
+          const parsed = JSON.parse(initialAccount);
+          // TEMPORARY: Fallback to target_account for old localStorage format (RHCLOUD-48475)
+          // TODO: Remove fallback after 90 days post-deploy
+          setSelectedAccountNumber(parsed.target_org ?? parsed.target_account);
         } catch {
           console.log('Unable to parse initial account. Using default account');
         }
@@ -117,14 +136,20 @@ const ContextSwitcher = ({ accountNumber, className, isInternal }: ContextSwitch
             setData(
               data
                 .reduce<CrossAccountRequestInternal[]>((acc, curr) => {
-                  const request = acc.find(({ target_account }) => target_account === curr.target_account);
+                  const request = acc.find((item) => resolveAccountIdentifier(item) === resolveAccountIdentifier(curr));
                   if (request) {
                     return acc;
                   }
                   return [...acc, curr];
                 }, [])
-                .filter(({ target_account }) => target_account !== accountNumber)
+                .filter((item) => resolveAccountIdentifier(item) !== orgId)
             );
+          }
+        })
+        .catch((error) => {
+          console.error('Failed to fetch cross-account requests:', error);
+          if (mounted) {
+            setData([]);
           }
         });
     }
@@ -137,7 +162,7 @@ const ContextSwitcher = ({ accountNumber, className, isInternal }: ContextSwitch
     return null;
   }
 
-  const filteredData = data && data.filter(({ target_account }) => `${target_account}`.includes(searchValue));
+  const filteredData = data && data.filter((item) => `${resolveAccountIdentifier(item)}`.includes(searchValue));
 
   const contextSwitcherToggle = (toggleRef: React.RefObject<any>) => (
     <MenuToggle ref={toggleRef} isExpanded={isOpen} onClick={onSelect} aria-label="Selected account:">
@@ -184,23 +209,27 @@ const ContextSwitcher = ({ accountNumber, className, isInternal }: ContextSwitch
       )}
       {filteredData?.length === 0 ? <DropdownItem>{intl.formatMessage(messages.noResults)}</DropdownItem> : <Fragment />}
       {filteredData ? (
-        filteredData.map(({ target_account, request_id, end_date, target_org, email, first_name, last_name }) => (
-          <DropdownItem onClick={() => handleItemClick(target_account, request_id, end_date, target_org)} key={request_id}>
-            <Content className="chr-c-content-account">
-              <Content component="p" className="account-label">
-                <span>{target_account}</span>
-                {target_account === selectedAccountNumber && (
-                  <Icon size="sm" className="pf-v6-u-ml-auto">
-                    <CheckIcon color="var(--pf-t--global--icon--color--brand--default)" />
-                  </Icon>
-                )}
+        filteredData.map((item) => {
+          const { target_account, request_id, end_date, target_org, email, first_name, last_name } = item;
+          const accountIdentifier = resolveAccountIdentifier(item);
+          return (
+            <DropdownItem onClick={() => handleItemClick(target_account, request_id, end_date, target_org)} key={request_id}>
+              <Content className="chr-c-content-account">
+                <Content component="p" className="account-label">
+                  <span>{accountIdentifier}</span>
+                  {accountIdentifier === selectedAccountNumber && (
+                    <Icon size="sm" className="pf-v6-u-ml-auto">
+                      <CheckIcon color="var(--pf-t--global--icon--color--brand--default)" />
+                    </Icon>
+                  )}
+                </Content>
+                <Content className="account-name" component="small">
+                  {first_name && last_name ? `${first_name} ${last_name}` : email}
+                </Content>
               </Content>
-              <Content className="account-name" component="small">
-                {first_name && last_name ? `${first_name} ${last_name}` : email}
-              </Content>
-            </Content>
-          </DropdownItem>
-        ))
+            </DropdownItem>
+          );
+        })
       ) : (
         <DropdownItem>
           <Bullseye>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -86,7 +86,7 @@ const MemoizedHeader = memo(
               <ToolbarGroup variant="filter-group">
                 {userReady && !isITLess && (
                   <ToolbarItem className="pf-v6-m-hidden pf-v6-m-visible-on-xl">
-                    <ContextSwitcher accountNumber={accountNumber} isInternal={isInternal} className="data-hj-suppress sentry-mask" />
+                    <ContextSwitcher accountNumber={accountNumber} orgId={orgId} isInternal={isInternal} className="data-hj-suppress sentry-mask" />
                   </ToolbarItem>
                 )}
               </ToolbarGroup>


### PR DESCRIPTION
### Description
  
  TAM users unable to see cross-account entries in account switcher dropdown. RBAC API stopped returning `target_account` field; component only had `target_org` but used `target_account` for dedup/display/filtering. Result: dedup collapsed all 3+ entries to 1, display showed blank. Fixed by using `target_org ?? target_account` fallback via `resolveAccountIdentifier()` helper. Added `orgId` prop to ContextSwitcher so filter compares org to org (not org to account number).

  [RHCLOUD-48475](https://issues.redhat.com/browse/RHCLOUD-48475)

  ---

  ### Screenshots

  N/A — fix makes broken dropdown work again, no UI changes.

  ---

  ### Anything reviewers should know?

  **Backward compatibility:** Fallback to `target_account` handles old localStorage from users who previously used cross-account feature + outdated rbac-client@6.0.1 type definition. Safe to keep during transition period.

  **TODO cleanup:** Comments added to `resolveAccountIdentifier()` and localStorage read. Remove fallback after:
  1. Upgrade `@redhat-cloud-services/rbac-client` to 9.x (separate ticket)
  2. 90 days post-deploy (allows TAM access expirations to rotate stale localStorage)

  **Test:** Added Cypress component test with HAR-shaped response data (no `target_account` field). Confirms 3 entries render with org IDs displayed. Existing tests updated to pass `orgId` prop.

  ---

  ### Checklist
  - [x] Accessibility: dropdown is existing component, no changes (N/A)
  - [ ] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [x] QE: No OUIA/ARIA changes (N/A)
  - [x] UX: No user-facing UX changes, just fix broken feature (N/A)

  ### AI disclosure

  Assisted by: Claude Code



[RHCLOUD-48475]: https://redhat.atlassian.net/browse/RHCLOUD-48475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context switcher now supports organization identifiers alongside account numbers for improved cross-account request handling and filtering.
  * Enhanced account/organization identification logic to prioritize organization IDs when available.

* **Tests**
  * Updated component tests to cover organization ID scenarios and cross-account request data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->