### PR TITLE
chore: reorder settings menu sections above theme toggle in toolbar

### DIFF
--- a/playwright/e2e/release-gate/favorite-services.spec.ts
+++ b/playwright/e2e/release-gate/favorite-services.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from '../../setup/test-setup';
 
 test.describe('Favorite Services (E2E User Flow)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    page.on('load', async () => {
+      await page.evaluate(() => document.getElementById('webpack-dev-server-client-overlay')?.remove()).catch(() => {});
+    });
   });
 
   test('should favorite on the page and unfavorite from the header dropdown', async ({ page }) => {

--- a/src/components/Header/HeaderTests/Tools.test.js
+++ b/src/components/Header/HeaderTests/Tools.test.js
@@ -179,8 +179,8 @@ describe('Tools', () => {
         settingsButton.click();
       });
 
-      // Check that the link with correct href exists (note: "Acess" is a typo in the source code)
-      const iamLink = screen.getByRole('link', { name: /Acess management/i });
+      // Check that the link with correct href exists
+      const iamLink = screen.getByRole('link', { name: /Access management/i });
       expect(iamLink).toBeInTheDocument();
       expect(iamLink).toHaveAttribute('href', '/iam/overview');
     });

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -176,7 +176,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
         {
           ouiaId: 'UserAccess',
           url: identityAndAccessManagmentPath,
-          title: isOrgAdmin ? (workspacesEnabled ? 'Acess management' : 'User Access') : 'My User Access',
+          title: isOrgAdmin ? (workspacesEnabled ? 'Access management' : 'User Access') : 'My User Access',
           description: workspacesEnabled ? (
             <Label status="custom" color="teal" variant="outline" icon={<UsersIcon />} isCompact>
               Workspaces model available

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -145,6 +145,65 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ],
     },
     {
+      title: 'Settings',
+      items: [
+        {
+          ouiaId: 'settings-menu-integrations',
+          url: '/settings/integrations',
+          title: 'Integrations',
+          isHidden: isITLessEnv,
+        },
+        {
+          ouiaId: 'settings-menu-notifications',
+          url: '/settings/notifications',
+          title: 'Notifications',
+        },
+        {
+          ouiaId: 'settings-menu-scheduler',
+          title: 'Scheduler',
+          isHidden: !schedulerDrawerEnabled,
+          onClick: () =>
+            toggleDrawerContent({
+              scope: 'schedulerUi',
+              module: './SchedulerPanelContent',
+            }),
+        },
+      ],
+    },
+    {
+      title: 'Identity and Access Management',
+      items: [
+        {
+          ouiaId: 'UserAccess',
+          url: identityAndAccessManagmentPath,
+          title: isOrgAdmin ? (workspacesEnabled ? 'Acess management' : 'User Access') : 'My User Access',
+          description: workspacesEnabled ? (
+            <Label status="custom" color="teal" variant="outline" icon={<UsersIcon />} isCompact>
+              Workspaces model available
+            </Label>
+          ) : null,
+        },
+        {
+          ouiaId: 'settings-menu-identity-provider',
+          url: '/iam/authentication-policy/identity-provider-integration',
+          title: 'Identity Provider Integration',
+          isHidden: isITLessEnv,
+        },
+        {
+          ouiaId: 'settings-menu-auth-factors',
+          url: '/iam/authentication-policy/authentication-factors',
+          title: 'Authentication Factors',
+          isHidden: isITLessEnv,
+        },
+        {
+          ouiaId: 'settings-menu-service-accounts',
+          url: '/iam/service-accounts',
+          title: 'Service Accounts',
+          isHidden: isITLessEnv,
+        },
+      ],
+    },
+    {
       title: intl.formatMessage(messages.theme),
       isHidden: !isFeltThemeEnabled,
       customContent: (
@@ -240,65 +299,6 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
           )}
         </ToggleGroup>
       ),
-    },
-    {
-      title: 'Settings',
-      items: [
-        {
-          ouiaId: 'settings-menu-integrations',
-          url: '/settings/integrations',
-          title: 'Integrations',
-          isHidden: isITLessEnv,
-        },
-        {
-          ouiaId: 'settings-menu-notifications',
-          url: '/settings/notifications',
-          title: 'Notifications',
-        },
-        {
-          ouiaId: 'settings-menu-scheduler',
-          title: 'Scheduler',
-          isHidden: !schedulerDrawerEnabled,
-          onClick: () =>
-            toggleDrawerContent({
-              scope: 'schedulerUi',
-              module: './SchedulerPanelContent',
-            }),
-        },
-      ],
-    },
-    {
-      title: 'Identity and Access Management',
-      items: [
-        {
-          ouiaId: 'UserAccess',
-          url: identityAndAccessManagmentPath,
-          title: isOrgAdmin ? (workspacesEnabled ? 'Acess management' : 'User Access') : 'My User Access',
-          description: workspacesEnabled ? (
-            <Label status="custom" color="teal" variant="outline" icon={<UsersIcon />} isCompact>
-              Workspaces model available
-            </Label>
-          ) : null,
-        },
-        {
-          ouiaId: 'settings-menu-identity-provider',
-          url: '/iam/authentication-policy/identity-provider-integration',
-          title: 'Identity Provider Integration',
-          isHidden: isITLessEnv,
-        },
-        {
-          ouiaId: 'settings-menu-auth-factors',
-          url: '/iam/authentication-policy/authentication-factors',
-          title: 'Authentication Factors',
-          isHidden: isITLessEnv,
-        },
-        {
-          ouiaId: 'settings-menu-service-accounts',
-          url: '/iam/service-accounts',
-          title: 'Service Accounts',
-          isHidden: isITLessEnv,
-        },
-      ],
     },
   ];
 


### PR DESCRIPTION
### Description

  Reorder settings menu sections in the header toolbar so that Settings and Identity and Access Management appear above the theme toggle, instead of below it. This improves discoverability of these frequently used sections.

  Also fixes the favorite-services Playwright e2e test + fix typo "Acess" -> "Access"

  Changes:
  - src/components/Header/Tools.tsx — moved "Settings" and "Identity and Access Management" sections above the theme toggle in the toolbar menu
  - playwright/e2e/release-gate/favorite-services.spec.ts — updated serviceToTest and quickstartIdSelector to match the renamed service

<img width="355" height="651" alt="Screenshot 2026-07-21 at 14 07 06" src="https://github.com/user-attachments/assets/7bbbf8fb-05eb-4e11-b731-327a5f1f3ad9" />


[RHCLOUD-49466](https://redhat.atlassian.net/browse/RHCLOUD-49466)


[RHCLOUD-49466]: https://redhat.atlassian.net/browse/RHCLOUD-49466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Updated the settings menu layout so **Settings** and **Identity and Access Management** appear earlier, making administrative options easier to find.
  * Corrected the “Access management” title spelling and removed duplicate dropdown entries while keeping existing behavior intact (including the scheduler drawer action).
* **Tests**
  * Improved the Favorite Services end-to-end flow by suppressing the development overlay during page loads, without changing the test’s favorite/unfavorite checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->