### PR TITLE
fix: disable breadcrumbs for dashboard-hub routes

### DIFF
--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -79,7 +79,9 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
   const isHelpPanelEnabled = useFlag('platform.chrome.help-panel');
   const isDrawerEnabled = isNotificationsEnabled || isHelpPanelEnabled;
   const { pathname } = useLocation();
-  const noBreadcrumb = !['/', '/allservices', '/favoritedservices', '/learning-resources'].includes(pathname);
+  const isDashboardHubRoute = /^\/dashboard-hub(?:\/|$)/.test(pathname);
+  const noBreadcrumb = !['/', '/allservices', '/favoritedservices', '/learning-resources'].includes(pathname) && !isDashboardHubRoute;
+
   return (
     <Page
       className={


### PR DESCRIPTION
### Description
Hide breadcrumbs on `/dashboard-hub` pages. The dashboard hub has its own layout, so Chrome breadcrumbs are not applicable.

 Uses a regex `/^\/dashboard-hub(?:\/|$)/` to match `/dashboard-hub` exactly and its sub-routes (e.g. /dashboard-hub/:id), without false-matching routes like /dashboard-hubble.

Related to [RHCLOUD48316](https://redhat.atlassian.net/browse/RHCLOUD-48316) and https://github.com/RedHatInsights/widget-layout/pull/345

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs are now hidden on dashboard hub pages, including URLs with an optional trailing slash, while keeping the existing breadcrumb behavior for the home page and other selected sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->