### PR TITLE
feat(lightwell): make lightwell text and logo clickable

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -78,7 +78,7 @@
 }
 
 
-.chr-c-menu-settings .pf-v6-c-menu__group:first-of-type > .pf-v6-c-menu__group-title {
+.chr-c-menu-settings .pf-v6-c-menu__group-title:empty {
   display: none;
 }
 

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -133,9 +133,17 @@ describe('Header Lightwell mode', () => {
     expect(logoLink.getAttribute('href')).toBe('/');
   });
 
-  it('should render masthead logo without a link when in Lightwell mode', () => {
+  it('should render masthead logo as a link to /lightwell when in Lightwell mode', () => {
     renderHeader(true);
-    const logoLinks = screen.queryAllByRole('link', { name: /logo/i });
-    expect(logoLinks.length).toBe(0);
+    const logoLink = screen.getByRole('link', { name: /logo/i });
+    expect(logoLink).toBeTruthy();
+    expect(logoLink.getAttribute('href')).toBe('/lightwell');
+  });
+
+  it('should render Lightwell title as a link to /lightwell when in Lightwell mode', () => {
+    renderHeader(true);
+    const titleLink = screen.getByRole('link', { name: 'Lightwell' });
+    expect(titleLink).toBeTruthy();
+    expect(titleLink.getAttribute('href')).toBe('/lightwell');
   });
 });

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -85,12 +85,16 @@ const MemoizedHeader = memo(
             <MastheadLogo
               data-codemods
               className="chr-c-masthead__logo pf-v6-u-pr-0 pf-v6-u-pl-sm"
-              {...(!isLightwellHeader && { component: (props: LinkWrapperProps) => <ChromeLink {...props} appId="landing" href="/" /> })}
+              component={(props: LinkWrapperProps) => (
+                <ChromeLink {...props} {...(isLightwellHeader ? { href: '/lightwell' } : { appId: 'landing', href: '/' })} />
+              )}
             >
               <Logo theme={theme} />
             </MastheadLogo>
             {isLightwellHeader ? (
-              <span className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-mt-xs">Lightwell</span>
+              <ChromeLink href="/lightwell" className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-mt-xs chr-m-plain">
+                Lightwell
+              </ChromeLink>
             ) : (
               !(!md && searchOpen) && <AllServicesDropdown />
             )}

--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -222,6 +222,7 @@ aside {
 }
 
 .chr-m-plain {
+  color: inherit;
   text-decoration: none;
 }
 


### PR DESCRIPTION
### Description
Make the Lightwell text clickable.

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:


#### After:

<img width="317" height="79" alt="Screenshot 2026-08-10 at 13 07 17" src="https://github.com/user-attachments/assets/4e9a50de-fb43-499f-aed7-43ee440152c9" />


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [x] _(Optional) QE: OUIA changed, test impact, no coverage_
- [x] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude Code (Opus 4.6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The masthead logo now links to the appropriate landing page, including the Lightwell page in Lightwell mode.
  * The Lightwell title is now clickable and links to the Lightwell page.

* **Bug Fixes**
  * Empty menu group headings are now hidden to prevent unnecessary blank space.

* **Style**
  * Plain masthead links now inherit the surrounding text color while retaining their existing appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->