### PR TITLE
fix(useDarkMode): export default hook

### DIFF
--- a/src/state/stores/darkModeStore.ts
+++ b/src/state/stores/darkModeStore.ts
@@ -51,3 +51,5 @@ export const useDarkModeStore = () => {
     isDark: state.isDark,
   };
 };
+
+export default useDarkModeStore;


### PR DESCRIPTION
### Description

Add a default export for the `useDarkModeStore` hook. The hook was only available as a named export, which is inconsistent with how consuming apps typically import hooks and prevents usage via `import useDarkModeStore from '...'` syntax.

[RHCLOUD-XXXXX](https://issues.redhat.com/browse/RHCLOUD-XXXXX)

---

### Anything reviewers should know?

This is a non-breaking additive change — the existing named export is preserved. The default export is added alongside it for convenience.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included

### AI disclosure
Assisted by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dark mode store export to support both default and named imports. This should not change app behavior, but makes the module easier to use in other parts of the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->