### PR TITLE
fix(header): remove dropdown carets from Settings and Help toolbar buttons

### DIFF
--- a/src/components/Header/SettingsToggle.tsx
+++ b/src/components/Header/SettingsToggle.tsx
@@ -83,7 +83,7 @@ const SettingsToggle = (props: SettingsToggleProps) => {
         <MenuToggle
           ref={toggleRef}
           variant="default"
-          className={props.className}
+          className={['chr-c-settings-toggle', props.className].filter(Boolean).join(' ')}
           id={props.id?.toString()}
           onClick={() => setIsOpen((prev) => !prev)}
           aria-label={props.ariaLabel}

--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -12,3 +12,19 @@
   --pf-v6-c-button--m-primary--m-display-lg--Gap: 0.25rem;
   --pf-v6-c-button--Gap: 0.25rem;
 }
+
+// PF6 MenuToggle has no prop to suppress the caret without variant="plain" (which removes button styling).
+.tooltip-button-settings-cy {
+  justify-content: center;
+
+  .pf-v6-c-menu-toggle__controls {
+    display: none;
+  }
+}
+
+.chr-c-help-panel-toggle,
+.tooltip-button-help-cy {
+  .pf-v6-c-menu-toggle__toggle-icon {
+    display: none;
+  }
+}

--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -14,16 +14,13 @@
 }
 
 // PF6 MenuToggle has no prop to suppress the caret without variant="plain" (which removes button styling).
-.chr-c-settings-toggle {
-  justify-content: center;
-
+.chr-c-settings-toggle,
+.chr-c-help-toggle {
   .pf-v6-c-menu-toggle__controls {
     display: none;
   }
 }
 
-.chr-c-help-toggle {
-  .pf-v6-c-menu-toggle__toggle-icon {
-    display: none;
-  }
+.chr-c-settings-toggle {
+  justify-content: center;
 }

--- a/src/components/Header/Tools.scss
+++ b/src/components/Header/Tools.scss
@@ -14,7 +14,7 @@
 }
 
 // PF6 MenuToggle has no prop to suppress the caret without variant="plain" (which removes button styling).
-.tooltip-button-settings-cy {
+.chr-c-settings-toggle {
   justify-content: center;
 
   .pf-v6-c-menu-toggle__controls {
@@ -22,8 +22,7 @@
   }
 }
 
-.chr-c-help-panel-toggle,
-.tooltip-button-help-cy {
+.chr-c-help-toggle {
   .pf-v6-c-menu-toggle__toggle-icon {
     display: none;
   }

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -447,7 +447,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
           aria-label="Toggle help panel"
           onClick={handleToggle}
           isExpanded={isHelpPanelOpen}
-          className="tooltip-button-help-cy chr-c-help-panel-toggle"
+          className="tooltip-button-help-cy chr-c-help-panel-toggle chr-c-help-toggle"
         >
           Help
         </MenuToggle>
@@ -466,7 +466,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
         ariaLabel="Help menu"
         hasToggleIndicator={null}
         dropdownItems={aboutMenuDropdownItems}
-        className="tooltip-button-help-cy"
+        className="tooltip-button-help-cy chr-c-help-toggle"
       />
     </Tooltip>
   );


### PR DESCRIPTION


### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->
Settings cog and help buttons in navigation bar were rendering a carat when they shouldn't suddenly. Digging into this PatternFly 6 (MenuToggle) doesn't have a way to keep the styling of the button without having the carat, so just used plain css to override and left a comment about it so we can get rid once there's a sufficient prop. 

[RHCLOUD-49284](https://issues.redhat.com/browse/RHCLOUD-49284)

---
### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:
<img width="717" height="172" alt="Screenshot 2026-07-16 at 11 14 29 AM" src="https://github.com/user-attachments/assets/3e9588e2-9b08-4271-8cbb-2318954e6ee9" />

#### After:
<img width="575" height="164" alt="Screenshot 2026-07-16 at 11 15 02 AM" src="https://github.com/user-attachments/assets/a11ee07f-1af9-4db3-841c-f15b9a91b3a6" />

---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

There is no prop to remove the carat in MenuToggle, so that's why I used plain css here for now
---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-49284]: https://redhat.atlassian.net/browse/RHCLOUD-49284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved header toolbar toggle alignment and centered the settings control.
  * Refined the settings menu toggle appearance by hiding unnecessary controls.
  * Updated the Help toggle styling for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->