### PR TITLE
Use template with hidden navigation for /lightwell route

### DIFF
--- a/src/components/AppPlaceholder/index.tsx
+++ b/src/components/AppPlaceholder/index.tsx
@@ -12,7 +12,7 @@ import LoadingFallback from '../../utils/loading-fallback';
 
 // Component that is displayed as a placeholder before auth init is finished
 const AppPlaceholder = () => {
-  const hideNavLoader = [undefined, '', 'landing', 'allservices', 'favoritedservices', 'learning-resources'].includes(getUrl('bundle'));
+  const hideNavLoader = [undefined, '', 'landing', 'allservices', 'favoritedservices', 'learning-resources', 'lightwell'].includes(getUrl('bundle'));
   return (
     <MemoryRouter>
       <Page


### PR DESCRIPTION
This route does not have menu so use the adequate template.
This limits the amount of flickering there is.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior so the navigation loader hides in more scenarios, including when the app opens in the lightwell bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->