### PR TITLE
Lightwell nav update

### DIFF
--- a/src/components/AllServicesDropdown/AllServicesDropdown.tsx
+++ b/src/components/AllServicesDropdown/AllServicesDropdown.tsx
@@ -17,7 +17,11 @@ export type ServicesNewNavProps = {
   Footer?: React.ReactNode;
 };
 
-const AllServicesDropdown = () => {
+export type AllServicesDropdownProps = {
+  iconOnly?: boolean;
+};
+
+const AllServicesDropdown = ({ iconOnly = false }: AllServicesDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -71,13 +75,15 @@ const AllServicesDropdown = () => {
   const toggle = (
     <MenuToggle
       ouiaId="AllServices-DropdownToggle"
-      className="chr-c-link-service-toggle pf-v6-u-pr-sm"
+      className={iconOnly ? undefined : 'chr-c-link-service-toggle pf-v6-u-pr-sm'}
+      variant={iconOnly ? 'plain' : undefined}
+      aria-label={iconOnly ? 'All services' : undefined}
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
     >
-      <ThIcon className="pf-v6-u-mr-sm" />
-      Red Hat Hybrid Cloud Console
+      <ThIcon className={iconOnly ? undefined : 'pf-v6-u-mr-sm'} />
+      {!iconOnly && 'Red Hat Hybrid Cloud Console'}
     </MenuToggle>
   );
 

--- a/src/components/AllServicesDropdown/AllServicesTabs.test.tsx
+++ b/src/components/AllServicesDropdown/AllServicesTabs.test.tsx
@@ -1,0 +1,100 @@
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: () => false,
+}));
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider, createStore } from 'jotai';
+import AllServicesTabs, { AllServicesTabsProps } from './AllServicesTabs';
+import type { AllServicesSection } from '../AllServices/allServicesLinks';
+import { describe, expect, it, jest } from '@jest/globals';
+
+const defaultProps: AllServicesTabsProps = {
+  activeTabKey: 'favorites',
+  handleTabClick: jest.fn(),
+  isExpanded: false,
+  onToggle: jest.fn(),
+  linkSections: [],
+  tabContentRef: React.createRef<HTMLElement>(),
+  onTabClick: jest.fn(),
+  activeTabTitle: 'My Favorite services',
+  setIsExpanded: jest.fn(),
+};
+
+const renderTabs = (props: Partial<AllServicesTabsProps> = {}) => {
+  const store = createStore();
+  return render(
+    <MemoryRouter>
+      <Provider store={store}>
+        <AllServicesTabs {...defaultProps} {...props} />
+      </Provider>
+    </MemoryRouter>
+  );
+};
+
+describe('AllServicesTabs', () => {
+  it('should render the Lightwell section with a link to /lightwell', () => {
+    renderTabs();
+    const link = document.querySelector('[data-ouia-component-id="AllServices-Dropdown-Lightwell"]');
+    expect(link).toBeTruthy();
+    expect(link!.getAttribute('href')).toBe('/lightwell');
+    expect(link!.textContent).toBe('Lightwell');
+  });
+
+  it('should render the Lightwell logomark image', () => {
+    renderTabs();
+    const img = document.querySelector('img[src*="lightwell-logomark"]');
+    expect(img).toBeTruthy();
+    expect(img!.getAttribute('alt')).toBe('');
+    expect(img!.classList.contains('platform-icon')).toBe(true);
+  });
+
+  it('should render the View all services link', () => {
+    renderTabs();
+    const link = document.querySelector('[data-ouia-component-id="View all link"]');
+    expect(link).toBeTruthy();
+    expect(link!.getAttribute('href')).toBe('/allservices');
+  });
+
+  it('should render My Favorite services tab', () => {
+    renderTabs();
+    const favTab = document.querySelector('[data-ouia-component-id="AllServices-favorites-Tab"]');
+    expect(favTab).toBeTruthy();
+  });
+
+  it('should render tabs for each linkSection', () => {
+    const sections: AllServicesSection[] = [
+      { id: 'ai-ml', title: 'AI/ML', links: [] },
+      { id: 'security', title: 'Security', links: [] },
+    ];
+    renderTabs({ linkSections: sections });
+
+    const aiTab = document.querySelector('[data-ouia-component-id="AllServices-ai-ml-Tab"]');
+    const secTab = document.querySelector('[data-ouia-component-id="AllServices-security-Tab"]');
+    expect(aiTab).toBeTruthy();
+    expect(secTab).toBeTruthy();
+  });
+
+  it('should call onTabClick when a section tab is clicked', async () => {
+    const onTabClick = jest.fn();
+    const sections: AllServicesSection[] = [{ id: 'settings', title: 'Settings', links: [] }];
+    renderTabs({ linkSections: sections, onTabClick });
+
+    const tab = document.querySelector('[data-ouia-component-id="AllServices-settings-Tab"]') as HTMLElement;
+    await userEvent.click(tab);
+
+    expect(onTabClick).toHaveBeenCalledWith(sections[0], '0-settings');
+  });
+
+  it('should call setIsExpanded(false) when View all services is clicked', async () => {
+    const setIsExpanded = jest.fn();
+    renderTabs({ setIsExpanded });
+
+    const link = document.querySelector('[data-ouia-component-id="View all link"]') as HTMLElement;
+    await userEvent.click(link);
+
+    expect(setIsExpanded).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/AllServicesDropdown/AllServicesTabs.tsx
+++ b/src/components/AllServicesDropdown/AllServicesTabs.tsx
@@ -10,9 +10,11 @@ import StarIcon from '@patternfly/react-icons/dist/dynamic/icons/star-icon';
 import { FAVORITE_TAB_ID, TAB_CONTENT_ID } from './common';
 import type { AllServicesSection as AllServicesSectionType } from '../AllServices/allServicesLinks';
 import { Content, ContentVariants } from '@patternfly/react-core/dist/dynamic/components/Content';
+import { Split, SplitItem } from '@patternfly/react-core/dist/dynamic/layouts/Split';
 import { Link } from 'react-router-dom';
 import './AllServicesTabs.scss';
 import PlatformServiceslinks from './PlatformServicesLinks';
+import ChromeLink from '../ChromeLink';
 import { isPreviewAtom } from '../../state/atoms/releaseAtom';
 
 export type AllServicesTabsProps = {
@@ -93,6 +95,20 @@ const AllServicesTabs = ({
         Platforms
       </Content>
       <PlatformServiceslinks />
+      <Divider className="pf-v6-u-mt-md" />
+      <Content className="pf-v6-u-pl-lg pf-v6-u-pr-0 pf-v6-u-pt-lg pf-v6-u-mb-md" component={ContentVariants.small}>
+        Lightwell
+      </Content>
+      <Split className="pf-v6-u-px-lg pf-v6-u-mb-0">
+        <SplitItem>
+          <img src="/apps/frontend-assets/partners-icons/lightwell-logomark.svg" alt="" className="platform-icon" />
+        </SplitItem>
+        <SplitItem className="pf-v6-u-pt-xs">
+          <ChromeLink href="/lightwell" data-ouia-component-id="AllServices-Dropdown-Lightwell" className="pf-v6-u-pl-sm chr-m-plain">
+            Lightwell
+          </ChromeLink>
+        </SplitItem>
+      </Split>
       <>
         <Divider className="pf-v6-u-mt-md" />
         <Content className="pf-v6-u-pl-lg pf-v6-u-pr-0 pf-v6-u-pt-lg pf-v6-u-mb-sm pf-v6-u-pb-xs" component={ContentVariants.small}>

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -81,6 +81,13 @@
   display: none;
 }
 
+.chr-c-masthead__lightwell-logo {
+  width: 24px;
+  height: 24px;
+  align-self: center;
+  margin-left: var(--pf-t--global--spacer--sm);
+}
+
 .chr-c-masthead__lightwell-title {
   align-self: center;
   font-family: 'Red Hat Display', 'RedHatDisplay', 'Overpass', overpass, helvetica, arial, sans-serif;

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -39,8 +39,9 @@ import { MemoryRouter } from 'react-router-dom';
 import { Provider, createStore } from 'jotai';
 import { Header } from './Header';
 import { layoutLightwellHeaderAtom } from '../../state/atoms/releaseAtom';
-import ChromeAuthContext from '../../auth/ChromeAuthContext';
+import ChromeAuthContext, { ChromeAuthContextValue } from '../../auth/ChromeAuthContext';
 import InternalChromeContext from '../../utils/internalChromeContext';
+import { ChromeAPI } from '@redhat-cloud-services/types';
 import { describe, expect, it, jest } from '@jest/globals';
 
 const mockUser = {
@@ -66,13 +67,13 @@ const mockAuthContextValue = {
   logout: jest.fn(),
   getUser: jest.fn<() => Promise<typeof mockUser>>().mockResolvedValue(mockUser),
   getToken: jest.fn<() => Promise<string>>().mockResolvedValue('test-token'),
-};
+} as unknown as ChromeAuthContextValue;
 
 const mockInternalChromeContext = {
   drawerActions: {
     toggleDrawerContent: jest.fn(),
   },
-};
+} as unknown as ChromeAPI;
 
 const renderHeader = (lightwellHeader = false) => {
   const store = createStore();
@@ -84,10 +85,8 @@ const renderHeader = (lightwellHeader = false) => {
     store,
     ...render(
       <MemoryRouter>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        <ChromeAuthContext.Provider value={mockAuthContextValue as any}>
-          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-          <InternalChromeContext.Provider value={mockInternalChromeContext as any}>
+        <ChromeAuthContext.Provider value={mockAuthContextValue}>
+          <InternalChromeContext.Provider value={mockInternalChromeContext}>
             <Provider store={store}>
               <Header />
             </Provider>
@@ -128,9 +127,9 @@ describe('Header Lightwell mode', () => {
     expect(logoLink.getAttribute('href')).toBe('/');
   });
 
-  it('should render masthead logo without a link when in Lightwell mode', () => {
+  it('should not render masthead logo when in Lightwell mode', () => {
     renderHeader(true);
-    const logoLinks = screen.queryAllByRole('link', { name: /logo/i });
-    expect(logoLinks.length).toBe(0);
+    const logo = screen.queryByAltText('Red Hat Logo');
+    expect(logo).toBeFalsy();
   });
 });

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -110,6 +110,15 @@ describe('Header Lightwell mode', () => {
     expect(screen.queryByText('Red Hat Hybrid Cloud Console')).toBeFalsy();
   });
 
+  it('should render AllServicesDropdown with icon-only toggle when in Lightwell mode', () => {
+    renderHeader(true);
+    const toggle = document.querySelector('[data-ouia-component-id="AllServices-DropdownToggle"]');
+    expect(toggle).toBeTruthy();
+    expect(toggle!.classList.contains('pf-m-plain')).toBe(true);
+    expect(toggle!.textContent).not.toContain('Red Hat Hybrid Cloud Console');
+    expect(toggle!.getAttribute('aria-label')).toBe('All services');
+  });
+
   it('should render search toolbar group when not in Lightwell mode', () => {
     renderHeader(false);
     expect(screen.getByTestId('search-toolbar-group')).toBeTruthy();

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -141,4 +141,17 @@ describe('Header Lightwell mode', () => {
     const logo = screen.queryByAltText('Red Hat Logo');
     expect(logo).toBeFalsy();
   });
+
+  it('should render Lightwell logomark in masthead when in Lightwell mode', () => {
+    renderHeader(true);
+    const logomark = document.querySelector('.chr-c-masthead__lightwell-logo');
+    expect(logomark).toBeTruthy();
+    expect(logomark!.getAttribute('src')).toContain('lightwell-logomark');
+  });
+
+  it('should not render Lightwell logomark when not in Lightwell mode', () => {
+    renderHeader(false);
+    const logomark = document.querySelector('.chr-c-masthead__lightwell-logo');
+    expect(logomark).toBeFalsy();
+  });
 });

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -71,13 +71,15 @@ const MemoizedHeader = memo(
         <MastheadMain>
           {!hideNav && <MastheadMenuToggle setIsNavOpen={setIsNavOpen} isNavOpen={isNavOpen} />}
           <MastheadBrand data-codemods>
-            <MastheadLogo
-              data-codemods
-              className="chr-c-masthead__logo pf-v6-u-pr-0 pf-v6-u-pl-sm"
-              {...(!isLightwellHeader && { component: (props: LinkWrapperProps) => <ChromeLink {...props} appId="landing" href="/" /> })}
-            >
-              <Logo theme={theme} />
-            </MastheadLogo>
+            {!isLightwellHeader && (
+              <MastheadLogo
+                data-codemods
+                className="chr-c-masthead__logo pf-v6-u-pr-0 pf-v6-u-pl-sm"
+                component={(props: LinkWrapperProps) => <ChromeLink {...props} appId="landing" href="/" />}
+              >
+                <Logo theme={theme} />
+              </MastheadLogo>
+            )}
             {isLightwellHeader ? (
               <span className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-pl-sm">Lightwell</span>
             ) : (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -83,6 +83,7 @@ const MemoizedHeader = memo(
             {isLightwellHeader ? (
               <>
                 <AllServicesDropdown iconOnly />
+                <img src="/apps/frontend-assets/partners-icons/lightwell-logomark.svg" alt="" className="chr-c-masthead__lightwell-logo" />
                 <span className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-pl-sm">Lightwell</span>
               </>
             ) : (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -81,7 +81,10 @@ const MemoizedHeader = memo(
               </MastheadLogo>
             )}
             {isLightwellHeader ? (
-              <span className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-pl-sm">Lightwell</span>
+              <>
+                <AllServicesDropdown iconOnly />
+                <span className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-pl-sm">Lightwell</span>
+              </>
             ) : (
               !(!md && searchOpen) && <AllServicesDropdown />
             )}

--- a/src/layouts/Lightwell.test.tsx
+++ b/src/layouts/Lightwell.test.tsx
@@ -30,8 +30,9 @@ import Lightwell from './Lightwell';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { notificationDrawerExpandedAtom } from '../state/atoms/notificationDrawerAtom';
 import { layoutBannerHiddenAtom, layoutForceGlassThemeAtom, layoutLightwellHeaderAtom } from '../state/atoms/releaseAtom';
-import ChromeAuthContext from '../auth/ChromeAuthContext';
+import ChromeAuthContext, { ChromeAuthContextValue } from '../auth/ChromeAuthContext';
 import InternalChromeContext from '../utils/internalChromeContext';
+import { ChromeAPI } from '@redhat-cloud-services/types';
 
 const mockUser = {
   identity: {
@@ -56,13 +57,13 @@ const mockAuthContextValue = {
   logout: jest.fn(),
   getUser: jest.fn<() => Promise<typeof mockUser>>().mockResolvedValue(mockUser),
   getToken: jest.fn<() => Promise<string>>().mockResolvedValue('test-token'),
-};
+} as unknown as ChromeAuthContextValue;
 
 const mockInternalChromeContextValue = {
   drawerActions: {
     toggleDrawerContent: jest.fn(),
   },
-};
+} as unknown as ChromeAPI;
 
 const renderLightwell = (flagOverrides: Record<string, boolean> = {}) => {
   const defaultFlags: Record<string, boolean> = {
@@ -79,10 +80,8 @@ const renderLightwell = (flagOverrides: Record<string, boolean> = {}) => {
     store,
     ...render(
       <MemoryRouter>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        <ChromeAuthContext.Provider value={mockAuthContextValue as any}>
-          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-          <InternalChromeContext.Provider value={mockInternalChromeContextValue as any}>
+        <ChromeAuthContext.Provider value={mockAuthContextValue}>
+          <InternalChromeContext.Provider value={mockInternalChromeContextValue}>
             <Provider store={store}>
               <Lightwell Footer={<div data-testid="mock-footer" />} />
             </Provider>
@@ -171,5 +170,22 @@ describe('Lightwell', () => {
     expect(store.get(layoutLightwellHeaderAtom)).toBe(true);
     unmount();
     expect(store.get(layoutLightwellHeaderAtom)).toBe(false);
+  });
+
+  it('should render breadcrumb with "Hybrid Cloud Console" linking to / and active "Lightwell"', () => {
+    const { container } = renderLightwell();
+    const breadcrumb = container.querySelector('.chr-c-breadcrumbs');
+    expect(breadcrumb).toBeTruthy();
+
+    const items = breadcrumb!.querySelectorAll('.pf-v6-c-breadcrumb__item');
+    expect(items.length).toBe(2);
+
+    const firstLink = items[0].querySelector('a');
+    expect(firstLink).toBeTruthy();
+    expect(firstLink!.getAttribute('href')).toBe('/');
+    expect(firstLink!.textContent).toContain('Hybrid Cloud Console');
+
+    const activeItem = items[1];
+    expect(activeItem.textContent).toContain('Lightwell');
   });
 });

--- a/src/layouts/Lightwell.tsx
+++ b/src/layouts/Lightwell.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { ScalprumComponent } from '@scalprum/react-core';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core/dist/dynamic/components/Breadcrumb';
 import { Masthead } from '@patternfly/react-core/dist/dynamic/components/Masthead';
-import { Page } from '@patternfly/react-core/dist/dynamic/components/Page';
+import { Page, PageBreadcrumb } from '@patternfly/react-core/dist/dynamic/components/Page';
+import { ToolbarGroup } from '@patternfly/react-core/dist/dynamic/components/Toolbar';
 import { useAtom, useSetAtom } from 'jotai';
 import { useFlag } from '@unleash/proxy-client-react';
 import { Header } from '../components/Header/Header';
+import ChromeLink from '../components/ChromeLink';
 import RedirectBanner from '../components/Stratosphere/RedirectBanner';
 import LoadingFallback from '../utils/loading-fallback';
 import ErrorComponent from '../components/ErrorComponents/DefaultErrorComponent';
@@ -73,6 +76,18 @@ const Lightwell = ({ Footer }: LightwellProps) => {
           isNotificationDrawerExpanded: isNotificationsDrawerExpanded,
         })}
       >
+        <ToolbarGroup className="chr-c-breadcrumbs__group">
+          <PageBreadcrumb hasBodyWrapper={false} className="chr-c-breadcrumbs pf-v6-u-p-0 pf-v6-u-w-100">
+            <div className="pf-v6-u-display-flex pf-v6-u-pt-sm pf-v6-u-pb-0 pf-v6-u-pl-lg">
+              <Breadcrumb>
+                <BreadcrumbItem to="/" component={(props) => <ChromeLink {...props} href="/" />}>
+                  Hybrid Cloud Console
+                </BreadcrumbItem>
+                <BreadcrumbItem isActive>Lightwell</BreadcrumbItem>
+              </Breadcrumb>
+            </div>
+          </PageBreadcrumb>
+        </ToolbarGroup>
         <RedirectBanner />
         <ScalprumComponent
           scope="contentSources"


### PR DESCRIPTION
Note: This PR duplicates/supersedes https://github.com/RedHatInsights/insights-chrome/pull/3616

### Description
Lightwell UX would like to adhere to being a tenant of HCC. In doing so, we would like a way to allow the user to navigate to HCC and back. Currently, there is no way to do that unless the user manipulates the URL.

**Reasons for this proposal:**

- We would like a way to navigate the user back to HCC and the services it provides.
- Brand has set a guideline that states that we cannot show the Fedora or the word “Red Hat” before Lightwell. It's just Lightwell and its “L” logo.

In this pull request, the following changes are implemented in separate commits:
- hide Red Hat logo in masthead on /lightwell path
- show icon-only AllServicesDropdown on /lightwell path
- add Lightwell section in AllServices dropdown below Platforms
- add breadcrumb to Lightwell layout
- add Lightwell logomark next to masthead title

We do not intend on changing the overall masthead for HCC and the other tenants today, but we do have a strong desire to stay engaged with HCC UX on future designs so that the navigation between tenants are more consistent and also maintain adherence to Brand’s guidelines for this experience.

[RHCLOUD-49501](https://redhat.atlassian.net/browse/RHCLOUD-49501)

---

### Screenshots

No Lightwell screenshots are shared here, please refer to the Jira ticket.

#### Before:

n/a

#### After:

n/a

---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-49501]: https://redhat.atlassian.net/browse/RHCLOUD-49501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lightwell branding to the header, including a Lightwell logomark and title.
  * Updated the services menu in Lightwell mode to support an icon-only toggle and added a Lightwell entry/link.
  * Added Lightwell breadcrumbs with a link back to Hybrid Cloud Console and an active Lightwell crumb.
* **Style**
  * Refined Lightwell logo sizing and alignment in the masthead.
* **Tests**
  * Added/updated UI tests to validate Lightwell header, services menu behavior, and breadcrumb structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->