### PR TITLE
test: add e2e tests for theming

### DIFF
--- a/playwright/e2e/color-scheme.spec.ts
+++ b/playwright/e2e/color-scheme.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '../setup/test-setup';
+import { ChromeTopbar } from './pages/chrome-topbar';
+
+const DARK_THEME_CLASS = 'pf-v6-theme-dark';
+const THEME_STORAGE_KEY = 'chrome:theme';
+
+test.describe('Color Scheme — Light / Dark / System', () => {
+  const REQUIRED_FLAGS = ['platform.chrome.dark-mode', 'platform.chrome.dark-mode_system'];
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/featureflags/v0**', async (route) => {
+      let toggles: object[] = [];
+      try {
+        const response = await route.fetch();
+        toggles = ((await response.json()) as { toggles?: object[] }).toggles ?? [];
+      } catch {
+        // noop
+      }
+      const filtered = toggles.filter((t: { name?: string }) => !REQUIRED_FLAGS.includes(t.name ?? ''));
+      for (const name of REQUIRED_FLAGS) {
+        filtered.push({ name, enabled: true, impressionData: false, variant: { name: 'disabled', enabled: false } });
+      }
+      await route.fulfill({ json: { toggles: filtered } });
+    });
+    await page.goto('/');
+    await page.evaluate((key) => localStorage.removeItem(key), THEME_STORAGE_KEY);
+    await page.reload();
+  });
+
+  test('should show Color scheme section with System, Light, and Dark options', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+
+    await expect(page.locator('#color-scheme-system')).toBeVisible();
+    await expect(page.locator('#color-scheme-light')).toBeVisible();
+    await expect(page.locator('#color-scheme-dark')).toBeVisible();
+  });
+
+  test('should switch to Light mode', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#color-scheme-light').click();
+
+    await expect(page.locator('#color-scheme-light')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(DARK_THEME_CLASS));
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), THEME_STORAGE_KEY);
+    expect(stored).toBe('light');
+  });
+
+  test('should switch to Dark mode', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#color-scheme-dark').click();
+
+    await expect(page.locator('#color-scheme-dark')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).toHaveClass(new RegExp(DARK_THEME_CLASS));
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), THEME_STORAGE_KEY);
+    expect(stored).toBe('dark');
+  });
+
+  test('should switch to System mode', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#color-scheme-system').click();
+
+    await expect(page.locator('#color-scheme-system')).toHaveAttribute('aria-pressed', 'true');
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), THEME_STORAGE_KEY);
+    expect(stored).toBe('system');
+  });
+
+  test('should toggle from Dark to Light', async ({ page }) => {
+    await page.evaluate((key) => localStorage.setItem(key, 'dark'), THEME_STORAGE_KEY);
+    await page.reload();
+
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await expect(page.locator('html')).toHaveClass(new RegExp(DARK_THEME_CLASS));
+    await page.locator('#color-scheme-light').click();
+
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(DARK_THEME_CLASS));
+  });
+
+  test('should persist Dark mode after page reload', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#color-scheme-dark').click();
+    await expect(page.locator('html')).toHaveClass(new RegExp(DARK_THEME_CLASS));
+
+    await page.reload();
+    await topbar.openSettings();
+
+    await expect(page.locator('html')).toHaveClass(new RegExp(DARK_THEME_CLASS));
+  });
+});

--- a/playwright/e2e/color-scheme.spec.ts
+++ b/playwright/e2e/color-scheme.spec.ts
@@ -1,27 +1,13 @@
 import { expect, test } from '../setup/test-setup';
 import { ChromeTopbar } from './pages/chrome-topbar';
+import { mockFeatureFlags } from '../helpers/feature-flags';
 
 const DARK_THEME_CLASS = 'pf-v6-theme-dark';
 const THEME_STORAGE_KEY = 'chrome:theme';
 
 test.describe('Color Scheme — Light / Dark / System', () => {
-  const REQUIRED_FLAGS = ['platform.chrome.dark-mode', 'platform.chrome.dark-mode_system'];
-
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/featureflags/v0**', async (route) => {
-      let toggles: object[] = [];
-      try {
-        const response = await route.fetch();
-        toggles = ((await response.json()) as { toggles?: object[] }).toggles ?? [];
-      } catch {
-        // noop
-      }
-      const filtered = toggles.filter((t: { name?: string }) => !REQUIRED_FLAGS.includes(t.name ?? ''));
-      for (const name of REQUIRED_FLAGS) {
-        filtered.push({ name, enabled: true, impressionData: false, variant: { name: 'disabled', enabled: false } });
-      }
-      await route.fulfill({ json: { toggles: filtered } });
-    });
+    await mockFeatureFlags(page, ['platform.chrome.dark-mode', 'platform.chrome.dark-mode_system']);
     await page.goto('/');
     await page.evaluate((key) => localStorage.removeItem(key), THEME_STORAGE_KEY);
     await page.reload();

--- a/playwright/e2e/contrast-mode.spec.ts
+++ b/playwright/e2e/contrast-mode.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../setup/test-setup';
 import { ChromeTopbar } from './pages/chrome-topbar';
+import { mockFeatureFlags } from '../helpers/feature-flags';
 
 const HIGH_CONTRAST_CLASS = 'pf-v6-theme-high-contrast';
 const GLASS_THEME_CLASS = 'pf-v6-theme-glass';
@@ -7,23 +8,8 @@ const HIGH_CONTRAST_STORAGE_KEY = 'chrome:high-contrast';
 const GLASS_STORAGE_KEY = 'chrome:glass-theme';
 
 test.describe('Contrast Mode — System / Default / High Contrast / Glass', () => {
-  const REQUIRED_FLAGS = ['platform.chrome.high-contrast', 'platform.chrome.glass-theme'];
-
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/featureflags/v0**', async (route) => {
-      let toggles: object[] = [];
-      try {
-        const response = await route.fetch();
-        toggles = ((await response.json()) as { toggles?: object[] }).toggles ?? [];
-      } catch {
-        // noop
-      }
-      const filtered = toggles.filter((t: { name?: string }) => !REQUIRED_FLAGS.includes(t.name ?? ''));
-      for (const name of REQUIRED_FLAGS) {
-        filtered.push({ name, enabled: true, impressionData: false, variant: { name: 'disabled', enabled: false } });
-      }
-      await route.fulfill({ json: { toggles: filtered } });
-    });
+    await mockFeatureFlags(page, ['platform.chrome.high-contrast', 'platform.chrome.glass-theme']);
     await page.goto('/');
     await page.evaluate(
       ([hcKey, glassKey]) => {
@@ -56,6 +42,9 @@ test.describe('Contrast Mode — System / Default / High Contrast / Glass', () =
 
     const stored = await page.evaluate((key) => localStorage.getItem(key), HIGH_CONTRAST_STORAGE_KEY);
     expect(stored).toBe('default');
+
+    const glassStored = await page.evaluate((key) => localStorage.getItem(key), GLASS_STORAGE_KEY);
+    expect(glassStored).not.toBe('true');
   });
 
   test('should switch to High contrast mode', async ({ page }) => {
@@ -89,6 +78,8 @@ test.describe('Contrast Mode — System / Default / High Contrast / Glass', () =
     await page.locator('#contrast-system').click();
 
     await expect(page.locator('#contrast-system')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(GLASS_THEME_CLASS));
 
     const stored = await page.evaluate((key) => localStorage.getItem(key), HIGH_CONTRAST_STORAGE_KEY);
     expect(stored).toBe('system');

--- a/playwright/e2e/contrast-mode.spec.ts
+++ b/playwright/e2e/contrast-mode.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '../setup/test-setup';
+import { ChromeTopbar } from './pages/chrome-topbar';
+
+const HIGH_CONTRAST_CLASS = 'pf-v6-theme-high-contrast';
+const GLASS_THEME_CLASS = 'pf-v6-theme-glass';
+const HIGH_CONTRAST_STORAGE_KEY = 'chrome:high-contrast';
+const GLASS_STORAGE_KEY = 'chrome:glass-theme';
+
+test.describe('Contrast Mode — System / Default / High Contrast / Glass', () => {
+  const REQUIRED_FLAGS = ['platform.chrome.high-contrast', 'platform.chrome.glass-theme'];
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/featureflags/v0**', async (route) => {
+      let toggles: object[] = [];
+      try {
+        const response = await route.fetch();
+        toggles = ((await response.json()) as { toggles?: object[] }).toggles ?? [];
+      } catch {
+        // noop
+      }
+      const filtered = toggles.filter((t: { name?: string }) => !REQUIRED_FLAGS.includes(t.name ?? ''));
+      for (const name of REQUIRED_FLAGS) {
+        filtered.push({ name, enabled: true, impressionData: false, variant: { name: 'disabled', enabled: false } });
+      }
+      await route.fulfill({ json: { toggles: filtered } });
+    });
+    await page.goto('/');
+    await page.evaluate(
+      ([hcKey, glassKey]) => {
+        localStorage.removeItem(hcKey);
+        localStorage.removeItem(glassKey);
+      },
+      [HIGH_CONTRAST_STORAGE_KEY, GLASS_STORAGE_KEY] as [string, string]
+    );
+    await page.reload();
+  });
+
+  test('should show Contrast mode section with all options', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+
+    await expect(page.locator('#contrast-system')).toBeVisible();
+    await expect(page.locator('#contrast-default')).toBeVisible();
+    await expect(page.locator('#contrast-high')).toBeVisible();
+    await expect(page.locator('#contrast-glass')).toBeVisible();
+  });
+
+  test('should switch to Default contrast', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#contrast-default').click();
+
+    await expect(page.locator('#contrast-default')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(GLASS_THEME_CLASS));
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), HIGH_CONTRAST_STORAGE_KEY);
+    expect(stored).toBe('default');
+  });
+
+  test('should switch to High contrast mode', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#contrast-high').click();
+
+    await expect(page.locator('#contrast-high')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), HIGH_CONTRAST_STORAGE_KEY);
+    expect(stored).toBe('high');
+  });
+
+  test('should switch to Glass mode', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#contrast-glass').click();
+
+    await expect(page.locator('#contrast-glass')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).toHaveClass(new RegExp(GLASS_THEME_CLASS));
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), GLASS_STORAGE_KEY);
+    expect(stored).toBe('true');
+  });
+
+  test('should switch to System contrast', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#contrast-system').click();
+
+    await expect(page.locator('#contrast-system')).toHaveAttribute('aria-pressed', 'true');
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), HIGH_CONTRAST_STORAGE_KEY);
+    expect(stored).toBe('system');
+  });
+
+  test('Glass and High contrast should be mutually exclusive', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    const html = page.locator('html');
+    await topbar.openSettings();
+
+    await page.locator('#contrast-high').click();
+    await expect(html).toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+    await expect(html).not.toHaveClass(new RegExp(GLASS_THEME_CLASS));
+
+    await page.locator('#contrast-glass').click();
+    await expect(html).toHaveClass(new RegExp(GLASS_THEME_CLASS));
+    await expect(html).not.toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+
+    await page.locator('#contrast-high').click();
+    await expect(html).toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+    await expect(html).not.toHaveClass(new RegExp(GLASS_THEME_CLASS));
+  });
+
+  test('should persist High contrast after page reload', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#contrast-high').click();
+    await expect(page.locator('html')).toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+
+    await page.reload();
+    await topbar.openSettings();
+
+    await expect(page.locator('html')).toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+  });
+
+  test('should persist Glass mode after page reload', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#contrast-glass').click();
+    await expect(page.locator('html')).toHaveClass(new RegExp(GLASS_THEME_CLASS));
+
+    await page.reload();
+    await topbar.openSettings();
+
+    await expect(page.locator('html')).toHaveClass(new RegExp(GLASS_THEME_CLASS));
+  });
+
+  test('switching from Glass to Default should remove glass class', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#contrast-glass').click();
+    await expect(page.locator('html')).toHaveClass(new RegExp(GLASS_THEME_CLASS));
+
+    await page.locator('#contrast-default').click();
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(GLASS_THEME_CLASS));
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(HIGH_CONTRAST_CLASS));
+  });
+});

--- a/playwright/e2e/theme-toggle.spec.ts
+++ b/playwright/e2e/theme-toggle.spec.ts
@@ -1,11 +1,13 @@
 import { expect, test } from '../setup/test-setup';
 import { ChromeTopbar } from './pages/chrome-topbar';
+import { mockFeatureFlags } from '../helpers/feature-flags';
 
 const FELT_THEME_CLASS = 'pf-v6-theme-felt';
 const FELT_STORAGE_KEY = 'chrome:felt-theme';
 
 test.describe('Theme Toggle — Default / Project Felt', () => {
   test.beforeEach(async ({ page }) => {
+    await mockFeatureFlags(page, ['platform.chrome.felt-theme']);
     await page.goto('/');
     await page.evaluate((key) => localStorage.removeItem(key), FELT_STORAGE_KEY);
     await page.reload();
@@ -39,6 +41,20 @@ test.describe('Theme Toggle — Default / Project Felt', () => {
     expect(stored).toBe('true');
   });
 
+  test('should switch from Felt back to Default', async ({ page }) => {
+    await page.evaluate((key) => localStorage.setItem(key, 'true'), FELT_STORAGE_KEY);
+    await page.reload();
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await expect(page.locator('html')).toHaveClass(new RegExp(FELT_THEME_CLASS));
+
+    await page.locator('#theme-default').click();
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(FELT_THEME_CLASS));
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), FELT_STORAGE_KEY);
+    expect(stored).toBe('false');
+  });
+
   test('should persist Felt theme after page reload', async ({ page }) => {
     const topbar = new ChromeTopbar(page);
     await topbar.openSettings();
@@ -46,6 +62,7 @@ test.describe('Theme Toggle — Default / Project Felt', () => {
     await expect(page.locator('html')).toHaveClass(new RegExp(FELT_THEME_CLASS));
 
     await page.reload();
+    await topbar.openSettings();
 
     await expect(page.locator('html')).toHaveClass(new RegExp(FELT_THEME_CLASS));
   });

--- a/playwright/e2e/theme-toggle.spec.ts
+++ b/playwright/e2e/theme-toggle.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '../setup/test-setup';
+import { ChromeTopbar } from './pages/chrome-topbar';
+
+const FELT_THEME_CLASS = 'pf-v6-theme-felt';
+const FELT_STORAGE_KEY = 'chrome:felt-theme';
+
+test.describe('Theme Toggle — Default / Project Felt', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate((key) => localStorage.removeItem(key), FELT_STORAGE_KEY);
+    await page.reload();
+  });
+
+  test('should show Theme section with Default and Project Felt options', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+
+    await expect(page.locator('#theme-default')).toBeVisible();
+    await expect(page.locator('#theme-felt')).toBeVisible();
+  });
+
+  test('should default to Default theme', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+
+    await expect(page.locator('#theme-default')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).not.toHaveClass(new RegExp(FELT_THEME_CLASS));
+  });
+
+  test('should switch to Project Felt theme', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#theme-felt').click();
+
+    await expect(page.locator('#theme-felt')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('html')).toHaveClass(new RegExp(FELT_THEME_CLASS));
+
+    const stored = await page.evaluate((key) => localStorage.getItem(key), FELT_STORAGE_KEY);
+    expect(stored).toBe('true');
+  });
+
+  test('should persist Felt theme after page reload', async ({ page }) => {
+    const topbar = new ChromeTopbar(page);
+    await topbar.openSettings();
+    await page.locator('#theme-felt').click();
+    await expect(page.locator('html')).toHaveClass(new RegExp(FELT_THEME_CLASS));
+
+    await page.reload();
+
+    await expect(page.locator('html')).toHaveClass(new RegExp(FELT_THEME_CLASS));
+  });
+});

--- a/playwright/helpers/feature-flags.ts
+++ b/playwright/helpers/feature-flags.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+
+interface FeatureToggle {
+  name: string;
+  enabled: boolean;
+  impressionData: boolean;
+  variant: { name: string; enabled: boolean };
+}
+
+export async function mockFeatureFlags(page: Page, flags: string[]): Promise<void> {
+  await page.route('**/api/featureflags/v0**', async (route) => {
+    let toggles: FeatureToggle[] = [];
+    try {
+      const response = await route.fetch();
+      toggles = ((await response.json()) as { toggles?: FeatureToggle[] }).toggles ?? [];
+    } catch {
+      // noop
+    }
+    const filtered = toggles.filter((t) => !flags.includes(t.name));
+    for (const name of flags) {
+      filtered.push({ name, enabled: true, impressionData: false, variant: { name: 'disabled', enabled: false } });
+    }
+    await route.fulfill({ json: { toggles: filtered } });
+  });
+}


### PR DESCRIPTION
### Description

Add Playwright e2e tests for the three theme settings panels: 
- color scheme (light/dark/system), 
- contrast mode (default/high contrast/glass), 
- theme toggle (default/project felt) 

Tests cover switching between options, verifying localStorage persistence across page reloads, and mutual exclusivity of contrast modes.

Feature flags are mocked via Unleash API interception to ensure tests are deterministic regardless of environment flag state.

[RHCLOUD-49097](https://redhat.atlassian.net/browse/RHCLOUD-49097)

[RHCLOUD-49097]: https://redhat.atlassian.net/browse/RHCLOUD-49097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for theme toggles, Color Scheme (Light/Dark/System), and Contrast Mode (Default/High Contrast/Glass/System).
  * Verified the settings UI renders the expected options and that selections update the correct active/pressed state.
  * Confirmed the correct theme styling is applied and that selections persist in browser storage across reloads (including switching and mutual exclusivity for contrast modes).
  * Introduced test-side feature flag mocking to reliably exercise the relevant UI paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->