### PR TITLE
Use PF6 native props in All Services dropdown and remove scss overrides

### DIFF
--- a/cypress/component/AllServicesDropdown/AllServicesTabs.cy.tsx
+++ b/cypress/component/AllServicesDropdown/AllServicesTabs.cy.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider as JotaiProvider, createStore } from 'jotai';
+import ChromeAuthContext from '../../../src/auth/ChromeAuthContext';
+import { FeatureFlagsProvider } from '../../../src/components/FeatureFlags';
+import AllServicesTabs from '../../../src/components/AllServicesDropdown/AllServicesTabs';
+import { isPreviewAtom } from '../../../src/state/atoms/releaseAtom';
+import { FAVORITE_TAB_ID } from '../../../src/components/AllServicesDropdown/common';
+import type { AllServicesSection } from '../../../src/components/AllServices/allServicesLinks';
+
+// Must exceed the component's 300ms hover-to-activate delay.
+const HOVER_SETTLE_MS = 400;
+
+const mockLinkSections: AllServicesSection[] = [
+  {
+    id: 'openshift',
+    title: 'OpenShift',
+    description: 'OpenShift platform services',
+    links: [],
+  },
+];
+
+const favTab = () => cy.get('[role="tab"]').contains('My Favorite services');
+
+const mountTabs = (previewMode: boolean) => {
+  const handleTabClick = cy.stub().as('handleTabClick');
+  const store = createStore();
+  store.set(isPreviewAtom, previewMode);
+
+  cy.mount(
+    // @ts-expect-error ChromeAuthContext.Provider value is intentionally partial in tests
+    <ChromeAuthContext.Provider value={{ user: { identity: { user: {}, internal: {} } } }}>
+      <MemoryRouter>
+        <JotaiProvider store={store}>
+          <FeatureFlagsProvider>
+            <AllServicesTabs
+              activeTabKey={FAVORITE_TAB_ID}
+              handleTabClick={handleTabClick}
+              isExpanded={false}
+              onToggle={() => {}}
+              linkSections={mockLinkSections}
+              tabContentRef={React.createRef()}
+              onTabClick={() => {}}
+              activeTabTitle="Favorites"
+              setIsExpanded={() => {}}
+            />
+          </FeatureFlagsProvider>
+        </JotaiProvider>
+      </MemoryRouter>
+    </ChromeAuthContext.Provider>
+  );
+};
+
+describe('<AllServicesTabs />', () => {
+  describe('TabWrapper hover behavior', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/featureflags/*', { toggles: [] });
+      cy.intercept('POST', '/api/chrome-service/v1/user/update-ui-preview', {});
+    });
+
+    it('should activate the tab when hovered for 300ms in preview mode', () => {
+      mountTabs(true);
+
+      favTab().trigger('mouseover', { force: true });
+
+      cy.get('@handleTabClick').should('have.been.called');
+    });
+
+    it('should not activate the tab when hovered outside preview mode', () => {
+      mountTabs(false);
+
+      favTab().trigger('mouseover', { force: true });
+      cy.wait(HOVER_SETTLE_MS);
+
+      cy.get('@handleTabClick').should('not.have.been.called');
+    });
+
+    it('should cancel activation when mouse leaves before 300ms', () => {
+      mountTabs(true);
+
+      favTab().trigger('mouseover', { force: true });
+      favTab().trigger('mouseout', { force: true });
+      cy.wait(HOVER_SETTLE_MS);
+
+      cy.get('@handleTabClick').should('not.have.been.called');
+    });
+  });
+});

--- a/src/components/AllServicesDropdown/AllServicesDropdown.scss
+++ b/src/components/AllServicesDropdown/AllServicesDropdown.scss
@@ -14,15 +14,6 @@
   max-width: 240px;
   // Ensure it doesn't shrink too much
   flex-shrink: 0;
-
-  // override menu toggle extra bottom border
-  &.pf-v6-c-menu-toggle::after {
-    border-bottom: none;
-  }
-  &.pf-v6-c-menu-toggle:hover::after,
-  &.pf-m-expanded::after {
-    border-bottom: var(--pf-t--global--border--width--extra-strong) solid var(--pf-t--global--border--color--status--info--default);
-  }
 }
 
 .platform-icon {
@@ -60,11 +51,6 @@
   // To not cover the entire screen including masthead
   .pf-v6-c-backdrop {
     position: relative;
-    background-color: rgba(21, 21, 21, 0.0)
-  }
-
-  .pf-v6-c-tabs__list::before {
-    border-left:none !important;
   }
 }
 
@@ -95,7 +81,7 @@
   .chr-c-panel-services-nav {
     margin-left: 25px;
     margin-right: 25px;
-    border-radius: 18px;
+    overflow: hidden;
     .chr-l-stack__item-browse-all-services {
       border-bottom: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--on-secondary);
     }
@@ -105,25 +91,17 @@
         height: 820px;
       }
       &__content {
-        border-bottom-right-radius: 16px;
-        border-top-right-radius: 16px;
         height: 820px;
         overflow: auto;
       }
       &__panel {
-        border-bottom-left-radius: 18px;
-        border-top-left-radius: 18px;
-        border-right: 1px solid var(--pf-t--global--border--color--default);
         flex-basis: 500px;
         height: 820px;
-        .pf-v6-c-tabs {
-          --pf-v6-c-tabs__item--m-current__link--after--BorderColor: transparent;
-          --pf-v6-c-tabs--m-vertical__link--PaddingTop: var(--pf-t--global--spacer--sm);
-          --pf-v6-c-tabs--m-vertical__link--PaddingBottom: var(--pf-t--global--spacer--sm);
-          --pf-v6-c-tabs__link--PaddingRight: var(--pf-t--global--spacer--md);
-          --pf-v6-c-tabs__link--PaddingLeft: var(--pf-t--global--spacer--md);
-          --pf-v6-c-tabs__item--m-current__link--Color: var(--pf-t--global--text--color--link--default);
-          --pf-v6-c-tabs--m-vertical--MaxWidth: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
+        &:focus-visible {
+          outline: var(--pf-t--global--border--width--focus--default) solid var(--pf-t--global--color--brand--default);
+          outline-offset: -2px;
         }
         .pf-v6-c-tabs__item-text {
           flex-grow: 1;

--- a/src/components/AllServicesDropdown/AllServicesDropdown.tsx
+++ b/src/components/AllServicesDropdown/AllServicesDropdown.tsx
@@ -75,6 +75,7 @@ const AllServicesDropdown = () => {
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
+      isFullHeight
     >
       <ThIcon className="pf-v6-u-mr-sm" />
       Red Hat Hybrid Cloud Console

--- a/src/components/AllServicesDropdown/AllServicesMenu.tsx
+++ b/src/components/AllServicesDropdown/AllServicesMenu.tsx
@@ -3,7 +3,6 @@ import { Backdrop } from '@patternfly/react-core/dist/dynamic/components/Backdro
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { Card, CardBody, CardHeader } from '@patternfly/react-core/dist/dynamic/components/Card';
 import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider';
-import { Stack, StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import { Panel, PanelMain } from '@patternfly/react-core/dist/dynamic/components/Panel';
 import { Sidebar, SidebarContent, SidebarPanel } from '@patternfly/react-core/dist/dynamic/components/Sidebar';
 import { TabContent } from '@patternfly/react-core/dist/dynamic/components/Tabs';
@@ -79,25 +78,21 @@ const AllServicesMenu = ({ setIsOpen, isOpen, menuRef, linkSections, favoritedSe
         onClick={handleClickOutside}
       >
         <Backdrop>
-          <Panel variant="raised" className="pf-v6-u-p-0 chr-c-panel-services-nav" ref={panelRef}>
+          <Panel variant="raised" isGlass className="pf-v6-u-p-0 chr-c-panel-services-nav" ref={panelRef}>
             <PanelMain>
-              <Sidebar>
-                <SidebarPanel>
-                  <Stack>
-                    <StackItem className="pf-v6-u-w-100">
-                      <AllServicesTabs
-                        activeTabKey={activeTabKey}
-                        handleTabClick={handleTabClick}
-                        isExpanded={isExpanded}
-                        onToggle={onToggle}
-                        linkSections={linkSections}
-                        tabContentRef={tabContentRef}
-                        onTabClick={onTabClick}
-                        activeTabTitle={activeTabKey === FAVORITE_TAB_ID ? 'Favorites' : selectedService.title}
-                        setIsExpanded={setIsOpen}
-                      />
-                    </StackItem>
-                  </Stack>
+              <Sidebar hasBorder>
+                <SidebarPanel backgroundVariant="secondary" tabIndex={0} role="region" aria-label="Service categories">
+                  <AllServicesTabs
+                    activeTabKey={activeTabKey}
+                    handleTabClick={handleTabClick}
+                    isExpanded={isExpanded}
+                    onToggle={onToggle}
+                    linkSections={linkSections}
+                    tabContentRef={tabContentRef}
+                    onTabClick={onTabClick}
+                    activeTabTitle={activeTabKey === FAVORITE_TAB_ID ? 'Favorites' : selectedService.title}
+                    setIsExpanded={setIsExpanded}
+                  />
                 </SidebarPanel>
                 <SidebarContent>
                   <Card isPlain>

--- a/src/components/AllServicesDropdown/AllServicesTabs.scss
+++ b/src/components/AllServicesDropdown/AllServicesTabs.scss
@@ -1,13 +1,3 @@
 .pf-v6-c-tabs.pf-m-vertical .pf-v6-c-tabs__list {
   max-width: 100%;
 }
-
-.pf-v6-c-tabs__item.pf-m-current {
-  background: var(--pf-t--global--background--color--secondary--default);
-  .pf-v6-c-tabs__item-text {
-    color: var(--pf-t--global--text--color--regular);
-  }
-  .pf-v6-c-tabs__link {
-    background: none;
-  }
-}

--- a/src/components/AllServicesDropdown/AllServicesTabs.tsx
+++ b/src/components/AllServicesDropdown/AllServicesTabs.tsx
@@ -45,6 +45,7 @@ const TabWrapper = (props: TabWrapper) => {
       // should be available only in preview
       // use refs to supply the required tab events
       if (isPreview) {
+        (document.activeElement as HTMLElement)?.blur();
         tabRef.current?.click();
       }
     }, 300);


### PR DESCRIPTION

### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

[RHCLOUD-49598](https://redhat.atlassian.net/browse/RHCLOUD-49598)

- These changes restore PatternFly's default border and background
  handling in the All Services dropdown panel by removing custom SCSS
  overrides that conflicted with the High Contrast theme, replacing manual
  border-radius/border-right rules with Sidebar hasBorder and overflow: 
  hidden. The dropdown toggle button now uses isFullHeight so its hover
  state spans the full masthead height, and the tab accordion's collapse
  action is scoped correctly to avoid closing the entire dropdown. A tab
  hover interaction bug is also fixed by blurring the previously-focused
  element before the programmatic click fires, preventing stale focus
  rings from appearing alongside the newly activated tab.

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:


https://github.com/user-attachments/assets/825b9a45-9336-4a8b-bed7-7995f70c2b28


#### After:




https://github.com/user-attachments/assets/27209d7e-5c62-48f0-9cae-b9ded32b3010


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-49598]: https://redhat.atlassian.net/browse/RHCLOUD-49598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the All Services menu’s desktop layout, scrolling, focus visibility, and panel boundaries.
  * Fixed tab expansion behavior so it remains independent from opening and closing the overall menu.
  * Improved hover previews by clearing stale focus before switching tabs.
  * Updated full-height toggle behavior and refined visual styling for menus and tabs.
  * Improved hover interactions so previews activate and cancel more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->