### PR TITLE
fix(docs): Fix broken link in GlobalFilter Popover

### DIFF
--- a/src/components/GlobalFilter/GroupFilterInputGroup.tsx
+++ b/src/components/GlobalFilter/GroupFilterInputGroup.tsx
@@ -80,7 +80,7 @@ const GroupFilterInputGroup: React.FunctionComponent<GroupFilterInputGroupProps>
             <div>
               {intl.formatMessage(messages.filterByTagsPopoverContent1)}{' '}
               <a
-                href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/proc-installing-satellite-inventory-upload-plugin_assembly-setting-up-subscriptionwatch-ctxt"
+                href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html-single/getting_started_with_the_subscriptions_service/index#proc-installing-satellite-inventory-upload-plugin_assembly-about-subscriptionwatch"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
### Description
GlobalFilter's popover currently points to invalid documentation link within this sentence:
_If connected to a Satellite, tags from that Satellite can be imported._

GlobalFilter is present all over Lightspeed UI, but one example for reproducing is to visit https://console.redhat.com/insights/vulnerability/cves and open **?**-popover next to the filter, and then clicking on the "_imported_" hyperlink.
<img width="552" height="410" alt="Screenshot From 2026-06-25 19-38-29" src="https://github.com/user-attachments/assets/09fb35f4-6cb0-4b2f-9201-96096f7ecdd5" />

[RHINENG-22291](https://redhat.atlassian.net/browse/RHINENG-22291)

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHINENG-22291]: https://redhat.atlassian.net/browse/RHINENG-22291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the help Popover’s satellite-inventory documentation link to direct users to the latest page URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->