### PR TITLE
fix(theme): preserve useDarkModeStore export for Module Federation consumers

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useFlag } from '@unleash/proxy-client-react';
-import { getDarkModeStore } from '../state/stores/darkModeStore';
+import { getDarkModeStore, useDarkModeStore } from '../state/stores/darkModeStore';
+
+// Force webpack to treat useDarkModeStore as a used export so the module cache
+// includes it when remote modules load it via Module Federation.
+void useDarkModeStore;
 
 export enum ThemeVariants {
   light,


### PR DESCRIPTION
### Summary

  - Fixes useDarkModeStore being unavailable to remote modules consuming it via Module Federation (./theme/useDarkModeStore)
  - Remote consumers like uhc-portal's useRemoteHook({ scope: 'chrome', module: './theme/useDarkModeStore', importName: 'useDarkModeStore' }) were
  stuck at { loading: true } forever (uhc-portal#617 (https://github.com/RedHatInsights/uhc-portal/pull/617))
  - Reference the export in useTheme.ts to keep it in the module cache

  ### Root cause

  The Module Federation expose at `./theme/useDarkModeStore` points to `darkModeStore.ts`, which has three exports: `getDarkModeStore`, `_resetDarkModeStore`, and `useDarkModeStore`. However, only `getDarkModeStore` is imported internally by Chrome (in `useTheme.ts`).

  Our initial theory was that webpack's usedExports optimization simply tree-shakes the unused exports from the bundle entirely. This turned out to be wrong. The MF expose chunk (e.g. chunk 60341) contains all three exports in its factory:

  `t.d(r, {_resetDarkModeStore: () => l, getDarkModeStore: () => o, useDarkModeStore: () => d})`

  The actual mechanism is more subtle: webpack creates two factories for the same module ID. Chrome's own app chunk (e.g. chunk 41947) includes a trimmed factory with only the internally-used export:

  `r.d(t, {getDarkModeStore: () => i})  // only getDarkModeStore!`

  This chunk also registers itself as fulfilling the MF expose chunk's ID (via push([[9453, 41947, 60341], ...]) — note 60341 in the chunk group). At runtime:

  1. Chrome's app chunk loads first → its trimmed factory runs → module is cached with only getDarkModeStore → chunk 60341 is marked "installed"
  2. When a remote module calls window.chrome.get('./theme/useDarkModeStore'), webpack's __webpack_require__ returns the cached module — missing
  useDarkModeStore
  3. The full factory in the MF expose chunk never runs because the module is already cached

  This can be verified on any environment (including production):

```js
  window.chrome.get('./theme/useDarkModeStore').then(f => console.log(Object.keys(f())))
  // Returns: ['getDarkModeStore']
  // Expected: ['getDarkModeStore', '_resetDarkModeStore', 'useDarkModeStore']
```

  When a remote module calls `useRemoteHook({ importName: 'useDarkModeStore' }),` getModule returns undefined. Scalprum's HookExecutor skips rendering for falsy hook functions, so loading is never set to false.

  ### Fix
  
  Import useDarkModeStore in useTheme.ts with a void reference. This makes webpack's usedExports analysis mark it as "used," so the trimmed factory in Chrome's app chunk includes it. The module cache then has the export available when MF consumers request it.

  Without fix — Chrome's app chunk factory:
  `r.d(t, {getDarkModeStore: () => i})`

  With fix — Chrome's app chunk factory:
  `r.d(t, {getDarkModeStore: () => s, useDarkModeStore: () => c})`

###   Why export default (#3593) doesn't fix this

  Adding export default useDarkModeStore doesn't help because the problem is on the import side, not the export side. Webpack's usedExports optimization is driven by what Chrome's own code imports. If nothing in Chrome imports useDarkModeStore (whether named or default), webpack's trimmed factory omits it, and the module cache won't have it. The consumer's useRemoteHook call explicitly sets importName: 'useDarkModeStore' (a named export), so even if a default survived, it wouldn't match.

###   Test plan

  - [x] npm run build → verify Chrome's app chunk exports both getDarkModeStore and useDarkModeStore
  - [ ] window.chrome.get('./theme/useDarkModeStore').then(f => console.log(Object.keys(f()))) returns all exports
  - [ ] Verify useRemoteHook with importName: 'useDarkModeStore' resolves correctly from a consuming app
  - [x] Existing tests pass (npm run verify)
  - [x] Verified locally: built without fix → chunk 41947 factory exports only `getDarkModeStore`; built with fix → chunk 41947 factory exports both
  `getDarkModeStore` and `useDarkModeStore`; reverted and rebuilt to confirm regression returns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme functionality when loading remotely integrated modules.
  * Ensured dark mode remains available across federated application boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->