### PR TITLE
feat(lightwell): add navigation to global navigation for project lightwell

### DIFF
--- a/src/components/AllServicesDropdown/PlatformServicesLinks.tsx
+++ b/src/components/AllServicesDropdown/PlatformServicesLinks.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import ChromeLink from '../ChromeLink';
 import { Split, SplitItem } from '@patternfly/react-core/dist/dynamic/layouts/Split';
 
 import AnsibleIcon from '../AllServicesDropdown/icon-ansible';
 import OpenShiftIcon from '../AllServicesDropdown/icon-openshift';
 import RhelIcon from '../AllServicesDropdown/icon-rhel';
+import LightWell from '../AllServicesDropdown/icon-lightwell';
 import { useFlag } from '@unleash/proxy-client-react';
 
 const PlatformServiceslinks = () => {
@@ -13,16 +14,28 @@ const PlatformServiceslinks = () => {
   return (
     <>
       {isITLess ? null : (
-        <Split className="pf-v6-u-px-lg pf-v6-u-mb-0">
-          <SplitItem>
-            <AnsibleIcon />
-          </SplitItem>
-          <SplitItem className="pf-v6-u-pt-xs">
-            <ChromeLink href="/ansible" data-ouia-component-id="AllServices-Dropdown-Ansible" className="pf-v6-u-pl-sm chr-m-plain">
-              Red Hat Ansible Automation Platform
-            </ChromeLink>
-          </SplitItem>
-        </Split>
+        <Fragment>
+          <Split className="pf-v6-u-px-lg pf-v6-u-mb-0">
+            <SplitItem>
+              <LightWell />
+            </SplitItem>
+            <SplitItem className="pf-v6-u-pt-xs">
+              <ChromeLink href="/lightwell" data-ouia-component-id="AllServices-Dropdown-Lightwell" className="pf-v6-u-pl-sm chr-m-plain">
+                Project Lightwell
+              </ChromeLink>
+            </SplitItem>
+          </Split>
+          <Split className="pf-v6-u-px-lg pf-v6-u-mb-0">
+            <SplitItem>
+              <AnsibleIcon />
+            </SplitItem>
+            <SplitItem className="pf-v6-u-pt-xs">
+              <ChromeLink href="/ansible" data-ouia-component-id="AllServices-Dropdown-Ansible" className="pf-v6-u-pl-sm chr-m-plain">
+                Red Hat Ansible Automation Platform
+              </ChromeLink>
+            </SplitItem>
+          </Split>
+        </Fragment>
       )}
       <Split className="pf-v6-u-pl-lg pf-v6-u-mb-0">
         <SplitItem>

--- a/src/components/AllServicesDropdown/icon-lightwell.tsx
+++ b/src/components/AllServicesDropdown/icon-lightwell.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const ContainerSecurityIcon = () => {
+  return (
+    <svg className="platform-icon allservices-icon" width="28" height="28" viewBox="0 0 38 38">
+      <rect x="1" y="1" width="36" height="36" rx="9" fill="#000" stroke="#4D4D4D" strokeWidth="2" />
+      <g transform="translate(6, 5)">
+        {/* Shield */}
+        <path d="M13,3 L5,6 L5,14 C5,19.5 8.5,24 13,25.5 C17.5,24 21,19.5 21,14 L21,6 Z" fill="#1A1A1A" stroke="#666" strokeWidth="1" />
+        {/* Checkmark circle */}
+        <circle cx="12" cy="17" r="3" fill="#FFF" />
+        <path d="M10.5,17 L11.5,18 L13.5,16" stroke="#000" strokeWidth="1.2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        {/* Container hexagons */}
+        <path d="M20,8 L23,6.5 L26,8 L26,11 L23,12.5 L20,11 Z" fill="#EE0000" stroke="#EE0000" strokeWidth="0.5" />
+        <path d="M22,14 L25,12.5 L28,14 L28,17 L25,18.5 L22,17 Z" fill="#EE0000" stroke="#EE0000" strokeWidth="0.5" />
+        <path d="M20,20 L23,18.5 L26,20 L26,23 L23,24.5 L20,23 Z" fill="#EE0000" stroke="#EE0000" strokeWidth="0.5" />
+      </g>
+    </svg>
+  );
+};
+export default ContainerSecurityIcon as unknown as React.ComponentClass;


### PR DESCRIPTION
### Description

Add a new `ContainerSecurityIcon` SVG component for use in the AllServicesDropdown, matching the existing icon pattern (28x28 inline SVG with rounded rectangle background). The icon depicts a shield with a checkmark and three red hexagonal containers, based on the [Red Hat container security visual](https://www.redhat.com/rhdc/managed-files/container-security.webp).

---

### Screenshots

#### After:


https://github.com/user-attachments/assets/448903bf-aa72-440b-aa9f-3fbbe28bd4da



---

### Anything reviewers should know?

The original source image was a complex raster-traced SVG (430KB, 715 paths). Instead of using that, the icon was hand-crafted as a clean vector SVG (~1KB) to match the style and weight of the other inline icon components in the dropdown.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure

Assisted by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Project Lightwell” entry to the services dropdown.
  * Introduced a new icon for the Lightwell service so it displays consistently with other items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->