### PR TITLE
feat: expose isITLess as a navigation visibility function

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -33,6 +33,7 @@ List of available permissions methods:
     * `isEmpty` uses [lodash isEmpty](https://lodash.com/docs/4.17.15#isEmpty) to evaluate api response.
     * `isNotEmpty` is a negation of `isEmpty`
 * `featureFlag` - test if feature flag name is enabled. First argument is name of the featureFlag and second is the expected value (`true` or `false`)
+* `isITLess` - test if current environment is ITLess (FedRAMP/Commercial). First argument is the expected value (`true` or `false`)
 
 #### apiRequest example
 

--- a/src/utils/VisibilitySingleton.test.ts
+++ b/src/utils/VisibilitySingleton.test.ts
@@ -5,6 +5,8 @@ import axios from 'axios';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+import * as common from './common';
+
 jest.mock('@scalprum/core', () => {
   return {
     __esModule: true,
@@ -407,6 +409,34 @@ describe('VisibilitySingleton', () => {
       mockedAxios.post.mockRejectedValueOnce(new Error('Network Error'));
       const result = await visibilityFunctions.loosePermissionsKessel(['rbac_roles_read']);
       expect(result).toBe(false);
+    });
+  });
+
+  describe('isITLess', () => {
+    let itLessSpy: jest.SpyInstance;
+
+    afterEach(() => {
+      itLessSpy?.mockRestore();
+    });
+
+    test('should return true when expected=true and environment is ITLess', () => {
+      itLessSpy = jest.spyOn(common, 'ITLess').mockReturnValue(true);
+      expect(visibilityFunctions.isITLess(true)).toBe(true);
+    });
+
+    test('should return false when expected=false and environment is ITLess', () => {
+      itLessSpy = jest.spyOn(common, 'ITLess').mockReturnValue(true);
+      expect(visibilityFunctions.isITLess(false)).toBe(false);
+    });
+
+    test('should return true when expected=false and environment is not ITLess', () => {
+      itLessSpy = jest.spyOn(common, 'ITLess').mockReturnValue(false);
+      expect(visibilityFunctions.isITLess(false)).toBe(true);
+    });
+
+    test('should return false when expected=true and environment is not ITLess', () => {
+      itLessSpy = jest.spyOn(common, 'ITLess').mockReturnValue(false);
+      expect(visibilityFunctions.isITLess(true)).toBe(false);
     });
   });
 });

--- a/src/utils/VisibilitySingleton.ts
+++ b/src/utils/VisibilitySingleton.ts
@@ -1,5 +1,5 @@
 import { ChromeAPI } from '@redhat-cloud-services/types';
-import { LOGIN_SCOPES_STORAGE_KEY, isProd } from './common';
+import { LOGIN_SCOPES_STORAGE_KEY, isProd, ITLess } from './common';
 import cookie from 'js-cookie';
 import axios, { AxiosRequestConfig } from 'axios';
 import isEmpty from 'lodash/isEmpty';
@@ -212,6 +212,7 @@ const initialize = ({
         return false;
       }
     },
+    isITLess: (expected: boolean) => ITLess() === expected,
   };
 
   // in order to properly distribute the module, it has be added to the webpack share scope to avoid reference issues if these functions are called from chrome shared modules


### PR DESCRIPTION
## Summary
- Exposes the existing `ITLess()` utility from `common.ts` as an `isITLess` navigation visibility function in `VisibilitySingleton.ts`
- Accepts a boolean argument so nav items can gate on `isITLess(true)` (FedRAMP only) or `isITLess(false)` (commercial only)
- Adds tests and documents the new method in `docs/navigation.md`

## Motivation
Apps like notifications-frontend need to use different permission methods depending on environment:
- FedRAMP/Commercial (ITLess): `loosePermissions` (v1 RBAC)
- Regular cloud: `loosePermissionsKessel` (v2 Kessel)

Without `isITLess` as a visibility function, there's no way to discriminate in `frontend.yaml`.

## Usage in frontend.yaml
```yaml
# Only visible on regular cloud (not FedRAMP)
- id: configureEvents-v2
  title: Configure Events
  href: '/settings/notifications/configure-events'
  permissions:
    - method: loosePermissionsKessel
      args:
        - - notifications_notifications_view
    - method: isITLess
      args:
        - - false

# Only visible on FedRAMP
- id: configureEvents-v1
  title: Configure Events
  href: '/settings/notifications/configure-events'
  permissions:
    - method: loosePermissions
      args:
        - - notifications:*:*
    - method: isITLess
      args:
        - - true
```

## Test plan
- [x] Unit tests for all four combinations (ITLess true/false × expected true/false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `isITLess` permission helper for dynamic navigation to control visibility based on whether the environment is ITLess.

* **Documentation**
  * Updated navigation documentation to include `isITLess` and clarify it takes an expected boolean value.

* **Tests**
  * Added test coverage for `isITLess` across ITLess vs non-ITLess scenarios and both expected values, using a controlled environment check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->