### PR TITLE
feat(lightwell-logout): add Logout to lightwell pages

### DIFF
--- a/src/components/Header/UserToggle.test.tsx
+++ b/src/components/Header/UserToggle.test.tsx
@@ -133,4 +133,12 @@ describe('UserToggle - userMenu config', () => {
     expect(screen.queryByText('User Preferences')).not.toBeInTheDocument();
     expect(screen.getByText('Log out')).toBeInTheDocument();
   });
+
+  it('should show only logout when Lightwell config is used', () => {
+    renderUserToggle({ showLogout: true });
+    expect(screen.queryByText('My profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('My User Access')).not.toBeInTheDocument();
+    expect(screen.queryByText('User Preferences')).not.toBeInTheDocument();
+    expect(screen.getByText('Log out')).toBeInTheDocument();
+  });
 });

--- a/src/layouts/Lightwell.tsx
+++ b/src/layouts/Lightwell.tsx
@@ -83,7 +83,9 @@ const Lightwell = ({ Footer }: LightwellProps) => {
                 settingsGroups: {
                   showColorScheme: true,
                 },
-                userMenu: {},
+                userMenu: {
+                  showLogout: true,
+                },
               }}
             />
           </Masthead>


### PR DESCRIPTION
### Description

Add Logout to lightwell pages.

---

### Screenshots

#### Before:

<img width="305" height="359" alt="Screenshot 2026-08-12 at 15 20 18" src="https://github.com/user-attachments/assets/0a63470a-57d3-409a-9a4b-0333e57e7a1a" />


#### After:

<img width="339" height="384" alt="Screenshot 2026-08-12 at 15 05 56" src="https://github.com/user-attachments/assets/894480c9-030c-43cb-aca7-30e64dd4b253" />


---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude Code (Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the “Log out” option in the Lightwell header user menu.

* **Bug Fixes**
  * Updated the user menu behavior so configurations showing only logout hide other menu items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->