### PR TITLE
Do not pre-render footer if not shown in the final page

### DIFF
--- a/src/components/AppPlaceholder/index.tsx
+++ b/src/components/AppPlaceholder/index.tsx
@@ -13,6 +13,8 @@ import LoadingFallback from '../../utils/loading-fallback';
 // Component that is displayed as a placeholder before auth init is finished
 const AppPlaceholder = () => {
   const hideNavLoader = [undefined, '', 'landing', 'allservices', 'favoritedservices', 'learning-resources', 'lightwell'].includes(getUrl('bundle'));
+  const hideFooter = ['lightwell'].includes(getUrl('bundle'));
+
   return (
     <MemoryRouter>
       <Page
@@ -40,7 +42,7 @@ const AppPlaceholder = () => {
       >
         <div className="chr-render">
           {LoadingFallback}
-          <ChromeFooter />
+          {!hideFooter && <ChromeFooter />}
         </div>
       </Page>
     </MemoryRouter>


### PR DESCRIPTION
### Description
/lightwell route does not show footer. Without this changes footer flashes before the Lightwell app is loaded.

Possibly there are other apps where this is the case?

---

### Screenshots


#### Before:

https://github.com/user-attachments/assets/b6d10199-780c-4859-ba54-0702158ccfcd


#### After:

https://github.com/user-attachments/assets/1017e5b6-4475-4a65-881b-25c7f42f4e3f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The footer now stays hidden for the Lightwell bundle, matching the intended page layout.
  * Existing navigation loader and sidebar behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->