### PR TITLE
fix(lightwell): Update branding for Lightwell (CPUX-6724)

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -102,12 +102,12 @@ describe('Header Lightwell mode', () => {
   it('should render AllServicesDropdown with "Red Hat Hybrid Cloud Console" when not in Lightwell mode', () => {
     renderHeader(false);
     expect(screen.getByText('Red Hat Hybrid Cloud Console')).toBeTruthy();
-    expect(screen.queryByText('Red Hat Lightwell')).toBeFalsy();
+    expect(screen.queryByText('Lightwell')).toBeFalsy();
   });
 
-  it('should render "Red Hat Lightwell" text instead of AllServicesDropdown when in Lightwell mode', () => {
+  it('should render "Lightwell" text instead of AllServicesDropdown when in Lightwell mode', () => {
     renderHeader(true);
-    expect(screen.getByText('Red Hat Lightwell')).toBeTruthy();
+    expect(screen.getByText('Lightwell')).toBeTruthy();
     expect(screen.queryByText('Red Hat Hybrid Cloud Console')).toBeFalsy();
   });
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -79,7 +79,7 @@ const MemoizedHeader = memo(
               <Logo theme={theme} />
             </MastheadLogo>
             {isLightwellHeader ? (
-              <span className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-pl-sm">Red Hat Lightwell</span>
+              <span className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-pl-sm">Lightwell</span>
             ) : (
               !(!md && searchOpen) && <AllServicesDropdown />
             )}

--- a/src/state/atoms/releaseAtom.ts
+++ b/src/state/atoms/releaseAtom.ts
@@ -82,7 +82,7 @@ export const layoutForceFeltThemeAtom = atom(isLightwellPath);
 
 /**
  * Atom for layouts to signal a simplified header for Lightwell.
- * When true, the AllServicesDropdown is replaced with a static "Red Hat Lightwell"
+ * When true, the AllServicesDropdown is replaced with a static "Lightwell"
  * header and the Search input is hidden.
  */
 export const layoutLightwellHeaderAtom = atom(false);


### PR DESCRIPTION
### Description
According to the brand rules, we need to omit "Red Hat" for the product name in this case.

Here's the UX verdict on the subject: https://redhat.atlassian.net/browse/CPUX-6724?focusedCommentId=17703347

---

### Screenshots
<img width="1306" height="1038" alt="image" src="https://github.com/user-attachments/assets/c7fcedfe-cb02-44ba-8a4b-5f8515280349" />


#### Before:
"Red Hat Lightwell"

#### After:
"Lightwell"

---

### Anything reviewers should know?
This was requested by UX and can be acked by Andy.

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Updated the Lightwell header to display “Lightwell” instead of “Red Hat Lightwell.”
* **Tests**
  * Updated header validation to reflect the revised Lightwell label and ensure the standard console title remains hidden in Lightwell mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->