### PR TITLE
fix(sentry): pass in konflux sentry vars

### DIFF
--- a/.tekton/insights-chrome-push.yaml
+++ b/.tekton/insights-chrome-push.yaml
@@ -24,6 +24,12 @@ spec:
     value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/insights-chrome:{{revision}}
   - name: dockerfile
     value: build-tools/Dockerfile
+  - name: build-container-additional-secret
+    value: build-container-additional-secret
+  - name: build-args
+    value:
+      - ENABLE_SENTRY=true
+      - SENTRY_RELEASE={{revision}}
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -84,6 +90,10 @@ spec:
     - default: Dockerfile
       description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
+      type: string
+    - default: build-container-additional-secret
+      description: Name of a Konflux-managed secret that will be mounted and made available to the container build process.
+      name: build-container-additional-secret
       type: string
     - default: 'false'
       description: Skip checks against built image
@@ -331,6 +341,8 @@ spec:
         value: $(params.image-expires-after)
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
+      - name: ADDITIONAL_SECRET
+        value: $(params.build-container-additional-secret)
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])

--- a/.tekton/insights-chrome-push.yaml
+++ b/.tekton/insights-chrome-push.yaml
@@ -24,12 +24,6 @@ spec:
     value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/insights-chrome:{{revision}}
   - name: dockerfile
     value: build-tools/Dockerfile
-  - name: build-container-additional-secret
-    value: build-container-additional-secret
-  - name: build-args
-    value:
-      - ENABLE_SENTRY=true
-      - SENTRY_RELEASE={{revision}}
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -90,10 +84,6 @@ spec:
     - default: Dockerfile
       description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
-      type: string
-    - default: build-container-additional-secret
-      description: Name of a Konflux-managed secret that will be mounted and made available to the container build process.
-      name: build-container-additional-secret
       type: string
     - default: 'false'
       description: Skip checks against built image
@@ -342,10 +332,12 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: ADDITIONAL_SECRET
-        value: $(params.build-container-additional-secret)
+        value: build-container-additional-secret
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - ENABLE_SENTRY=true
+        - SENTRY_RELEASE={{revision}}
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: BUILDAH_FORMAT


### PR DESCRIPTION
Chrome isnt uploading source maps because in the build step we dont pass in the vars to konflux. This allows the passing through of info.

- Pass build-container-additional-secret so the Konflux-managed secret (containing SENTRY_AUTH_TOKEN) is mounted during the image build
- Pass build-args with ENABLE_SENTRY=true and SENTRY_RELEASE={{revision}} so webpack’s Sentry plugin runs with the correct release tag
- Declare the secret param in the inline pipelineSpec and forward it to the buildah task as ADDITIONAL_SECRET

Chrome uses an inline pipelineSpec and not the docker-build-oci-ta file so it needs the ADDITIONAL_SECRET stuff 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline configuration with error tracking integration.
  * Added new build parameters to the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->