### PR TITLE
fix: remove workspace-list flag usage

### DIFF
--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -102,7 +102,6 @@ const mockUser = {
 const defaultFlags: Record<string, boolean> = {
   'platform.sources.integrations': false,
   'platform.rbac.workspaces': false,
-  'platform.rbac.workspaces-list': false,
   'platform.chrome.help-panel': false,
   'platform.chrome.ask-redhat-help': false,
   'platform.learning-resources.global-learning-resources': false,

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -82,7 +82,6 @@ const Tools = () => {
   const togglePreviewWithCheck = useSetAtom(togglePreviewWithCheckAtom);
   const enableIntegrations = useFlag('platform.sources.integrations');
   const workspacesEnabled = useFlag('platform.rbac.workspaces');
-  const workspacesListEnabled = useFlag('platform.rbac.workspaces-list');
   const helpPanelEnabled = useFlag('platform.chrome.help-panel');
   const askRedHatEnabled = useFlag('platform.chrome.ask-redhat-help');
   const enableGlobalLearningResourcesPage = useFlag('platform.learning-resources.global-learning-resources');
@@ -205,12 +204,11 @@ const Tools = () => {
           ouiaId: 'UserAccess',
           url: identityAndAccessManagmentPath,
           title: isOrgAdmin ? (workspacesEnabled ? 'Acess management' : 'User Access') : 'My User Access',
-          description:
-            workspacesEnabled || workspacesListEnabled ? (
-              <Label status="custom" color="teal" variant="outline" icon={<UsersIcon />} isCompact>
-                Workspaces model available
-              </Label>
-            ) : null,
+          description: workspacesEnabled ? (
+            <Label status="custom" color="teal" variant="outline" icon={<UsersIcon />} isCompact>
+              Workspaces model available
+            </Label>
+          ) : null,
         },
         {
           ouiaId: 'settings-menu-identity-provider',


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->
- remove usage of the `platform.rbac.workspaces-list` flag.
- ensure the user has `platform.rbac.workspaces` for the *Workspaces Model Available* label to appear

[RHCLOUD-47873](https://redhat.atlassian.net/browse/RHCLOUD-47873)
---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-47873]: https://redhat.atlassian.net/browse/RHCLOUD-47873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Workspaces model available” label in Identity and Access Management to render strictly based on the correct workspace capability, preventing it from appearing when the related flag is not enabled.
  * Updated header unit test feature-flag defaults to align with the new label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->