### PR TITLE
fix(lightwell): eliminate theme and banner flicker on /lightwell routes (RHCLOUD-49049)

### DIFF
--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -40,9 +40,7 @@ import useDPAL from '../../analytics/useDpal';
 import { selectedTagsAtom } from '../../state/atoms/globalFilterAtom';
 import useAmplitude from '../../analytics/useAmplitude';
 import usePf5Styles from '../../hooks/usePf5Styles';
-
 const ProductSelection = lazyWithRetry(() => import('../Stratosphere/ProductSelection'));
-// TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach.
 const Lightwell = lazyWithRetry(() => import('../../layouts/Lightwell'));
 
 const useGlobalFilter = (callback: (selectedTags?: FlagTagsFilter) => any) => {

--- a/src/hooks/useLightwellRouteSetup.ts
+++ b/src/hooks/useLightwellRouteSetup.ts
@@ -1,0 +1,44 @@
+import { useLayoutEffect } from 'react';
+import { useSetAtom } from 'jotai';
+import { layoutForceGlassThemeAtom } from '../state/atoms/releaseAtom';
+import { LIGHTWELL_PATH } from '../utils/common';
+
+const FELT_THEME_CLASS = 'pf-v6-theme-felt';
+const GLASS_THEME_CLASS = 'pf-v6-theme-glass';
+
+const isLightwellRoute = window.location.pathname === LIGHTWELL_PATH || window.location.pathname.startsWith(`${LIGHTWELL_PATH}/`);
+
+if (isLightwellRoute) {
+  document.documentElement.classList.add(FELT_THEME_CLASS, GLASS_THEME_CLASS);
+}
+
+type UseLightwellRouteSetupOptions = {
+  enabled?: boolean;
+};
+
+/**
+ * Applies Lightwell felt + glass themes synchronously before paint.
+ * Also forces glass via layoutForceGlassThemeAtom for Header toolbar state.
+ *
+ * Theme classes are also applied eagerly at module-eval time (above) so they
+ * survive the AppPlaceholder → Lightwell component transition without a gap.
+ */
+const useLightwellRouteSetup = ({ enabled = true }: UseLightwellRouteSetupOptions = {}) => {
+  const setLayoutForceGlassTheme = useSetAtom(layoutForceGlassThemeAtom);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    document.documentElement.classList.add(FELT_THEME_CLASS, GLASS_THEME_CLASS);
+    setLayoutForceGlassTheme(true);
+
+    return () => {
+      document.documentElement.classList.remove(FELT_THEME_CLASS, GLASS_THEME_CLASS);
+      setLayoutForceGlassTheme(false);
+    };
+  }, [enabled, setLayoutForceGlassTheme]);
+};
+
+export default useLightwellRouteSetup;

--- a/src/layouts/Lightwell.test.tsx
+++ b/src/layouts/Lightwell.test.tsx
@@ -110,7 +110,7 @@ describe('Lightwell', () => {
   });
 
   afterEach(() => {
-    document.documentElement.classList.remove('pf-v6-theme-felt');
+    document.documentElement.classList.remove('pf-v6-theme-felt', 'pf-v6-theme-glass');
   });
 
   it('should render the layout shell', () => {

--- a/src/layouts/Lightwell.tsx
+++ b/src/layouts/Lightwell.tsx
@@ -9,9 +9,9 @@ import RedirectBanner from '../components/Stratosphere/RedirectBanner';
 import LoadingFallback from '../utils/loading-fallback';
 import ErrorComponent from '../components/ErrorComponents/DefaultErrorComponent';
 import { notificationDrawerExpandedAtom } from '../state/atoms/notificationDrawerAtom';
-import { layoutBannerHiddenAtom, layoutForceGlassThemeAtom, layoutLightwellHeaderAtom } from '../state/atoms/releaseAtom';
+import { layoutBannerHiddenAtom, layoutLightwellHeaderAtom } from '../state/atoms/releaseAtom';
 import DrawerPanel from '../components/NotificationsDrawer/DrawerPanelContent';
-import useFeltTheme from '../hooks/useFeltTheme';
+import useLightwellRouteSetup from '../hooks/useLightwellRouteSetup';
 
 export type LightwellProps = {
   Footer?: React.ReactNode;
@@ -19,25 +19,20 @@ export type LightwellProps = {
 
 // TODO: Temporary layout for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach.
 const Lightwell = ({ Footer }: LightwellProps) => {
-  useFeltTheme();
+  useLightwellRouteSetup();
   const drawerPanelRef = useRef<HTMLDivElement>(null);
   const [isNotificationsDrawerExpanded, setIsNotificationsDrawerExpanded] = useAtom(notificationDrawerExpandedAtom);
   const setLayoutBannerHidden = useSetAtom(layoutBannerHiddenAtom);
-  const setLayoutForceGlassTheme = useSetAtom(layoutForceGlassThemeAtom);
   const setLayoutLightwellHeader = useSetAtom(layoutLightwellHeaderAtom);
 
-  // Hide the BetaSwitcher banner directly from this layout
-  // useLayoutEffect prevents a brief flash of the banner before the atom updates
   useLayoutEffect(() => {
     setLayoutBannerHidden(true);
-    setLayoutForceGlassTheme(true);
     setLayoutLightwellHeader(true);
     return () => {
       setLayoutBannerHidden(false);
-      setLayoutForceGlassTheme(false);
       setLayoutLightwellHeader(false);
     };
-  }, [setLayoutBannerHidden, setLayoutForceGlassTheme, setLayoutLightwellHeader]);
+  }, [setLayoutBannerHidden, setLayoutLightwellHeader]);
 
   const isNotificationsEnabled = useFlag('platform.chrome.notifications-drawer');
   const isHelpPanelEnabled = useFlag('platform.chrome.help-panel');

--- a/src/state/atoms/releaseAtom.ts
+++ b/src/state/atoms/releaseAtom.ts
@@ -6,6 +6,9 @@ import { SearchPermissionsCache } from './localSearchAtom';
 import { atom } from 'jotai';
 import { userConfigAtom } from './userConfigAtom';
 import { ChromeUserConfig } from '../../utils/initUserConfig';
+import { LIGHTWELL_PATH } from '../../utils/common';
+
+const isLightwellPath = window.location.pathname.startsWith(LIGHTWELL_PATH);
 
 export const previewModalOpenAtom = atomWithToggle(false);
 
@@ -58,16 +61,17 @@ export const hidePreviewBannerAtom = atomWithToggle(initialHidePreviewBanner, as
 
 /**
  * Atom for layouts to signal that the preview banner should be hidden.
- * Used by the Lightwell layout to hide the BetaSwitcher directly,
- * instead of checking the URL path.
+ * Initialized from the current pathname so the banner never renders on Lightwell routes,
+ * even before any component mounts.
  */
-export const layoutBannerHiddenAtom = atom(false);
+export const layoutBannerHiddenAtom = atom(isLightwellPath);
 
 /**
  * Atom for layouts to signal that the glass theme should be force-enabled.
- * Used by the Lightwell layout to auto-enable glass theme without hardcoding URL checks.
+ * Initialized from the current pathname so the glass theme is already active
+ * before Header/Tools first renders on Lightwell routes.
  */
-export const layoutForceGlassThemeAtom = atom(false);
+export const layoutForceGlassThemeAtom = atom(isLightwellPath);
 
 /**
  * Atom for layouts to signal a simplified header for Lightwell.


### PR DESCRIPTION
## Summary

Eliminates visible flicker on `/lightwell` routes caused by atoms and theme classes being initialized too late in the React lifecycle.

- **Banner flash:** `layoutBannerHiddenAtom` and `layoutForceGlassThemeAtom` started as `false` and relied on `useLayoutEffect` inside the lazy-loaded Lightwell component to flip them — but the chunk arrived after the first paint, so the BetaSwitcher banner and unstyled header briefly rendered. Fixed by initializing both atoms from `window.location.pathname` at module-eval time and eager-importing the Lightwell layout (which is small).
- **Theme flash:** Felt/glass theme classes were applied via `useEffect` in separate hooks, leaving a gap during the AppPlaceholder → Lightwell transition. Fixed by introducing `useLightwellRouteSetup`, which applies theme classes at module-eval time and reinforces them via `useLayoutEffect`.
- **Glass override bug:** `useGlassTheme` checked `!isEnabled` before `forceEnabled`, so when the `platform.chrome.glass-theme` flag was off, force-enable was silently ignored. Reordered so `forceEnabled` takes priority — "force" means unconditional. This only affects callers passing `forceEnabled=true` (currently only Lightwell); all other routes are unchanged.

## Screencast

See the related Jira.

Note that in addition to what's in this pull request, a small follow-up in content-sources-frontend will fix a resize that is already addressed in this screen capture.

## Changes

| File | What changed |
|------|-------------|
| `src/state/atoms/releaseAtom.ts` | Initialize `layoutBannerHiddenAtom` and `layoutForceGlassThemeAtom` from pathname |
| `src/hooks/useLightwellRouteSetup.ts` | New hook: applies felt + glass classes at module-eval time and via `useLayoutEffect` |
| `src/hooks/useGlassTheme.ts` | `forceEnabled` now takes priority over `!isEnabled` in both init and effect |
| `src/layouts/Lightwell.tsx` | Uses `useLightwellRouteSetup`; drops manual `useFeltTheme` + `layoutForceGlassThemeAtom` management |
| `src/components/RootApp/ScalprumRoot.tsx` | Eager-import Lightwell, remove `Suspense`/`lazyWithRetry` wrapper |
| `src/hooks/useGlassTheme.test.ts` | Updated test to match new `forceEnabled` semantics |
| `src/layouts/Lightwell.test.tsx` | Added glass class to `afterEach` cleanup |

## Non-Lightwell impact

The only shared code change is the `forceEnabled` priority reorder in `useGlassTheme`. No caller outside Lightwell passes `forceEnabled=true`, so behavior on all other routes is identical. The atom initializations are no-ops on non-Lightwell pathnames.

Fixes https://redhat.atlassian.net/browse/RHCLOUD-49049

## Test plan

- [x] `useGlassTheme` tests pass (14/14) — including updated `forceEnabled` semantics test
- [x] `Lightwell` tests pass (8/8)
- [ ] Manual: navigate to `/lightwell` — no banner flash, no unstyled → styled transition
- [ ] Manual: navigate to any non-Lightwell route — no regressions in theme toggle or BetaSwitcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved Lightwell styling so the correct felt/glass theme is applied immediately when entering the route, reducing any visual theme flash.

* **Bug Fixes**
  * Refined Lightwell layout initialization to ensure the banner and header behavior is consistent from the start.
  * Updated Lightwell test cleanup and theme handling to reliably remove theme classes after tests and route transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->