### PR TITLE
Lightwell: Set 'Red Hat Display' as header font

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -83,5 +83,6 @@
 
 .chr-c-masthead__lightwell-title {
   align-self: center;
+  font-family: 'Red Hat Display', 'RedHatDisplay', 'Overpass', overpass, helvetica, arial, sans-serif;
   font-weight: 700;
 }


### PR DESCRIPTION
### Description

The Lightwell header that we're showing on the /lightwell route currently doesn't have a font set, so it falls back to "Red Hat Text". To be visually consistent with packages.redhat.com, we should explicitly set it to "Red Hat Display" though.

This is a very trivial and uncritical change, so no testing was added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the header title typography to use a more specific font stack with sensible fallbacks for consistent display across systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->