### PR TITLE
Add generic useOramaSearch hook for fuzzy search over arbitrary data

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -71,6 +71,7 @@ const plugins = (dev = false, beta = false, restricted = false) => {
         './SatelliteToken': resolve(__dirname, '../src/layouts/SatelliteToken.tsx'),
         './ModularInventory': resolve(__dirname, '../src/inventoryPoc/index.ts'),
         './search/useSearch': resolve(__dirname, '../src/hooks/useSearch.ts'),
+        './search/useOramaSearch': resolve(__dirname, '../src/hooks/useOramaSearch.ts'),
         './analytics/intercom/OpenShiftItercom': resolve(__dirname, '../src/components/OpenShiftIntercom/OpenShiftIntercomModule.tsx'),
         './analytics/intercom/useOpenShiftIntercomStore': resolve(__dirname, '../src/state/stores/openShiftIntercomStore.ts'),
         './theme/useDarkModeStore': resolve(__dirname, '../src/state/stores/darkModeStore.ts'),

--- a/cypress/component/GatewayErrors.cy.tsx
+++ b/cypress/component/GatewayErrors.cy.tsx
@@ -3,8 +3,8 @@ import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 
 import { removeScalprum } from '@scalprum/core';
-import type { AuthContextProps } from 'react-oidc-context';
 import { ChromeUser } from '@redhat-cloud-services/types';
+import type { IqeAuthRef } from '../../src/utils/iqeEnablement';
 import { Provider as JotaiProvider, createStore, useAtomValue } from 'jotai';
 import { AxiosError, AxiosResponse } from 'axios';
 
@@ -35,7 +35,7 @@ function createEnv(code: string, childNode: React.ReactNode) {
   chromeStore.set(activeModuleAtom, undefined);
   chromeStore.set(gatewayErrorAtom, undefined);
   // initializes request interceptors
-  qe.init(chromeStore, { current: { user: { access_token: 'foo' } } as unknown as AuthContextProps });
+  qe.init(chromeStore, { current: { user: { access_token: 'foo' } } as unknown as IqeAuthRef });
 
   const Component = () => {
     const [mounted, setMounted] = useState(false);

--- a/src/chrome/create-chrome.ts
+++ b/src/chrome/create-chrome.ts
@@ -168,7 +168,14 @@ export const createChromeContext = ({
       refreshToken: chromeAuth.refreshToken,
       qe: {
         ...qe,
-        init: () => qe.init(chromeStore, { current: { user: { access_token: chromeAuth.token } } as any }),
+        init: () =>
+          qe.init(chromeStore, {
+            current: {
+              user: { access_token: chromeAuth.token },
+              signinRedirect: () => chromeAuth.login(),
+              signinSilent: () => chromeAuth.loginSilent(),
+            },
+          }),
       },
       reAuthWithScopes: chromeAuth.reAuthWithScopes,
     } as any,

--- a/src/hooks/useOramaSearch.test.ts
+++ b/src/hooks/useOramaSearch.test.ts
@@ -1,0 +1,122 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useOramaSearch from './useOramaSearch';
+
+const schema = {
+  title: 'string' as const,
+  description: 'string' as const,
+  path: 'string' as const,
+};
+
+const testData = [
+  { title: 'Get Users', description: 'Retrieve a list of all users in the system', path: '/api/v1/users' },
+  { title: 'Create User', description: 'Create a new user account', path: '/api/v1/users' },
+  { title: 'Get Clusters', description: 'List all OpenShift clusters', path: '/api/v1/clusters' },
+  { title: 'Delete Subscription', description: 'Remove a subscription from the system', path: '/api/v1/subscriptions' },
+];
+
+describe('useOramaSearch', () => {
+  it('should return isReady false when no data is provided', () => {
+    const { result } = renderHook(() => useOramaSearch(undefined, schema));
+    expect(result.current.isReady).toBe(false);
+  });
+
+  it('should return isReady false for empty data', async () => {
+    const { result } = renderHook(() => useOramaSearch([], schema));
+    expect(result.current.isReady).toBe(false);
+  });
+
+  it('should become ready after data is provided', async () => {
+    const { result } = renderHook(() => useOramaSearch(testData, schema));
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+  });
+
+  it('should return matching results for a search term', async () => {
+    const { result } = renderHook(() => useOramaSearch(testData, schema));
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    let results: Awaited<ReturnType<typeof result.current.query>> = [];
+    await act(async () => {
+      results = await result.current.query('users');
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.document.title === 'Get Users')).toBe(true);
+  });
+
+  it('should return empty results for non-matching term', async () => {
+    const { result } = renderHook(() => useOramaSearch(testData, schema));
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    let results: Awaited<ReturnType<typeof result.current.query>> = [];
+    await act(async () => {
+      results = await result.current.query('xyznonexistent');
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should return empty results when not ready', async () => {
+    const { result } = renderHook(() => useOramaSearch(undefined, schema));
+
+    let results: Awaited<ReturnType<typeof result.current.query>> = [];
+    await act(async () => {
+      results = await result.current.query('users');
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should support fuzzy matching', async () => {
+    const { result } = renderHook(() => useOramaSearch(testData, schema));
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    let results: Awaited<ReturnType<typeof result.current.query>> = [];
+    await act(async () => {
+      results = await result.current.query('usrs');
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('should re-index when data changes', async () => {
+    const { result, rerender } = renderHook(({ data }) => useOramaSearch(data, schema), {
+      initialProps: { data: testData },
+    });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    const newData = [{ title: 'New Endpoint', description: 'A brand new endpoint', path: '/api/v2/new' }];
+    rerender({ data: newData });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    let results: Awaited<ReturnType<typeof result.current.query>> = [];
+    await act(async () => {
+      results = await result.current.query('brand new');
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].document.title).toBe('New Endpoint');
+  });
+
+  it('should respect custom search options', async () => {
+    const { result } = renderHook(() => useOramaSearch(testData, schema));
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    let results: Awaited<ReturnType<typeof result.current.query>> = [];
+    await act(async () => {
+      results = await result.current.query('users', { limit: 1, properties: ['title'] });
+    });
+
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it('should handle indexing errors gracefully', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const badSchema = { title: 'number' as const };
+    const badData = [{ title: 'not a number' }];
+    const { result } = renderHook(() => useOramaSearch(badData as any, badSchema));
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(result.current.query).toBeDefined();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/hooks/useOramaSearch.ts
+++ b/src/hooks/useOramaSearch.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Orama, Results, create, insert, search } from '@orama/orama';
+
+type OramaSchemaDefinition = Record<string, 'string' | 'string[]' | 'number' | 'boolean'>;
+
+export type OramaSearchResult<T> = {
+  id: string;
+  score: number;
+  document: T;
+};
+
+export interface UseOramaSearchOptions {
+  threshold?: number;
+  tolerance?: number;
+  limit?: number;
+  properties?: string[];
+  boost?: Record<string, number>;
+}
+
+export interface UseOramaSearchResult<T> {
+  query: (term: string, options?: UseOramaSearchOptions) => Promise<OramaSearchResult<T>[]>;
+  isReady: boolean;
+}
+
+function useOramaSearch<T extends Record<string, unknown>>(data: T[] | undefined, schema: OramaSchemaDefinition): UseOramaSearchResult<T> {
+  const dbRef = useRef<Orama<typeof schema> | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const schemaKey = JSON.stringify(schema);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const buildIndex = async () => {
+      dbRef.current = null;
+      setIsReady(false);
+
+      if (!data || data.length === 0) {
+        return;
+      }
+
+      try {
+        const db = create({ schema });
+        const insertions = data.map((entry) => insert(db, entry as never));
+        await Promise.all(insertions);
+
+        if (!cancelled) {
+          dbRef.current = db;
+          setIsReady(true);
+        }
+      } catch (error) {
+        console.warn('Failed to build Orama search index:', error);
+      }
+    };
+
+    buildIndex();
+    return () => {
+      cancelled = true;
+    };
+  }, [data, schemaKey]);
+
+  const query = useCallback(async (term: string, options?: UseOramaSearchOptions): Promise<OramaSearchResult<T>[]> => {
+    if (!dbRef.current) {
+      return [];
+    }
+
+    const results: Results<T> = await search(dbRef.current, {
+      term,
+      threshold: options?.threshold ?? 0.5,
+      tolerance: options?.tolerance ?? 1.5,
+      limit: options?.limit ?? 10,
+      ...(options?.properties ? { properties: options.properties } : {}),
+      ...(options?.boost ? { boost: options.boost } : {}),
+    });
+
+    return results.hits.map((hit) => ({
+      id: String(hit.id),
+      score: hit.score,
+      document: hit.document as T,
+    }));
+  }, []);
+
+  return { query, isReady };
+}
+
+export default useOramaSearch;

--- a/src/utils/iqeEnablement.ts
+++ b/src/utils/iqeEnablement.ts
@@ -3,9 +3,13 @@
 import { get3scaleError } from './responseInterceptors';
 import crossAccountBouncer from '../auth/crossAccountBouncer';
 import { createStore } from 'jotai';
-// eslint-disable-next-line no-restricted-imports
-import type { AuthContextProps } from 'react-oidc-context';
 import { gatewayErrorAtom } from '../state/atoms/gatewayErrorAtom';
+
+export interface IqeAuthRef {
+  user?: { access_token?: string } | null;
+  signinRedirect: (...args: never[]) => Promise<void>;
+  signinSilent: (...args: never[]) => Promise<unknown>;
+}
 // TODO: Refactor this file to use modern JS
 
 let xhrResults: XMLHttpRequest[] = [];
@@ -83,7 +87,7 @@ const spreadAdditionalHeaders = (options: RequestInit | undefined) => {
   return additionalHeaders;
 };
 
-export function init(chromeStore: ReturnType<typeof createStore>, authRef: React.MutableRefObject<AuthContextProps>) {
+export function init(chromeStore: ReturnType<typeof createStore>, authRef: React.MutableRefObject<IqeAuthRef>) {
   const open = window.XMLHttpRequest.prototype.open;
   const send = window.XMLHttpRequest.prototype.send;
   const setRequestHeader = window.XMLHttpRequest.prototype.setRequestHeader;


### PR DESCRIPTION
### Description

[RHCLOUD-47884](https://issues.redhat.com/browse/RHCLOUD-47884)

Adds a generic `useOramaSearch` React hook that creates an Orama full-text search index from any data array. The hook accepts data and a schema definition, manages its own Orama DB instance, and re-indexes automatically when data changes. It returns a `query` function for fuzzy search with configurable threshold, tolerance, boosting, and result limits.

The hook is exposed via Module Federation (`./search/useOramaSearch`) so consuming apps (e.g. learning-resources HelpPanel) can use it for fuzzy search over API documentation or other datasets.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure

Assisted by: Claude Code


[RHCLOUD-47884]: https://redhat.atlassian.net/browse/RHCLOUD-47884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `useOramaSearch` hook for ranked, fuzzy search over provided data, with readiness handling, per-query limits, and optional field targeting.
* **Configuration**
  * Exposed the search hook via module federation for external consumption.
* **Tests**
  * Added a test suite covering readiness states, empty/non-matching queries, fuzzy matching, re-indexing on data changes, and query option pass-through.
* **Chores**
  * Updated authentication enablement typings and adjusted initialization to provide redirect and silent sign-in handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->