### PR TITLE
fix: use navItems instead of routes for FEO canonical data structure

### DIFF
--- a/cypress/fixtures/settings-navigation.json
+++ b/cypress/fixtures/settings-navigation.json
@@ -53,7 +53,7 @@
             "id": "notifications",
             "description": "A standardized way of notifying users of events for supported services on the Hybrid Cloud Console.",
             "expandable": true,
-            "routes": [
+            "navItems": [
                 {
                     "id": "notificationOverview",
                     "appId": "notifications",

--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -48,7 +48,6 @@ export type NavItem = {
   groupId?: string;
   expandable?: boolean;
   href?: string;
-  routes?: NavItem[];
   navItems?: NavItem[];
   active?: boolean;
   isHidden?: boolean;
@@ -223,7 +222,7 @@ export type ChromeNavItemProps = {
 
 export type ChromeNavExpandableProps = {
   title: string;
-  routes: RouteDefinition[];
+  navItems?: NavItem[];
   active?: boolean;
   isHidden?: boolean;
   id?: string;

--- a/src/components/AllServices/AllServicesBundle.tsx
+++ b/src/components/AllServices/AllServicesBundle.tsx
@@ -11,12 +11,11 @@ import { Split, SplitItem } from '@patternfly/react-core/dist/dynamic/layouts/Sp
 type AllServicesBundleProps = BundleNavigation;
 
 const AllServicesBundle = ({ id, title, description, navItems }: AllServicesBundleProps) => {
-  const items = navItems.flatMap(({ href, title, navItems, id, routes, isExternal }) => {
-    const children = routes || navItems;
-    return children
-      ? children.flatMap(({ routes, title: childTitle, href: subHref, id: subId, isExternal }) => {
-          return routes
-            ? routes.map(({ href: childHref, id: nestedId, title: nestedTitle, isExternal }) => ({
+  const items = navItems.flatMap(({ href, title, navItems: childNavItems, id, isExternal }) => {
+    return childNavItems
+      ? childNavItems.flatMap(({ navItems: nestedNavItems, title: childTitle, href: subHref, id: subId, isExternal }) => {
+          return nestedNavItems
+            ? nestedNavItems.map(({ href: childHref, id: nestedId, title: nestedTitle, isExternal }) => ({
                 title: nestedTitle,
                 href: childHref,
                 id: nestedId,

--- a/src/components/AppFilter/useAppFilter.test.js
+++ b/src/components/AppFilter/useAppFilter.test.js
@@ -145,7 +145,7 @@ describe('useAppFilter', () => {
       {
         id: TEST_ID,
         title: TEST_TITLE,
-        navItems: [{ title: 'title', expandable: true, routes: [{ href: '/foo/bar/baz/quaxx', appId: 'foo', title: 'Nested' }] }],
+        navItems: [{ title: 'title', expandable: true, navItems: [{ href: '/foo/bar/baz/quaxx', appId: 'foo', title: 'Nested' }] }],
       },
     ]);
     let result;
@@ -170,7 +170,7 @@ describe('useAppFilter', () => {
           {
             title: 'title',
             expandable: true,
-            routes: [
+            navItems: [
               { href: '/openshift/cost-management/foo', appId: 'foo', title: 'cost-nested' },
               { href: '/openshift/subscriptions/foo', appId: 'foo', title: 'subs-nested-ins' },
               { href: '/insights/subscriptions/foo', appId: 'foo', title: 'subs-nested-o' },
@@ -211,12 +211,12 @@ describe('useAppFilter', () => {
       {
         id: TEST_ID,
         title: TEST_TITLE,
-        navItems: [{ title: 'title', expandable: true, routes: [{ href: '/openshift/cost-management/foo', appId: 'foo', title: 'cost-nested' }] }],
+        navItems: [{ title: 'title', expandable: true, navItems: [{ href: '/openshift/cost-management/foo', appId: 'foo', title: 'cost-nested' }] }],
       },
       {
         id: 'duplicate',
         title: 'Duplicate',
-        navItems: [{ title: 'title', expandable: true, routes: [{ href: '/openshift/cost-management/foo', appId: 'foo', title: 'cost-nested' }] }],
+        navItems: [{ title: 'title', expandable: true, navItems: [{ href: '/openshift/cost-management/foo', appId: 'foo', title: 'cost-nested' }] }],
       },
     ]);
     let result;

--- a/src/components/AppFilter/useAppFilter.ts
+++ b/src/components/AppFilter/useAppFilter.ts
@@ -23,13 +23,13 @@ function findModuleByLink(href: string, { modules }: Pick<ChromeModule, 'modules
   return routes.find((route) => href.includes(route)) || '';
 }
 
-function getBundleLink({ title, isExternal, href, routes, expandable, ...rest }: NavItem, modules: { [key: string]: ChromeModule }) {
+function getBundleLink({ title, isExternal, href, navItems, expandable, ...rest }: NavItem, modules: { [key: string]: ChromeModule }) {
   const costLinks: NavItem[] = [];
   const subscriptionsLinks: NavItem[] = [];
   let url = href;
   let appId = rest.appId!;
   if (expandable) {
-    routes?.forEach(({ href, title, ...rest }) => {
+    navItems?.forEach(({ href, title, ...rest }) => {
       if (href?.includes('/openshift/cost-management') && rest.filterable !== false) {
         costLinks.push({ ...rest, isFedramp: false, href, title });
       }

--- a/src/components/Navigation/ChromeNavExpandable.test.js
+++ b/src/components/Navigation/ChromeNavExpandable.test.js
@@ -26,7 +26,7 @@ describe('ChromeNavExpandable', () => {
     appId: 'testModule',
     href: '/foo',
     title: expandableTitle,
-    routes: [{ appId: 'bar', title: 'title', href: '/foo/bar' }],
+    navItems: [{ appId: 'bar', title: 'title', href: '/foo/bar' }],
     id: 'test-id',
   };
 
@@ -55,7 +55,7 @@ describe('ChromeNavExpandable', () => {
       <NavContextWrapper>
         <ChromeNavExpandable
           {...testProps}
-          routes={[
+          navItems={[
             {
               appId: 'testModule',
               href: '/foo',

--- a/src/components/Navigation/ChromeNavExpandable.tsx
+++ b/src/components/Navigation/ChromeNavExpandable.tsx
@@ -3,15 +3,15 @@ import { NavExpandable } from '@patternfly/react-core/dist/dynamic/components/Na
 import ChromeNavItemFactory from './ChromeNavItemFactory';
 import { ChromeNavExpandableProps } from '../../@types/types';
 
-const ChromeNavExpandable = ({ title, routes, active, isHidden, id }: ChromeNavExpandableProps) => {
-  if (isHidden || routes.length === 0) {
+const ChromeNavExpandable = ({ title, navItems, active, isHidden, id }: ChromeNavExpandableProps) => {
+  if (isHidden || !navItems || navItems.length === 0) {
     return null;
   }
 
   const quickStartHighlightId = title.replace(/\s/g, '-');
   return (
     <NavExpandable id={id} isExpanded={active} isActive={active} title={title} data-quickstart-id={quickStartHighlightId}>
-      {routes.map((item, index) => (
+      {navItems.map((item, index) => (
         <ChromeNavItemFactory key={index} {...item} />
       ))}
     </NavExpandable>

--- a/src/components/Navigation/ChromeNavItemFactory.test.js
+++ b/src/components/Navigation/ChromeNavItemFactory.test.js
@@ -34,7 +34,7 @@ describe('ChromeNavItemFactory', () => {
     id: 'test-id',
     title: expandableTitle,
     expandable: true,
-    routes: [itemProps],
+    navItems: [itemProps],
   };
   const groupItemProps = {
     groupId: 'group',

--- a/src/hooks/useAllLinks.ts
+++ b/src/hooks/useAllLinks.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { BundleNav, BundleNavigation, NavItem } from '../@types/types';
-import { isExpandableNav } from '../utils/common';
 import { useVisibleBundles } from '../state/atoms/visibleBundlesAtom';
 
 const getFirstChildRoute = (routes: NavItem[] = []): NavItem | undefined => {
@@ -12,7 +11,7 @@ const getFirstChildRoute = (routes: NavItem[] = []): NavItem | undefined => {
   const nestedItems = firstLeaf ? [] : routes.filter((item) => item.expandable);
   // make sure to find first deeply nested item
   nestedItems.every((item) => {
-    childRoute = getFirstChildRoute(item.routes);
+    childRoute = getFirstChildRoute(item.navItems);
     return !childRoute;
   });
 
@@ -20,32 +19,28 @@ const getFirstChildRoute = (routes: NavItem[] = []): NavItem | undefined => {
 };
 
 const handleBundleResponse = (bundle: Omit<BundleNavigation, 'id' | 'title'> & Partial<Pick<BundleNavigation, 'id' | 'title'>>): BundleNav => {
-  const flatLinks = bundle?.navItems?.reduce<(NavItem | NavItem[])[]>((acc, { navItems, routes, expandable, ...rest }) => {
-    // item is a group
-
+  const flatLinks = bundle?.navItems?.reduce<(NavItem | NavItem[])[]>((acc, { navItems, expandable, ...rest }) => {
+    // item is a group or expandable section with children
     if (navItems) {
-      acc.push(...handleBundleResponse({ ...rest, navItems }).links);
-      return acc;
-    }
-
-    if (typeof expandable !== 'undefined' && typeof routes !== 'undefined' && typeof rest.id !== 'undefined') {
-      const childRoute = getFirstChildRoute(routes);
-      if (childRoute) {
-        const expandableLink = {
-          ...childRoute,
-          title: rest.title,
-          description: rest.description,
-          id: rest.id,
-        };
-        acc.push(...routes, expandableLink);
-        // return acc;
+      if (expandable === true && typeof rest.id !== 'undefined') {
+        const childRoute = getFirstChildRoute(navItems);
+        if (childRoute) {
+          const expandableLink = {
+            ...childRoute,
+            title: rest.title,
+            description: rest.description,
+            id: rest.id,
+          };
+          acc.push(...navItems, expandableLink);
+        }
       }
-    }
 
-    // item is an expandable section
-    if (typeof expandable !== 'undefined' && typeof routes !== 'undefined') {
-      // console.log('rest:', { ...rest, routes });
-      acc.push(...handleBundleResponse({ ...rest, navItems: routes }).links);
+      if (expandable === true) {
+        acc.push(...handleBundleResponse({ ...rest, navItems }).links);
+        return acc;
+      }
+
+      acc.push(...handleBundleResponse({ ...rest, navItems }).links);
       return acc;
     }
 
@@ -69,9 +64,7 @@ const handleBundleResponse = (bundle: Omit<BundleNavigation, 'id' | 'title'> & P
 const getNavLinks = (navItems: NavItem[]): NavItem[] => {
   const links: NavItem[] = [];
   navItems?.forEach((item) => {
-    if (isExpandableNav(item) && item.routes) {
-      links.push(...getNavLinks(item.routes));
-    } else if (item.groupId && item.navItems) {
+    if (item.navItems) {
       links.push(...getNavLinks(item.navItems));
     } else {
       links.push(item);

--- a/src/hooks/useAllLinks.ts
+++ b/src/hooks/useAllLinks.ts
@@ -35,11 +35,6 @@ const handleBundleResponse = (bundle: Omit<BundleNavigation, 'id' | 'title'> & P
         }
       }
 
-      if (expandable === true) {
-        acc.push(...handleBundleResponse({ ...rest, navItems }).links);
-        return acc;
-      }
-
       acc.push(...handleBundleResponse({ ...rest, navItems }).links);
       return acc;
     }

--- a/src/state/atoms/visibleBundlesAtom.test.ts
+++ b/src/state/atoms/visibleBundlesAtom.test.ts
@@ -38,19 +38,19 @@ describe('filterHiddenItems', () => {
     expect(result[0].navItems).toEqual([expect.objectContaining({ title: 'visible child' })]);
   });
 
-  it('should recursively filter hidden routes in expandable items', () => {
+  it('should recursively filter hidden navItems in expandable items', () => {
     const items: NavItem[] = [
       {
         title: 'expandable',
         expandable: true,
-        routes: [
+        navItems: [
           { title: 'v2 route', href: '/iam/access-management/roles' },
           { title: 'v1 route', href: '/iam/user-access/roles', isHidden: true },
         ],
       },
     ];
     const result = filterHiddenItems(items);
-    expect(result[0].routes).toEqual([expect.objectContaining({ title: 'v2 route' })]);
+    expect(result[0].navItems).toEqual([expect.objectContaining({ title: 'v2 route' })]);
   });
 
   it('should remove a parent group if it is hidden', () => {
@@ -76,7 +76,7 @@ describe('filterHiddenItems', () => {
           {
             title: 'expandable',
             expandable: true,
-            routes: [
+            navItems: [
               { title: 'deep visible', href: '/a' },
               { title: 'deep hidden', href: '/b', isHidden: true },
             ],
@@ -85,7 +85,7 @@ describe('filterHiddenItems', () => {
       },
     ];
     const result = filterHiddenItems(items);
-    expect(result[0].navItems![0].routes).toEqual([expect.objectContaining({ title: 'deep visible' })]);
+    expect(result[0].navItems![0].navItems).toEqual([expect.objectContaining({ title: 'deep visible' })]);
   });
 
   it('should return empty array when all items are hidden', () => {
@@ -96,7 +96,7 @@ describe('filterHiddenItems', () => {
     expect(filterHiddenItems(items)).toEqual([]);
   });
 
-  it('should pass through items without navItems or routes unchanged', () => {
+  it('should pass through items without navItems unchanged', () => {
     const items: NavItem[] = [{ title: 'leaf', href: '/a', appId: 'foo' }];
     const result = filterHiddenItems(items);
     expect(result).toEqual([{ title: 'leaf', href: '/a', appId: 'foo' }]);

--- a/src/state/atoms/visibleBundlesAtom.ts
+++ b/src/state/atoms/visibleBundlesAtom.ts
@@ -22,7 +22,6 @@ export const filterHiddenItems = (navItems: NavItem[]): NavItem[] => {
     .map((item) => ({
       ...item,
       ...(item.navItems ? { navItems: filterHiddenItems(item.navItems) } : {}),
-      ...(item.routes ? { routes: filterHiddenItems(item.routes) } : {}),
     }));
 };
 

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -2,23 +2,23 @@ import { findNavLeafPath, getErrorMessage, isExpandableNav } from './common';
 import { NavItem } from '../@types/types';
 
 describe('isExpandableNav', () => {
-  it('returns true when expandable is true and routes is an array', () => {
-    const item: NavItem = { expandable: true, routes: [{ title: 'Child', href: '/child' }] };
+  it('returns true when expandable is true and navItems is an array', () => {
+    const item: NavItem = { expandable: true, navItems: [{ title: 'Child', href: '/child' }] };
     expect(isExpandableNav(item)).toBe(true);
   });
 
-  it('returns true when expandable is true and routes is empty array', () => {
-    const item: NavItem = { expandable: true, routes: [] };
+  it('returns true when expandable is true and navItems is empty array', () => {
+    const item: NavItem = { expandable: true, navItems: [] };
     expect(isExpandableNav(item)).toBe(true);
   });
 
-  it('returns false when expandable is true but routes is undefined', () => {
+  it('returns false when expandable is true but navItems is undefined', () => {
     const item: NavItem = { expandable: true };
     expect(isExpandableNav(item)).toBe(false);
   });
 
   it('returns false when expandable is false', () => {
-    const item: NavItem = { expandable: false, routes: [{ title: 'Child', href: '/child' }] };
+    const item: NavItem = { expandable: false, navItems: [{ title: 'Child', href: '/child' }] };
     expect(isExpandableNav(item)).toBe(false);
   });
 
@@ -41,12 +41,12 @@ describe('findNavLeafPath', () => {
     expect(result.navItems).toEqual([]);
   });
 
-  it('finds a leaf item in nested expandable routes', () => {
+  it('finds a leaf item in nested expandable navItems', () => {
     const navItems: NavItem[] = [
       {
         title: 'Parent',
         expandable: true,
-        routes: [{ title: 'Child', href: '/parent/child' }],
+        navItems: [{ title: 'Child', href: '/parent/child' }],
       },
     ];
     const result = findNavLeafPath(navItems, makeMatcher('/parent/child'));
@@ -61,7 +61,7 @@ describe('findNavLeafPath', () => {
     expect(result.navItems).toEqual([]);
   });
 
-  it('handles expandable items with undefined routes without crashing', () => {
+  it('handles expandable items with undefined navItems without crashing', () => {
     const navItems: NavItem[] = [
       { title: 'Bad Expandable', expandable: true },
       { title: 'Good Leaf', href: '/good' },
@@ -99,11 +99,11 @@ describe('findNavLeafPath', () => {
       {
         title: 'L1',
         expandable: true,
-        routes: [
+        navItems: [
           {
             title: 'L2',
             expandable: true,
-            routes: [{ title: 'L3', href: '/l1/l2/l3' }],
+            navItems: [{ title: 'L3', href: '/l1/l2/l3' }],
           },
         ],
       },

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -220,13 +220,13 @@ const activateChild = (
   childRoutes: NavItem[]
 ): {
   active: boolean;
-  routes: NavItem[];
+  navItems: NavItem[];
 } => {
   let hasActiveChild = false;
-  const routes = childRoutes.map((item) => {
+  const navItems = childRoutes.map((item) => {
     // If expandable traverse children again
     if (item.expandable) {
-      const nestedResult = activateChild(hrefMatch, item.routes || []);
+      const nestedResult = activateChild(hrefMatch, item.navItems || []);
       // mark active if nested child is active
       if (nestedResult.active) {
         hasActiveChild = true;
@@ -234,7 +234,7 @@ const activateChild = (
       return {
         ...item,
         active: nestedResult.active,
-        routes: nestedResult.routes,
+        navItems: nestedResult.navItems,
       };
     }
     const active = item.href === hrefMatch;
@@ -248,24 +248,23 @@ const activateChild = (
   });
   return {
     active: hasActiveChild,
-    routes,
+    navItems,
   };
 };
 
 function mutateSchema(hrefMatch: string, navItems: NavItem[]): NavItem[] {
   return navItems.map((item) => {
-    const { href, routes, navItems } = item;
+    const { href, navItems } = item;
     if (!href && navItems) {
+      if (item.expandable) {
+        return {
+          ...item,
+          ...activateChild(hrefMatch, navItems),
+        };
+      }
       return {
         ...item,
         navItems: mutateSchema(hrefMatch, navItems),
-      };
-    }
-
-    if (!href && routes) {
-      return {
-        ...item,
-        ...activateChild(hrefMatch, routes),
       };
     }
 
@@ -291,13 +290,9 @@ export const highlightItems = (pathname: string, navItems: NavItem[], sortedLink
 };
 
 export const levelArray = (navItems: NavItem[]): string[] => {
-  return flatMap<NavItem, string>(navItems, ({ href, routes, navItems }) => {
+  return flatMap<NavItem, string>(navItems, ({ href, navItems }) => {
     if (!href && navItems) {
       return levelArray(navItems);
-    }
-
-    if (!href && routes) {
-      return levelArray(routes);
     }
 
     if (href) {
@@ -493,8 +488,8 @@ export const isGlobalFilterAllowed = () => {
   return getUrl('bundle') === 'ansible' && ['inventory', 'drift', 'advisor'].includes(getUrl('app'));
 };
 
-export function isExpandableNav(item: NavItem): item is Required<NavItem, 'routes'> {
-  return !!item.expandable && Array.isArray(item.routes);
+export function isExpandableNav(item: NavItem): item is Required<NavItem, 'navItems'> {
+  return !!item.expandable && Array.isArray(item.navItems);
 }
 
 function isActiveLeaf(item: NavItem | undefined): boolean {
@@ -516,7 +511,7 @@ export function findNavLeafPath(
     const item = navItems[index];
     index += 1;
     if (item && isExpandableNav(item)) {
-      const { activeItem, navItems } = findNavLeafPath(item.routes, matcher) || {};
+      const { activeItem, navItems } = findNavLeafPath(item.navItems, matcher) || {};
       if (activeItem) {
         leaf = activeItem;
         // append parent nodes of an active item

--- a/src/utils/fetchNavigationFiles.ts
+++ b/src/utils/fetchNavigationFiles.ts
@@ -15,10 +15,13 @@ function normalizeNavItem(item: RawNavItem): NavItem {
   };
 }
 
-function normalizeBundle(bundle: BundleNavigation): BundleNavigation {
+type RawBundleNavigation = Omit<BundleNavigation, 'navItems'> & { routes?: RawNavItem[]; navItems?: RawNavItem[] };
+
+function normalizeBundle(bundle: RawBundleNavigation): BundleNavigation {
+  const children = bundle.navItems ?? bundle.routes ?? [];
   return {
     ...bundle,
-    navItems: (bundle.navItems as RawNavItem[]).map(normalizeNavItem),
+    navItems: children.map(normalizeNavItem),
   };
 }
 

--- a/src/utils/fetchNavigationFiles.ts
+++ b/src/utils/fetchNavigationFiles.ts
@@ -4,6 +4,24 @@ import { Required } from 'utility-types';
 import { itLessBundles, requiredBundles } from '../components/AppFilter/useAppFilter';
 import { ITLess, getChromeStaticPathname } from './common';
 
+type RawNavItem = Omit<NavItem, 'navItems'> & { routes?: RawNavItem[]; navItems?: RawNavItem[] };
+
+function normalizeNavItem(item: RawNavItem): NavItem {
+  const { routes, navItems, ...rest } = item;
+  const children = navItems ?? routes;
+  return {
+    ...rest,
+    ...(children ? { navItems: children.map(normalizeNavItem) } : {}),
+  };
+}
+
+function normalizeBundle(bundle: BundleNavigation): BundleNavigation {
+  return {
+    ...bundle,
+    navItems: (bundle.navItems as RawNavItem[]).map(normalizeNavItem),
+  };
+}
+
 export function isBundleNavigation(item: unknown): item is BundleNavigation {
   return typeof item !== 'undefined';
 }
@@ -38,7 +56,7 @@ const fetchNavigationFiles = async (feoGenerated = false) => {
   if (feoGenerated) {
     // aggregate data call
     const { data: aggregateData } = await axios.get<BundleNavigation[]>('/api/chrome-service/v1/static/bundles-generated.json');
-    const bundleNavigation = aggregateData.filter(isBundleNavigation);
+    const bundleNavigation = aggregateData.filter(isBundleNavigation).map(normalizeBundle);
     return bundleNavigation;
   }
   const bundles = ITLess() ? itLessBundles : requiredBundles;
@@ -65,7 +83,7 @@ const fetchNavigationFiles = async (feoGenerated = false) => {
         })
     )
   )
-    .then((data) => data.filter(isBundleNavigation))
+    .then((data) => data.filter(isBundleNavigation).map(normalizeBundle))
     .then((data) => {
       filesCache.data = data;
       filesCache.ready = true;

--- a/src/utils/filterNavItemsByTitle.ts
+++ b/src/utils/filterNavItemsByTitle.ts
@@ -12,14 +12,12 @@ const filterNavItemsByTitle = (items: NavItem[], search: string): NavItem[] => {
         return item;
       }
 
-      const filteredRoutes = item.routes ? filterNavItemsByTitle(item.routes, search) : [];
       const filteredNavItems = item.navItems ? filterNavItemsByTitle(item.navItems, search) : [];
 
-      if (filteredRoutes.length > 0 || filteredNavItems.length > 0) {
+      if (filteredNavItems.length > 0) {
         return {
           ...item,
-          routes: filteredRoutes.length > 0 ? filteredRoutes : undefined,
-          navItems: filteredNavItems.length > 0 ? filteredNavItems : undefined,
+          navItems: filteredNavItems,
         };
       }
 

--- a/src/utils/isNavItemVisible.test.ts
+++ b/src/utils/isNavItemVisible.test.ts
@@ -38,37 +38,37 @@ describe('evaluateVisibility', () => {
     expect(result).toEqual(item);
   });
 
-  it('handles expandable item with routes', async () => {
+  it('handles expandable item with navItems', async () => {
     const item: NavItem = {
       title: 'Expandable',
       expandable: true,
-      routes: [{ title: 'Child', href: '/child' }],
+      navItems: [{ title: 'Child', href: '/child' }],
     };
     const result = await evaluateVisibility(item);
     expect(result.isHidden).toBe(false);
-    expect(result.routes).toHaveLength(1);
-    expect(result.routes![0]).toEqual(expect.objectContaining({ title: 'Child', isHidden: false }));
+    expect(result.navItems).toHaveLength(1);
+    expect(result.navItems![0]).toEqual(expect.objectContaining({ title: 'Child', isHidden: false }));
   });
 
-  it('handles expandable item with undefined routes without crashing', async () => {
+  it('handles expandable item with undefined navItems without crashing', async () => {
     const item: NavItem = {
-      title: 'Expandable No Routes',
+      title: 'Expandable No NavItems',
       expandable: true,
     };
     const result = await evaluateVisibility(item);
     expect(result.isHidden).toBe(false);
-    expect(result.routes).toBeUndefined();
+    expect(result.navItems).toBeUndefined();
   });
 
-  it('handles expandable item with empty routes', async () => {
+  it('handles expandable item with empty navItems', async () => {
     const item: NavItem = {
       title: 'Expandable Empty',
       expandable: true,
-      routes: [],
+      navItems: [],
     };
     const result = await evaluateVisibility(item);
     expect(result.isHidden).toBe(false);
-    expect(result.routes).toEqual([]);
+    expect(result.navItems).toEqual([]);
   });
 
   it('handles group item with navItems', async () => {
@@ -91,19 +91,19 @@ describe('evaluateVisibility', () => {
     expect(result.navItems).toBeUndefined();
   });
 
-  it('recursively evaluates nested expandable routes', async () => {
+  it('recursively evaluates nested expandable navItems', async () => {
     const item: NavItem = {
       title: 'Parent',
       expandable: true,
-      routes: [
+      navItems: [
         {
           title: 'Nested Expandable',
           expandable: true,
-          routes: [{ title: 'Deep Child', href: '/deep' }],
+          navItems: [{ title: 'Deep Child', href: '/deep' }],
         },
       ],
     };
     const result = await evaluateVisibility(item);
-    expect(result.routes![0].routes![0]).toEqual(expect.objectContaining({ title: 'Deep Child', isHidden: false }));
+    expect(result.navItems![0].navItems![0]).toEqual(expect.objectContaining({ title: 'Deep Child', isHidden: false }));
   });
 });

--- a/src/utils/isNavItemVisible.ts
+++ b/src/utils/isNavItemVisible.ts
@@ -20,7 +20,6 @@ export type ItemWithPermissionsConfig<T> = T & {
   groupId?: string;
   navItems?: ItemWithPermissionsConfig<NavItem>[];
   expandable?: boolean;
-  routes?: ItemWithPermissionsConfig<NavItem>[];
 };
 
 export const evaluateVisibility = async <T>(navItem: ItemWithPermissionsConfig<T>) => {
@@ -49,18 +48,8 @@ export const evaluateVisibility = async <T>(navItem: ItemWithPermissionsConfig<T
     }
   }
 
-  if (typeof result.groupId !== 'undefined' && Array.isArray(result.navItems)) {
-    /**
-     * Evalute group items
-     */
+  if (Array.isArray(result.navItems)) {
     result.navItems = await Promise.all(result.navItems.map(evaluateVisibility));
-  }
-
-  if (result.expandable === true && Array.isArray(result.routes)) {
-    /**
-     * Evaluate sub routes
-     */
-    result.routes = await Promise.all(result.routes.map(evaluateVisibility));
   }
 
   return result;

--- a/src/utils/useNavigation.test.js
+++ b/src/utils/useNavigation.test.js
@@ -221,7 +221,7 @@ describe('useNavigation', () => {
           },
           {
             expandable: true,
-            routes: [
+            navItems: [
               {
                 href: '/baz',
               },
@@ -310,7 +310,7 @@ describe('useNavigation', () => {
       const navItem = {
         expandable: true,
         title: 'bar',
-        routes: [
+        navItems: [
           {
             href: '/insights/dashboard',
           },
@@ -351,7 +351,7 @@ describe('useNavigation', () => {
             {
               expandable: true,
               title: 'bar',
-              routes: [
+              navItems: [
                 {
                   href: '/insights/dashboard',
                   active: true,

--- a/src/utils/useNavigation.ts
+++ b/src/utils/useNavigation.ts
@@ -16,7 +16,7 @@ function cleanNavItemsHref(navItem: NavItem) {
   }
 
   if (result.expandable === true) {
-    result.routes = result.routes?.map(cleanNavItemsHref);
+    result.navItems = result.navItems?.map(cleanNavItemsHref);
   }
 
   if (typeof result.href === 'string') {


### PR DESCRIPTION
## Summary

- Removes `routes` from `NavItem` type — the FEO `bundles-generated.json` uses `navItems` for expandable section children, not `routes`
- Updates all navigation components and utilities to read `navItems` as the single canonical field for children (groups and expandables)
- Fixes crash on `/ansible/ansible-dashboard/trial` where `ChromeNavExpandable` read `routes.length` on `undefined`
- Merges the separate group/expandable evaluation branches in `evaluateVisibility` — both targeted `navItems` after the rename, causing double-evaluation
- Tightens `handleBundleResponse` guards from `typeof expandable !== 'undefined'` to `expandable === true`

### Root cause

The FEO data format uses `navItems` for children on all items (groups AND expandables). The old codebase used `routes` for expandable items. After PR #3600 unified everything on FEO data, components still expected `routes` — which is `undefined` in FEO data.

### Files changed (18)

Type, components, utilities, fixtures, and tests — all `routes` → `navItems` for NavItem children.

## Test plan

- [x] `npm test` — 81 suites, 725 tests pass
- [x] `npx tsc --noEmit` — zero errors
- [ ] Navigate to `/ansible/ansible-dashboard/trial` — no crash
- [ ] Sidebar navigation renders expandable sections correctly
- [ ] All Services dropdown shows correct items
- [ ] All Services page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized nested navigation handling for expandable menus using the `navItems` shape.
  * Updated link discovery, activation propagation, visibility filtering, and title-based search to work consistently with nested `navItems`.
  * Added navigation normalization so bundle/navigation data reliably supports nested structures.
  * Improved behavior when expandable menu entries are empty or missing to avoid incorrect rendering.
* **Tests**
  * Updated and expanded unit/integration coverage for nested expandable menus, filtering, visibility evaluation, link generation, and active-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->