### PR TITLE
feat(routes): add new route for content-sources-frontend for authed experience

### DIFF
--- a/src/components/RootApp/ScalprumRoot.test.js
+++ b/src/components/RootApp/ScalprumRoot.test.js
@@ -299,6 +299,30 @@ describe('ScalprumRoot', () => {
     jsdomReset();
   });
 
+  it('should render /lightwell route without PageSidebar', async () => {
+    const useLocationSpy = jest.spyOn(routerDom, 'useLocation');
+    useLocationSpy.mockReturnValue({ pathname: '/lightwell', search: undefined, hash: undefined });
+
+    const { container } = await render(
+      <JotaiTestProvider initialValues={defaultAtomValues}>
+        <ChromeAuthContext.Provider value={chromeContextMockValue}>
+          <MemoryRouter initialEntries={['/lightwell']}>
+            <ScalprumRoot config={config} {...initialProps} />
+          </MemoryRouter>
+        </ChromeAuthContext.Provider>
+      </JotaiTestProvider>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('#chrome-app-render-root')).toBeTruthy();
+      expect(container.querySelector('.chr-c-masthead')).toBeTruthy();
+      expect(container.querySelector('.chr-render')).toBeTruthy();
+      expect(container.querySelector('#chr-c-sidebar')).toBeFalsy();
+    });
+
+    useLocationSpy.mockRestore();
+  });
+
   it('should not render GlobalFilter', async () => {
     const fetchSpy = jest.spyOn(window, 'fetch').mockImplementationOnce(() => Promise.resolve({ ok: true, json: () => ({}) }));
     const useLocationSpy = jest.spyOn(routerDom, 'useLocation');

--- a/src/components/RootApp/ScalprumRoot.test.js
+++ b/src/components/RootApp/ScalprumRoot.test.js
@@ -6,6 +6,17 @@ import { Provider as JotaiProvider } from 'jotai';
 
 jest.mock('../Footer/Footer', () => () => null);
 
+jest.mock('../../layouts/Lightwell', () => {
+  const Lightwell = ({ Footer }) => (
+    <div id="chrome-app-render-root">
+      <div className="chr-c-masthead" />
+      <div data-testid="lightwell-content" />
+      {Footer}
+    </div>
+  );
+  return { __esModule: true, default: Lightwell };
+});
+
 jest.mock('../Search/SearchInput', () => {
   return jest.fn().mockImplementation(() => <div />);
 });
@@ -316,7 +327,6 @@ describe('ScalprumRoot', () => {
     await waitFor(() => {
       expect(container.querySelector('#chrome-app-render-root')).toBeTruthy();
       expect(container.querySelector('.chr-c-masthead')).toBeTruthy();
-      expect(container.querySelector('.chr-render')).toBeTruthy();
       expect(container.querySelector('#chr-c-sidebar')).toBeFalsy();
     });
 

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -42,6 +42,8 @@ import useAmplitude from '../../analytics/useAmplitude';
 import usePf5Styles from '../../hooks/usePf5Styles';
 
 const ProductSelection = lazyWithRetry(() => import('../Stratosphere/ProductSelection'));
+// TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach.
+const Lightwell = lazyWithRetry(() => import('../../layouts/Lightwell'));
 
 const useGlobalFilter = (callback: (selectedTags?: FlagTagsFilter) => any) => {
   const selectedTags = useAtomValue(selectedTagsAtom);
@@ -88,7 +90,14 @@ const ScalprumRoot = memo(
           )}
           <Route path="/security" element={<DefaultLayout />} />
           {/* TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach. */}
-          <Route path="/lightwell" element={<DefaultLayout />} />
+          <Route
+            path="/lightwell"
+            element={
+              <Suspense fallback={LoadingFallback}>
+                <Lightwell Footer={<ChromeFooter />} />
+              </Suspense>
+            }
+          />
           <Route path="*" element={<DefaultLayout Sidebar={Navigation} />} />
         </Routes>
       </ChromeProvider>

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -87,6 +87,8 @@ const ScalprumRoot = memo(
             />
           )}
           <Route path="/security" element={<DefaultLayout />} />
+          {/* TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach. */}
+          <Route path="/lightwell" element={<DefaultLayout />} />
           <Route path="*" element={<DefaultLayout Sidebar={Navigation} />} />
         </Routes>
       </ChromeProvider>

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -93,6 +93,8 @@ const ChromeRoutes = ({ routesProps }: RoutesProps) => {
         }
         return <Route key={path} path={path} element={<Navigate replace to={to} />} />;
       })}
+      {/* TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach. */}
+      <Route path="/lightwell" element={<ChromeRoute scope="contentSources" module="./LightwellApp" path="/lightwell" {...routesProps} />} />
       {moduleRoutes.map((app) => (
         <Route key={app.path} path={app.absolute ? app.path : `${app.path}/*`} element={<ChromeRoute {...routesProps} {...app} />} />
       ))}

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -93,8 +93,6 @@ const ChromeRoutes = ({ routesProps }: RoutesProps) => {
         }
         return <Route key={path} path={path} element={<Navigate replace to={to} />} />;
       })}
-      {/* TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach. */}
-      <Route path="/lightwell" element={<ChromeRoute scope="contentSources" module="./LightwellApp" path="/lightwell" {...routesProps} />} />
       {moduleRoutes.map((app) => (
         <Route key={app.path} path={app.absolute ? app.path : `${app.path}/*`} element={<ChromeRoute {...routesProps} {...app} />} />
       ))}

--- a/src/layouts/Lightwell.test.tsx
+++ b/src/layouts/Lightwell.test.tsx
@@ -1,0 +1,137 @@
+jest.mock('../components/Header/Header', () => ({
+  Header: () => <div data-testid="mock-header">Header</div>,
+}));
+
+jest.mock('../components/Stratosphere/RedirectBanner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-redirect-banner">RedirectBanner</div>,
+}));
+
+jest.mock('../components/ErrorComponents/DefaultErrorComponent', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-error-component" />,
+}));
+
+jest.unmock('../components/NotificationsDrawer/DrawerPanelContent');
+
+// jest.mock does not intercept @scalprum/* in this project's SWC/Jest setup,
+// so we initialize scalprum with a stub config instead.
+import { initialize } from '@scalprum/core';
+
+const mockUseFlag = jest.fn<(flagName: string) => boolean>();
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: (flagName: string) => mockUseFlag(flagName),
+}));
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider, createStore } from 'jotai';
+import Lightwell from './Lightwell';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { notificationDrawerExpandedAtom } from '../state/atoms/notificationDrawerAtom';
+import ChromeAuthContext from '../auth/ChromeAuthContext';
+import InternalChromeContext from '../utils/internalChromeContext';
+
+const mockUser = {
+  identity: {
+    account_number: '123456',
+    org_id: 'org123',
+    user: {
+      username: 'testuser',
+      email: 'test@redhat.com',
+      first_name: 'Test',
+      last_name: 'User',
+      is_org_admin: false,
+      is_internal: false,
+    },
+  },
+};
+
+const mockAuthContextValue = {
+  user: mockUser,
+  token: 'test-token',
+  ready: true,
+  login: jest.fn(),
+  logout: jest.fn(),
+  getUser: jest.fn<() => Promise<typeof mockUser>>().mockResolvedValue(mockUser),
+  getToken: jest.fn<() => Promise<string>>().mockResolvedValue('test-token'),
+};
+
+const mockInternalChromeContextValue = {
+  drawerActions: {
+    toggleDrawerContent: jest.fn(),
+  },
+};
+
+const renderLightwell = (flagOverrides: Record<string, boolean> = {}) => {
+  const defaultFlags: Record<string, boolean> = {
+    'platform.chrome.notifications-drawer': false,
+    'platform.chrome.help-panel': false,
+  };
+
+  const flags = { ...defaultFlags, ...flagOverrides };
+  mockUseFlag.mockImplementation((name: string) => flags[name] ?? false);
+
+  const store = createStore();
+
+  return {
+    store,
+    ...render(
+      <MemoryRouter>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+        <ChromeAuthContext.Provider value={mockAuthContextValue as any}>
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+          <InternalChromeContext.Provider value={mockInternalChromeContextValue as any}>
+            <Provider store={store}>
+              <Lightwell Footer={<div data-testid="mock-footer" />} />
+            </Provider>
+          </InternalChromeContext.Provider>
+        </ChromeAuthContext.Provider>
+      </MemoryRouter>
+    ),
+  };
+};
+
+describe('Lightwell', () => {
+  beforeAll(() => {
+    initialize({
+      appsConfig: {
+        contentSources: {
+          name: 'contentSources',
+          manifestLocation: '/test/manifest.json',
+        },
+      },
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the layout shell', () => {
+    const { container } = renderLightwell();
+    expect(container.querySelector('#chrome-app-render-root')).toBeTruthy();
+    expect(container.querySelector('.chr-c-masthead')).toBeTruthy();
+    expect(container.querySelector('[data-testid="mock-footer"]')).toBeTruthy();
+  });
+
+  it('should not render sidebar navigation', () => {
+    const { container } = renderLightwell();
+    expect(container.querySelector('#chr-c-sidebar')).toBeFalsy();
+  });
+
+  it('should render when drawer flags are enabled', () => {
+    const { container } = renderLightwell({
+      'platform.chrome.notifications-drawer': true,
+      'platform.chrome.help-panel': true,
+    });
+    expect(container.querySelector('#chrome-app-render-root')).toBeTruthy();
+  });
+
+  it('should initialize with drawer collapsed', () => {
+    const { store } = renderLightwell({
+      'platform.chrome.help-panel': true,
+    });
+    expect(store.get(notificationDrawerExpandedAtom)).toBe(false);
+  });
+});

--- a/src/layouts/Lightwell.tsx
+++ b/src/layouts/Lightwell.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef } from 'react';
+import { ScalprumComponent } from '@scalprum/react-core';
+import { Masthead } from '@patternfly/react-core/dist/dynamic/components/Masthead';
+import { Page } from '@patternfly/react-core/dist/dynamic/components/Page';
+import { useAtom } from 'jotai';
+import { useFlag } from '@unleash/proxy-client-react';
+import { Header } from '../components/Header/Header';
+import RedirectBanner from '../components/Stratosphere/RedirectBanner';
+import LoadingFallback from '../utils/loading-fallback';
+import ErrorComponent from '../components/ErrorComponents/DefaultErrorComponent';
+import { notificationDrawerExpandedAtom } from '../state/atoms/notificationDrawerAtom';
+import DrawerPanel from '../components/NotificationsDrawer/DrawerPanelContent';
+
+export type LightwellProps = {
+  Footer?: React.ReactNode;
+};
+
+// TODO: Temporary layout for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach.
+const Lightwell = ({ Footer }: LightwellProps) => {
+  const drawerPanelRef = useRef<HTMLDivElement>(null);
+  const [isNotificationsDrawerExpanded, setIsNotificationsDrawerExpanded] = useAtom(notificationDrawerExpandedAtom);
+
+  const isNotificationsEnabled = useFlag('platform.chrome.notifications-drawer');
+  const isHelpPanelEnabled = useFlag('platform.chrome.help-panel');
+  const isDrawerEnabled = isNotificationsEnabled || isHelpPanelEnabled;
+
+  const focusDrawer = () => {
+    if (drawerPanelRef.current === null) {
+      return;
+    }
+    const tabbableElement = drawerPanelRef.current?.querySelector('[aria-label="Close"], a, button') as HTMLAnchorElement | HTMLButtonElement;
+    if (tabbableElement) {
+      tabbableElement.focus();
+    }
+  };
+
+  const toggleDrawer = () => {
+    setIsNotificationsDrawerExpanded((prev) => !prev);
+  };
+
+  useEffect(() => {
+    if (isNotificationsDrawerExpanded && drawerPanelRef.current !== null) {
+      focusDrawer();
+    }
+  }, [isNotificationsDrawerExpanded]);
+
+  return (
+    <div id="chrome-app-render-root">
+      <Page
+        onPageResize={null}
+        masthead={
+          <Masthead className="chr-c-masthead" display={{ sm: 'stack', '2xl': 'inline' }}>
+            <Header breadcrumbsProps={{ hideNav: true }} />
+          </Masthead>
+        }
+        {...(isDrawerEnabled && {
+          onNotificationDrawerExpand: focusDrawer,
+          notificationDrawer: <DrawerPanel ref={drawerPanelRef} toggleDrawer={toggleDrawer} />,
+          isNotificationDrawerExpanded: isNotificationsDrawerExpanded,
+        })}
+      >
+        <RedirectBanner />
+        <ScalprumComponent
+          scope="contentSources"
+          module="./LightwellApp"
+          appId="contentSources"
+          ErrorComponent={<ErrorComponent />}
+          fallback={LoadingFallback}
+        />
+        {Footer}
+      </Page>
+    </div>
+  );
+};
+
+export default Lightwell;


### PR DESCRIPTION
##  Description

  Adds a hardcoded route at `/lightwell` that renders a `ScalprumComponent` for the new federated module exposed by `content-sources-frontend`. This provides the entry point for the new authed UI experience within the Hybrid Cloud Console. The route uses a new thin Lightwell layout matching the All Services page shell — standard header/masthead, no left nav, no breadcrumbs, no global filter.

  Companion PR adding the exposed module: content-sources-frontend#1059 (https://github.com/content-services/content-sources-frontend/pull/1059/changes)

  Resolves RHCLOUD-48921 (https://issues.redhat.com/browse/RHCLOUD-48921)

 ##  Screenshots

  N/A — the federated module content is not yet available in this environment. The route renders the standard Chrome layout shell with a ScalprumComponent that will load contentSources#./LightwellApp once the companion PR is deployed.

 ##  Anything reviewers should know?

  - This is intentionally a short-term solution. Per RHCLOUD-48921, this must be revisited later to discuss longer-term plans and reduce tech debt.
  - A new Lightwell layout (src/layouts/Lightwell.tsx) was created to match the AllServices page shell (Page + Masthead/Header with hideNav: true, notification drawer, RedirectBanner). DefaultLayout was not reusable here because it includes breadcrumbs, GlobalFilter, and VirtualAssistant which are not wanted.
  - The contentSources scope is already registered in the scalprum config via the chrome service manifest, so no config changes were needed.

 ##  Checklist

  - [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] (Optional) QE: OUIA changed, test impact, no coverage
  - [ ] (Optional) UX: end-user UX modified, designs need sign-off

 ##  AI disclosure
  
  Assisted by: Claude Code