### PR TITLE
feat(routing): update routing and footer for new appp

### DIFF
--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -91,10 +91,10 @@ const ScalprumRoot = memo(
           <Route path="/security" element={<DefaultLayout />} />
           {/* TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach. */}
           <Route
-            path="/lightwell"
+            path="/lightwell/*"
             element={
               <Suspense fallback={LoadingFallback}>
-                <Lightwell Footer={<ChromeFooter />} />
+                <Lightwell />
               </Suspense>
             }
           />


### PR DESCRIPTION
### Description

Fix nested route matching for `/lightwell` and remove footer from lightwell pages.

The `/lightwell` route was defined as an exact path match, so navigating to any subroute (e.g., `/lightwell/foo`) fell through to the `*` catch-all, rendering `DefaultLayout` instead of the Lightwell layout — resulting in a 404. Changed to `/lightwell/*` so React Router matches all nested paths and the `contentSources` federated module can handle its own sub-routing. Also removed the `Footer` prop from the Lightwell route.

---

### Screenshots

N/A — no visual UI changes beyond removing the footer on lightwell pages.

---

### Anything reviewers should know?

This mirrors how other routes like `*` (DefaultLayout) handle nested paths. The `contentSources` ScalprumComponent inside `Lightwell` manages its own routing, so it needs the wildcard to receive sub-paths.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure

Assisted by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Lightwell page routing so nested page paths load correctly.
  * Updated page loading behavior to display a fallback while content is being prepared, resulting in a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->