### PR TITLE
feat(RHCLOUD-46183): Use feature flag to hide Global tag filter

### DIFF
--- a/src/components/GlobalFilter/GlobalFilter.test.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { Provider as JotaiProvider } from 'jotai';
+import { Provider as JotaiProvider, createStore } from 'jotai';
 import { useFlag } from '@unleash/proxy-client-react';
 import GlobalFilterWrapper from './GlobalFilter';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
 import InternalChromeContext from '../../utils/internalChromeContext';
 import { ChromeAPI } from '@redhat-cloud-services/types';
+import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 
 jest.mock('@unleash/proxy-client-react', () => ({
   useFlag: jest.fn(() => false),
@@ -15,6 +16,25 @@ jest.mock('@unleash/proxy-client-react', () => ({
 jest.mock('../../utils/common', () => ({
   ...jest.requireActual('../../utils/common'),
   isGlobalFilterAllowed: jest.fn(() => true),
+}));
+
+jest.mock('./GlobalFilterMenu', () => ({
+  GlobalFilterDropdown: () => <div data-testid="global-filter-dropdown" />,
+}));
+
+jest.mock('./tagsApi', () => ({
+  getAllTags: jest.fn(() => Promise.resolve()),
+  getAllWorkloads: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/FilterHooks', () => ({
+  useTagsFilter: jest.fn(() => ({
+    filter: {},
+    chips: [],
+    selectedTags: {},
+    setValue: jest.fn(),
+    filterTagsBy: '',
+  })),
 }));
 
 const mockedUseFlag = useFlag as jest.Mock;
@@ -32,8 +52,17 @@ const mockChromeAuth = {
   },
 } as unknown as typeof ChromeAuthContext extends React.Context<infer T> ? T : never;
 
+const makeStore = () => {
+  const store = createStore();
+  // activeModuleAtom defaults to undefined, which makes isGlobalFilterDisabledAtom true
+  // and causes the wrapper to return null regardless of any feature flag. Seed a valid
+  // module so that path is open and only the flag determines visibility.
+  store.set(activeModuleAtom, 'insights-dashboard');
+  return store;
+};
+
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <JotaiProvider>
+  <JotaiProvider store={makeStore()}>
     <ChromeAuthContext.Provider value={mockChromeAuth}>
       <InternalChromeContext.Provider value={{ getUserPermissions: mockGetUserPermissions } as unknown as ChromeAPI}>
         <MemoryRouter initialEntries={['/insights/dashboard']}>{children}</MemoryRouter>
@@ -49,7 +78,6 @@ describe('GlobalFilterWrapper', () => {
   });
 
   it('should call getUserPermissions when rbac.workspaces flag is disabled', async () => {
-    mockedUseFlag.mockReturnValue(false);
     render(<GlobalFilterWrapper />, { wrapper: Wrapper });
     await waitFor(() => expect(mockGetUserPermissions).toHaveBeenCalledWith('inventory'));
   });
@@ -58,5 +86,18 @@ describe('GlobalFilterWrapper', () => {
     mockedUseFlag.mockReturnValue(true);
     render(<GlobalFilterWrapper />, { wrapper: Wrapper });
     await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
+  });
+
+  it('should hide the global filter when platform.chrome.hide.global-filter is enabled', async () => {
+    // First establish that the dropdown renders when the flag is off, proving the test
+    // setup (auth, active module, allowed URL) is sufficient to show the component.
+    const { unmount } = render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(screen.getByTestId('global-filter-dropdown')).toBeInTheDocument());
+    unmount();
+
+    // Now enable only the hide flag and verify the flag alone causes the dropdown to disappear.
+    mockedUseFlag.mockImplementation((flag: string) => flag === 'platform.chrome.hide.global-filter');
+    render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(screen.queryByTestId('global-filter-dropdown')).not.toBeInTheDocument());
   });
 });

--- a/src/components/GlobalFilter/GlobalFilter.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.tsx
@@ -177,6 +177,7 @@ const GlobalFilterWrapper = () => {
   const { pathname } = useLocation();
   const { getUserPermissions } = useContext(InternalChromeContext);
   const isRbacV2 = useFlag('platform.rbac.workspaces');
+  const hideGlobalFilterFlag = useFlag('platform.chrome.hide.global-filter');
 
   // FIXME: Clean up the global filter display flag
   const isLanding = pathname === '/';
@@ -184,12 +185,12 @@ const GlobalFilterWrapper = () => {
 
   const isGlobalFilterDisabled = useAtomValue(isGlobalFilterDisabledAtom);
   const isGlobalFilterEnabled = useMemo(() => {
-    if (isGlobalFilterDisabled) {
+    if (hideGlobalFilterFlag || isGlobalFilterDisabled) {
       return false;
     }
     const globalFilterAllowed = isAllowed || globalFilterRemoved;
     return !isLanding && (globalFilterAllowed || Boolean(localStorage.getItem('chrome:experimental:global-filter')));
-  }, [isLanding, isAllowed, isGlobalFilterDisabled]);
+  }, [isLanding, isAllowed, isGlobalFilterDisabled, hideGlobalFilterFlag, globalFilterRemoved]);
 
   useEffect(() => {
     if (isRbacV2) {


### PR DESCRIPTION
### Description
https://redhat.atlassian.net/browse/RHCLOUD-46183
https://redhat.atlassian.net/browse/RHINENG-29499

Add feature flag to enable/disable Global tag filter :

- https://insights-stage.unleash.devshift.net/projects/default/features/platform.chrome.hide.global-filter

Pages where Global tag filter is used:
https://console.redhat.com/ansible/advisor/systems
https://console.redhat.com/ansible/inventory
https://console.redhat.com/insights/dashboard#tags=
https://console.redhat.com/insights/inventory
https://console.redhat.com/insights/advisor/systems
https://console.redhat.com/insights/advisor/recommendations
https://console.redhat.com/insights/patch/systems
https://console.redhat.com/insights/patch/advisories
https://console.redhat.com/insights/patch/packages
https://console.redhat.com/insights/vulnerability/cves
https://console.redhat.com/insights/vulnerability/systems

---

### Screenshots
#### Before - flag disbaled:
<img width="1209" height="273" alt="image" src="https://github.com/user-attachments/assets/85aced1d-9895-48d9-b775-055c29069d6a" />


#### After - flag enabled:
<img width="1209" height="273" alt="image" src="https://github.com/user-attachments/assets/e43f6215-79cb-4fae-a8b2-218ca7208fee" />

---

### Anything reviewers should know?
- Do not enable this feature flag in production

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
