### PR TITLE
chore: adds 2 day package cooldown per InfoSec guidance

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-49800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an installation safeguard requiring npm packages to be at least two days old before installation.
  * This helps reduce exposure to newly published packages and supports more reliable dependency setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->