### PR TITLE
fix: Potential fix for kessel v2 users in notifications

### DIFF
--- a/src/utils/VisibilitySingleton.test.ts
+++ b/src/utils/VisibilitySingleton.test.ts
@@ -316,18 +316,33 @@ describe('VisibilitySingleton', () => {
   });
 
   describe('loosePermissionsKessel', () => {
+    const mockWorkspaceId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
     beforeEach(() => {
       getUser.mockImplementation(() => Promise.resolve(userMock));
       mockedAxios.post.mockReset();
+      mockedAxios.get.mockReset();
+      mockedAxios.get.mockResolvedValue({ data: { data: [{ id: mockWorkspaceId }] } });
+      // Re-initialize to reset the workspace cache
+      initializeVisibilityFunctions({ getUser, getToken, getUserPermissions, isPreview: false });
+      visibilityFunctions = getVisibilityFunctions();
     });
 
-    test('should return false if org_id is missing', async () => {
-      getUser.mockImplementationOnce(() =>
-        Promise.resolve({
-          ...userMock,
-          identity: { ...userMock.identity, org_id: undefined },
-        })
-      );
+    test('should return false if workspace fetch fails', async () => {
+      mockedAxios.get.mockReset();
+      mockedAxios.get.mockRejectedValueOnce(new Error('Workspace fetch failed'));
+      initializeVisibilityFunctions({ getUser, getToken, getUserPermissions, isPreview: false });
+      visibilityFunctions = getVisibilityFunctions();
+      const result = await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
+      expect(result).toBe(false);
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    test('should return false if workspace returns empty data', async () => {
+      mockedAxios.get.mockReset();
+      mockedAxios.get.mockResolvedValueOnce({ data: { data: [] } });
+      initializeVisibilityFunctions({ getUser, getToken, getUserPermissions, isPreview: false });
+      visibilityFunctions = getVisibilityFunctions();
       const result = await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
       expect(result).toBe(false);
       expect(mockedAxios.post).not.toHaveBeenCalled();
@@ -343,10 +358,11 @@ describe('VisibilitySingleton', () => {
       mockedAxios.post.mockResolvedValueOnce({ data: { allowed: 'ALLOWED_TRUE' } });
       const result = await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
       expect(result).toBe(true);
+      expect(mockedAxios.get).toHaveBeenCalledWith('/api/rbac/v2/workspaces/', { params: { type: 'default' } });
       expect(mockedAxios.post).toHaveBeenCalledWith(
         '/api/kessel/v1beta2/checkself',
         expect.objectContaining({
-          object: { resourceId: 'redhat/123', resourceType: 'tenant', reporter: { type: 'rbac' } },
+          object: { resourceId: mockWorkspaceId, resourceType: 'workspace', reporter: { type: 'rbac' } },
           relation: 'rbac_roles_read',
         })
       );
@@ -407,6 +423,29 @@ describe('VisibilitySingleton', () => {
       mockedAxios.post.mockRejectedValueOnce(new Error('Network Error'));
       const result = await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
       expect(result).toBe(false);
+    });
+
+    test('should retry workspace fetch after a failure', async () => {
+      mockedAxios.get.mockReset();
+      mockedAxios.get.mockRejectedValueOnce(new Error('Workspace fetch failed'));
+      initializeVisibilityFunctions({ getUser, getToken, getUserPermissions, isPreview: false });
+      visibilityFunctions = getVisibilityFunctions();
+
+      const result1 = await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
+      expect(result1).toBe(false);
+
+      mockedAxios.get.mockResolvedValueOnce({ data: { data: [{ id: mockWorkspaceId }] } });
+      mockedAxios.post.mockResolvedValueOnce({ data: { allowed: 'ALLOWED_TRUE' } });
+      const result2 = await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
+      expect(result2).toBe(true);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    });
+
+    test('should cache workspace ID across multiple calls', async () => {
+      mockedAxios.post.mockResolvedValue({ data: { allowed: 'ALLOWED_TRUE' } });
+      await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
+      await visibilityFunctions.loosePermissionsKessel(['rbac_groups_read']);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/utils/VisibilitySingleton.ts
+++ b/src/utils/VisibilitySingleton.ts
@@ -7,6 +7,21 @@ import get from 'lodash/get';
 import { getSharedScope, initSharedScope } from '@scalprum/core';
 import { getFeatureFlagsError, getUnleashClient } from '../components/FeatureFlags/unleashClient';
 
+let workspacePromise: Promise<string | null> | null = null;
+
+async function getDefaultWorkspaceId(): Promise<string | null> {
+  if (!workspacePromise) {
+    workspacePromise = axios
+      .get('/api/rbac/v2/workspaces/', { params: { type: 'default' } })
+      .then((res) => res.data?.data?.[0]?.id ?? null)
+      .catch(() => {
+        workspacePromise = null;
+        return null;
+      });
+  }
+  return workspacePromise;
+}
+
 const matcherMapper = {
   isEmpty,
   isNotEmpty: (value: any) => !isEmpty(value),
@@ -60,6 +75,8 @@ const initialize = ({
   getUserPermissions: ChromeAPI['getUserPermissions'];
   isPreview: boolean;
 }) => {
+  workspacePromise = null;
+
   /**
    * Check if is permitted to see navigation link
    * @param {array} permissions array checked user permissions
@@ -127,7 +144,7 @@ const initialize = ({
     },
     loosePermissions: (permissions: string[]) => checkPermissions(permissions, 'some'),
     /**
-     * Check Kessel tenant-scoped permissions. Takes an array of Kessel relation
+     * Check Kessel workspace-scoped permissions. Takes an array of Kessel relation
      * strings and returns true if the user has at least one (OR logic).
      * The caller's frontend.yaml provides native Kessel relation names.
      */
@@ -137,15 +154,14 @@ const initialize = ({
           return false;
         }
 
-        const data = await getUser();
-        const orgId = data?.identity?.org_id;
-        if (!orgId) {
+        const workspaceId = await getDefaultWorkspaceId();
+        if (!workspaceId) {
           return false;
         }
 
         const resource = {
-          resourceId: `redhat/${orgId}`,
-          resourceType: 'tenant',
+          resourceId: workspaceId,
+          resourceType: 'workspace',
           reporter: { type: 'rbac' },
         };
         const dedupedRelations = [...new Set(relations)];


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->
A potential fix for the notifications nav items not appearing for v2 users, as suggested by claude.

[RHCLOUD-49445](https://issues.redhat.com/browse/RHCLOUD-49445)

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:


#### After:


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission checks by switching to the default workspace context.
  * Permission checks now fail safely when workspace information can’t be resolved.
  * Added caching to reduce repeated workspace lookups.

* **Tests**
  * Updated and expanded failure-path and retry/caching coverage for workspace-scoped permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHCLOUD-49445]: https://redhat.atlassian.net/browse/RHCLOUD-49445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ