### PR TITLE
feat(settings): allow hiding parts of settings dropdown

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,12 +22,12 @@ import ChromeAuthContext, { ChromeAuthContextValue } from '../../auth/ChromeAuth
 import { layoutLightwellHeaderAtom } from '../../state/atoms/releaseAtom';
 
 export type SettingsGroupConfig = {
-  hidePreview?: boolean;
-  hideSettingsGroup?: boolean;
-  hideIAM?: boolean;
-  hideTheme?: boolean;
-  hideColorScheme?: boolean;
-  hideContrastMode?: boolean;
+  showPreview?: boolean;
+  showSettingsGroup?: boolean;
+  showIAM?: boolean;
+  showTheme?: boolean;
+  showColorScheme?: boolean;
+  showContrastMode?: boolean;
 };
 
 export type ToolbarConfig = {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,10 +21,20 @@ import useWindowWidth from '../../hooks/useWindowWidth';
 import ChromeAuthContext, { ChromeAuthContextValue } from '../../auth/ChromeAuthContext';
 import { layoutLightwellHeaderAtom } from '../../state/atoms/releaseAtom';
 
+export type SettingsGroupConfig = {
+  hidePreview?: boolean;
+  hideSettingsGroup?: boolean;
+  hideIAM?: boolean;
+  hideTheme?: boolean;
+  hideColorScheme?: boolean;
+  hideContrastMode?: boolean;
+};
+
 export type ToolbarConfig = {
   hideNotifications?: boolean;
   hideHelp?: boolean;
   hideSettings?: boolean;
+  settingsGroups?: SettingsGroupConfig;
 };
 
 function hasUser(user: { orgId?: string; username?: string; accountNumber?: string; email?: string }): user is Required<typeof user> {

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -398,44 +398,7 @@ describe('Tools - toolbarConfig visibility', () => {
 describe('Tools - settingsGroups config', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('should hide preview group when settingsGroups.hidePreview is true', () => {
-    renderTools({}, { settingsGroups: { hidePreview: true } });
-    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
-  });
-
-  it('should hide Settings group when settingsGroups.hideSettingsGroup is true', () => {
-    renderTools({}, { settingsGroups: { hideSettingsGroup: true } });
-    expect(screen.queryByText('Integrations')).not.toBeInTheDocument();
-    expect(screen.queryByText('Notifications')).not.toBeInTheDocument();
-  });
-
-  it('should hide IAM group when settingsGroups.hideIAM is true', () => {
-    renderTools({}, { settingsGroups: { hideIAM: true } });
-    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
-  });
-
-  it('should hide theme group when settingsGroups.hideTheme is true', () => {
-    renderTools({ 'platform.chrome.felt-theme': true }, { settingsGroups: { hideTheme: true } });
-    expect(screen.queryByText('Theme')).not.toBeInTheDocument();
-  });
-
-  it('should hide color scheme group when settingsGroups.hideColorScheme is true', () => {
-    renderTools({ 'platform.chrome.dark-mode': true }, { settingsGroups: { hideColorScheme: true } });
-    expect(screen.queryByText('Color scheme')).not.toBeInTheDocument();
-  });
-
-  it('should hide contrast mode group when settingsGroups.hideContrastMode is true', () => {
-    renderTools({ 'platform.chrome.high-contrast': true }, { settingsGroups: { hideContrastMode: true } });
-    expect(screen.queryByText('Contrast mode')).not.toBeInTheDocument();
-  });
-
-  it('should still show preview when only IAM is hidden', () => {
-    renderTools({}, { settingsGroups: { hideIAM: true } });
-    expect(screen.getByTestId('PreviewSwitcher')).toBeInTheDocument();
-    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
-  });
-
-  it('should show all groups by default', () => {
+  it('should show all groups when no settingsGroups provided', () => {
     renderTools({ 'platform.chrome.dark-mode': true, 'platform.chrome.high-contrast': true, 'platform.chrome.felt-theme': true });
     expect(screen.getByTestId('PreviewSwitcher')).toBeInTheDocument();
     expect(screen.getByText('Identity and Access Management')).toBeInTheDocument();
@@ -444,31 +407,66 @@ describe('Tools - settingsGroups config', () => {
     expect(screen.getByText('Contrast mode')).toBeInTheDocument();
   });
 
-  it('should hide preview from mobile dropdown when settingsGroups.hidePreview is true', () => {
-    renderTools({}, { settingsGroups: { hidePreview: true } });
+  it('should show only preview when showPreview is true', () => {
+    renderTools({}, { settingsGroups: { showPreview: true } });
+    expect(screen.getByTestId('PreviewSwitcher')).toBeInTheDocument();
+    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
+  });
+
+  it('should show only settings group when showSettingsGroup is true', () => {
+    renderTools({}, { settingsGroups: { showSettingsGroup: true } });
+    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
+    expect(screen.getByText('Notifications')).toBeInTheDocument();
+  });
+
+  it('should show only IAM when showIAM is true', () => {
+    renderTools({}, { settingsGroups: { showIAM: true } });
+    expect(screen.getByText('Identity and Access Management')).toBeInTheDocument();
+    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
+  });
+
+  it('should show only theme when showTheme is true', () => {
+    renderTools({ 'platform.chrome.felt-theme': true }, { settingsGroups: { showTheme: true } });
+    expect(screen.getByText('Theme')).toBeInTheDocument();
+    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
+  });
+
+  it('should show only color scheme when showColorScheme is true', () => {
+    renderTools({ 'platform.chrome.dark-mode': true }, { settingsGroups: { showColorScheme: true } });
+    expect(screen.getByText('Color scheme')).toBeInTheDocument();
+    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
+    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
+  });
+
+  it('should show only contrast mode when showContrastMode is true', () => {
+    renderTools({ 'platform.chrome.high-contrast': true }, { settingsGroups: { showContrastMode: true } });
+    expect(screen.getByText('Contrast mode')).toBeInTheDocument();
+    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
+  });
+
+  it('should show multiple groups when multiple flags are true', () => {
+    renderTools({ 'platform.chrome.dark-mode': true }, { settingsGroups: { showPreview: true, showColorScheme: true } });
+    expect(screen.getByTestId('PreviewSwitcher')).toBeInTheDocument();
+    expect(screen.getByText('Color scheme')).toBeInTheDocument();
+    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
+  });
+
+  it('should hide preview from mobile dropdown when settingsGroups excludes it', () => {
+    renderTools({}, { settingsGroups: { showSettingsGroup: true } });
     expect(screen.queryByText(/Preview/)).not.toBeInTheDocument();
   });
 
-  it('should hide settings link from mobile dropdown when settingsGroups.hideSettingsGroup is true', () => {
-    renderTools({}, { settingsGroups: { hideSettingsGroup: true } });
-    // Desktop settings group title still absent, mobile "Settings" link also absent
-    // Only the desktop group heading "Settings" should remain (from dropdown groups)
+  it('should hide settings link from mobile dropdown when settingsGroups excludes it', () => {
+    renderTools({}, { settingsGroups: { showPreview: true } });
     const settingsElements = screen.queryAllByText('Settings');
-    // With hideSettingsGroup, the desktop group is filtered out AND the mobile link is filtered out
     expect(settingsElements).toHaveLength(0);
   });
 
   it('should only show color scheme when Lightwell config is used', () => {
-    const lightwellConfig = {
-      settingsGroups: {
-        hidePreview: true,
-        hideSettingsGroup: true,
-        hideIAM: true,
-        hideTheme: true,
-        hideContrastMode: true,
-      },
-    };
-    renderTools({ 'platform.chrome.dark-mode': true, 'platform.chrome.high-contrast': true, 'platform.chrome.felt-theme': true }, lightwellConfig);
+    renderTools(
+      { 'platform.chrome.dark-mode': true, 'platform.chrome.high-contrast': true, 'platform.chrome.felt-theme': true },
+      { settingsGroups: { showColorScheme: true } }
+    );
 
     expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
     expect(screen.queryByText('Integrations')).not.toBeInTheDocument();

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -395,6 +395,91 @@ describe('Tools - toolbarConfig visibility', () => {
   });
 });
 
+describe('Tools - settingsGroups config', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should hide preview group when settingsGroups.hidePreview is true', () => {
+    renderTools({}, { settingsGroups: { hidePreview: true } });
+    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
+  });
+
+  it('should hide Settings group when settingsGroups.hideSettingsGroup is true', () => {
+    renderTools({}, { settingsGroups: { hideSettingsGroup: true } });
+    expect(screen.queryByText('Integrations')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notifications')).not.toBeInTheDocument();
+  });
+
+  it('should hide IAM group when settingsGroups.hideIAM is true', () => {
+    renderTools({}, { settingsGroups: { hideIAM: true } });
+    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
+  });
+
+  it('should hide theme group when settingsGroups.hideTheme is true', () => {
+    renderTools({ 'platform.chrome.felt-theme': true }, { settingsGroups: { hideTheme: true } });
+    expect(screen.queryByText('Theme')).not.toBeInTheDocument();
+  });
+
+  it('should hide color scheme group when settingsGroups.hideColorScheme is true', () => {
+    renderTools({ 'platform.chrome.dark-mode': true }, { settingsGroups: { hideColorScheme: true } });
+    expect(screen.queryByText('Color scheme')).not.toBeInTheDocument();
+  });
+
+  it('should hide contrast mode group when settingsGroups.hideContrastMode is true', () => {
+    renderTools({ 'platform.chrome.high-contrast': true }, { settingsGroups: { hideContrastMode: true } });
+    expect(screen.queryByText('Contrast mode')).not.toBeInTheDocument();
+  });
+
+  it('should still show preview when only IAM is hidden', () => {
+    renderTools({}, { settingsGroups: { hideIAM: true } });
+    expect(screen.getByTestId('PreviewSwitcher')).toBeInTheDocument();
+    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
+  });
+
+  it('should show all groups by default', () => {
+    renderTools({ 'platform.chrome.dark-mode': true, 'platform.chrome.high-contrast': true, 'platform.chrome.felt-theme': true });
+    expect(screen.getByTestId('PreviewSwitcher')).toBeInTheDocument();
+    expect(screen.getByText('Identity and Access Management')).toBeInTheDocument();
+    expect(screen.getByText('Theme')).toBeInTheDocument();
+    expect(screen.getByText('Color scheme')).toBeInTheDocument();
+    expect(screen.getByText('Contrast mode')).toBeInTheDocument();
+  });
+
+  it('should hide preview from mobile dropdown when settingsGroups.hidePreview is true', () => {
+    renderTools({}, { settingsGroups: { hidePreview: true } });
+    expect(screen.queryByText(/Preview/)).not.toBeInTheDocument();
+  });
+
+  it('should hide settings link from mobile dropdown when settingsGroups.hideSettingsGroup is true', () => {
+    renderTools({}, { settingsGroups: { hideSettingsGroup: true } });
+    // Desktop settings group title still absent, mobile "Settings" link also absent
+    // Only the desktop group heading "Settings" should remain (from dropdown groups)
+    const settingsElements = screen.queryAllByText('Settings');
+    // With hideSettingsGroup, the desktop group is filtered out AND the mobile link is filtered out
+    expect(settingsElements).toHaveLength(0);
+  });
+
+  it('should only show color scheme when Lightwell config is used', () => {
+    const lightwellConfig = {
+      settingsGroups: {
+        hidePreview: true,
+        hideSettingsGroup: true,
+        hideIAM: true,
+        hideTheme: true,
+        hideContrastMode: true,
+      },
+    };
+    renderTools({ 'platform.chrome.dark-mode': true, 'platform.chrome.high-contrast': true, 'platform.chrome.felt-theme': true }, lightwellConfig);
+
+    expect(screen.queryByTestId('PreviewSwitcher')).not.toBeInTheDocument();
+    expect(screen.queryByText('Integrations')).not.toBeInTheDocument();
+    expect(screen.queryByText('Identity and Access Management')).not.toBeInTheDocument();
+    expect(screen.queryByText('Theme')).not.toBeInTheDocument();
+    expect(screen.queryByText('Contrast mode')).not.toBeInTheDocument();
+
+    expect(screen.getByText('Color scheme')).toBeInTheDocument();
+  });
+});
+
 describe('Tools - high contrast feature flag', () => {
   beforeEach(() => jest.clearAllMocks());
 
@@ -549,5 +634,30 @@ describe('Tools - glass ↔ high contrast mutual exclusivity', () => {
     fireEvent.click(defaultBtn!);
     expect(mockDisableGlass).toHaveBeenCalled();
     expect(mockSetDefaultContrast).toHaveBeenCalled();
+  });
+});
+
+describe('Tools - about menu items', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should render about menu items when help-panel flag is disabled', () => {
+    renderTools({ 'platform.chrome.help-panel': false });
+    expect(screen.getByText('Support options')).toBeInTheDocument();
+    expect(screen.getByText('Status page')).toBeInTheDocument();
+  });
+
+  it('should render ask-redhat item when flag is enabled', () => {
+    renderTools({ 'platform.chrome.ask-redhat-help': true });
+    expect(screen.getByText('Ask Red Hat')).toBeInTheDocument();
+  });
+
+  it('should render ITLess support URL in mobile dropdown', () => {
+    renderTools({ 'platform.chrome.itless': true });
+    expect(screen.getByText('Support options')).toBeInTheDocument();
+  });
+
+  it('should render learning resources link when flag is enabled', () => {
+    renderTools({ 'platform.learning-resources.global-learning-resources': true });
+    expect(screen.getByText('All learning resources')).toBeInTheDocument();
   });
 });

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -137,7 +137,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
   const settingsGroups = toolbarConfig?.settingsGroups;
   const settingsMenuDropdownGroups = [
     {
-      groupKey: 'hidePreview' satisfies keyof SettingsGroupConfig,
+      groupKey: 'showPreview' satisfies keyof SettingsGroupConfig,
       items: [
         {
           ouiaId: 'PreviewSwitcher',
@@ -147,7 +147,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ],
     },
     {
-      groupKey: 'hideSettingsGroup' satisfies keyof SettingsGroupConfig,
+      groupKey: 'showSettingsGroup' satisfies keyof SettingsGroupConfig,
       title: 'Settings',
       items: [
         {
@@ -174,7 +174,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ],
     },
     {
-      groupKey: 'hideIAM' satisfies keyof SettingsGroupConfig,
+      groupKey: 'showIAM' satisfies keyof SettingsGroupConfig,
       title: 'Identity and Access Management',
       items: [
         {
@@ -208,7 +208,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ],
     },
     {
-      groupKey: 'hideTheme' satisfies keyof SettingsGroupConfig,
+      groupKey: 'showTheme' satisfies keyof SettingsGroupConfig,
       title: intl.formatMessage(messages.theme),
       isHidden: !isFeltThemeEnabled,
       customContent: (
@@ -232,7 +232,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ),
     },
     {
-      groupKey: 'hideColorScheme' satisfies keyof SettingsGroupConfig,
+      groupKey: 'showColorScheme' satisfies keyof SettingsGroupConfig,
       title: intl.formatMessage(messages.colorScheme),
       isHidden: !isDarkModeEnabled,
       customContent: (
@@ -264,7 +264,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ),
     },
     {
-      groupKey: 'hideContrastMode' satisfies keyof SettingsGroupConfig,
+      groupKey: 'showContrastMode' satisfies keyof SettingsGroupConfig,
       title: intl.formatMessage(messages.contrastMode),
       isHidden: !isHighContrastEnabled && !isGlassModeEnabled,
       customContent: (
@@ -307,7 +307,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
         </ToggleGroup>
       ),
     },
-  ].filter(({ groupKey }) => !settingsGroups?.[groupKey as keyof SettingsGroupConfig]);
+  ].filter(({ groupKey }) => !settingsGroups || settingsGroups[groupKey as keyof SettingsGroupConfig]);
 
   useEffect(() => {
     if (user) {
@@ -402,23 +402,23 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
   const settingsMobileItems = toolbarConfig?.hideSettings
     ? []
     : [
-        ...(settingsGroups?.hideSettingsGroup
-          ? []
-          : [
+        ...(!settingsGroups || settingsGroups.showSettingsGroup
+          ? [
               {
                 url: settingsPath,
                 title: 'Settings',
                 target: '_self',
               },
-            ]),
-        ...(settingsGroups?.hidePreview
-          ? []
-          : [
+            ]
+          : []),
+        ...(!settingsGroups || settingsGroups.showPreview
+          ? [
               {
                 title: betaSwitcherTitle,
                 onClick: () => togglePreviewWithCheck(),
               },
-            ]),
+            ]
+          : []),
       ];
   const helpMobileItems = helpPanelEnabled || toolbarConfig?.hideHelp ? [] : aboutMenuDropdownItems;
 

--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -33,7 +33,7 @@ import { ThemeVariants, useTheme } from '../../hooks/useTheme';
 import { useGlassTheme } from '../../hooks/useGlassTheme';
 import { useFeltTheme } from '../../hooks/useFeltTheme';
 import { HighContrastVariants, useHighContrast } from '../../hooks/useHighContrast';
-import type { ToolbarConfig } from './Header';
+import type { SettingsGroupConfig, ToolbarConfig } from './Header';
 import './Tools.scss';
 
 const InternalButton = () => (
@@ -134,8 +134,10 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
   };
 
   /* list out the items for the settings menu */
+  const settingsGroups = toolbarConfig?.settingsGroups;
   const settingsMenuDropdownGroups = [
     {
+      groupKey: 'hidePreview' satisfies keyof SettingsGroupConfig,
       items: [
         {
           ouiaId: 'PreviewSwitcher',
@@ -145,6 +147,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ],
     },
     {
+      groupKey: 'hideSettingsGroup' satisfies keyof SettingsGroupConfig,
       title: 'Settings',
       items: [
         {
@@ -171,6 +174,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ],
     },
     {
+      groupKey: 'hideIAM' satisfies keyof SettingsGroupConfig,
       title: 'Identity and Access Management',
       items: [
         {
@@ -204,6 +208,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ],
     },
     {
+      groupKey: 'hideTheme' satisfies keyof SettingsGroupConfig,
       title: intl.formatMessage(messages.theme),
       isHidden: !isFeltThemeEnabled,
       customContent: (
@@ -227,6 +232,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ),
     },
     {
+      groupKey: 'hideColorScheme' satisfies keyof SettingsGroupConfig,
       title: intl.formatMessage(messages.colorScheme),
       isHidden: !isDarkModeEnabled,
       customContent: (
@@ -258,6 +264,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
       ),
     },
     {
+      groupKey: 'hideContrastMode' satisfies keyof SettingsGroupConfig,
       title: intl.formatMessage(messages.contrastMode),
       isHidden: !isHighContrastEnabled && !isGlassModeEnabled,
       customContent: (
@@ -300,7 +307,7 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
         </ToggleGroup>
       ),
     },
-  ];
+  ].filter(({ groupKey }) => !settingsGroups?.[groupKey as keyof SettingsGroupConfig]);
 
   useEffect(() => {
     if (user) {
@@ -395,15 +402,23 @@ const Tools = ({ toolbarConfig }: { toolbarConfig?: ToolbarConfig }) => {
   const settingsMobileItems = toolbarConfig?.hideSettings
     ? []
     : [
-        {
-          url: settingsPath,
-          title: 'Settings',
-          target: '_self',
-        },
-        {
-          title: betaSwitcherTitle,
-          onClick: () => togglePreviewWithCheck(),
-        },
+        ...(settingsGroups?.hideSettingsGroup
+          ? []
+          : [
+              {
+                url: settingsPath,
+                title: 'Settings',
+                target: '_self',
+              },
+            ]),
+        ...(settingsGroups?.hidePreview
+          ? []
+          : [
+              {
+                title: betaSwitcherTitle,
+                onClick: () => togglePreviewWithCheck(),
+              },
+            ]),
       ];
   const helpMobileItems = helpPanelEnabled || toolbarConfig?.hideHelp ? [] : aboutMenuDropdownItems;
 

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -97,6 +97,16 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ hasBanner, selectedAccoun
               setIsNavOpen,
               hideNav,
             }}
+            toolbarConfig={{
+              settingsGroups: {
+                showPreview: true,
+                showSettingsGroup: true,
+                showIAM: true,
+                showTheme: true,
+                showColorScheme: true,
+                showContrastMode: true,
+              },
+            }}
           />
         </Masthead>
       }

--- a/src/layouts/Lightwell.tsx
+++ b/src/layouts/Lightwell.tsx
@@ -75,7 +75,20 @@ const Lightwell = ({ Footer }: LightwellProps) => {
         onPageResize={null}
         masthead={
           <Masthead className="chr-c-masthead" display={{ sm: 'stack', '2xl': 'inline' }}>
-            <Header breadcrumbsProps={{ hideNav: true }} toolbarConfig={{ hideNotifications: true, hideHelp: true, hideSettings: true }} />
+            <Header
+              breadcrumbsProps={{ hideNav: true }}
+              toolbarConfig={{
+                hideNotifications: true,
+                hideHelp: true,
+                settingsGroups: {
+                  hidePreview: true,
+                  hideSettingsGroup: true,
+                  hideIAM: true,
+                  hideTheme: true,
+                  hideContrastMode: true,
+                },
+              }}
+            />
           </Masthead>
         }
         {...(isDrawerEnabled && {

--- a/src/layouts/Lightwell.tsx
+++ b/src/layouts/Lightwell.tsx
@@ -81,11 +81,7 @@ const Lightwell = ({ Footer }: LightwellProps) => {
                 hideNotifications: true,
                 hideHelp: true,
                 settingsGroups: {
-                  hidePreview: true,
-                  hideSettingsGroup: true,
-                  hideIAM: true,
-                  hideTheme: true,
-                  hideContrastMode: true,
+                  showColorScheme: true,
                 },
               }}
             />


### PR DESCRIPTION
### Description

Adds `SettingsGroupConfig` to `ToolbarConfig`, allowing consumers to selectively hide individual groups inside the settings (cog) dropdown without hiding the entire cog icon. Applied in Lightwell layout to show only the color scheme group.

Composable with existing `hideSettings` flag — `hideSettings: true` hides the entire cog; `settingsGroups` controls granularity within it.

[RHCLOUD-50156](https://issues.redhat.com/browse/RHCLOUD-50156)

---

### Screenshots

#### Before:

All settings groups visible in Lightwell (preview, settings, IAM, theme, color scheme, contrast mode).

#### After:

<img width="2535" height="565" alt="Screenshot 2026-08-10 at 9 37 30" src="https://github.com/user-attachments/assets/70e32202-fcb9-45dc-b7cb-18d046f2687c" />


---

### Anything reviewers should know?

Each dropdown group is tagged with a `groupKey` that maps to a key in `SettingsGroupConfig`. The array is filtered at build time via `.filter()` — no runtime cost when no config is provided. The `satisfies keyof SettingsGroupConfig` on each `groupKey` ensures compile-time safety if group keys are renamed or removed.

Lightwell.tsx was also updated by the user to add `hideContrastMode: true`, so only color scheme remains visible there.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude Code (Opus 4.6)

[RHCLOUD-50156]: https://redhat.atlassian.net/browse/RHCLOUD-50156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added granular toolbar visibility controls for Preview, Settings, IAM, Theme, Color Scheme, and Contrast Mode.
  * Toolbar configurations can selectively show or hide settings groups, including on mobile.
  * Enabled the full set of toolbar controls in the default layout.
  * Updated the Lightwell layout to use granular visibility options.

* **Bug Fixes**
  * Preserved default visibility when no settings-group configuration is provided.
  * Ensured hidden controls are consistently omitted from menus and mobile actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->