### PR TITLE
chore(readme): fix typo in readme to test sentry build time variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Start the dev server.
 npm run dev
 ```
 
-Use browser to visit [/staging/starter](https://stage.foo.redhat.com:1337/staging/starter) in chrome to access the `frontend-starter-app`.
+Use a browser to visit [/staging/starter](https://stage.foo.redhat.com:1337/staging/starter) in chrome to access the `frontend-starter-app`.
 
 Note: The `proxy` function is defined in [frontend-components/packages/config-utils/src/proxy.ts](https://github.com/RedHatInsights/frontend-components/blob/master/packages/config-utils/src/proxy.ts).
 


### PR DESCRIPTION
Fixes a simple typo in the readme to test out if our sentry build time variables are being set correctly for chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor grammar improvement in the README's section on running Chrome with other applications locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->