### PR TITLE
feat: Add platform infrastructure tests for Akamai redirects and route reachability (RHCLOUD-47546)

### DIFF
--- a/.tekton/platform-infra-tests-pipeline.yaml
+++ b/.tekton/platform-infra-tests-pipeline.yaml
@@ -84,3 +84,5 @@ spec:
               cat > $(results.TEST_OUTPUT.path) <<RESULT
               {"result":"${RESULT}","timestamp":"${TIMESTAMP}","successes":${SUCCESSES},"failures":${FAILURES},"warnings":0,"note":"${NOTE}"}
               RESULT
+
+              exit "${TEST_EXIT}"

--- a/.tekton/platform-infra-tests-pipeline.yaml
+++ b/.tekton/platform-infra-tests-pipeline.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   description: |
     Platform infrastructure tests for insights-chrome.
-    Currently a smoke test to validate the scheduled trigger infrastructure.
-    Will be extended with real test commands once the pipeline is proven.
+    Runs Playwright-based Akamai redirect and route reachability tests
+    against console.redhat.com environments on a daily schedule.
   params:
     - name: SNAPSHOT
       description: "The Konflux snapshot being tested"
@@ -15,16 +15,19 @@ spec:
   results:
     - name: TEST_OUTPUT
       description: "Test result summary"
-      value: $(tasks.smoke-test.results.TEST_OUTPUT)
+      value: $(tasks.run-platform-infra-tests.results.TEST_OUTPUT)
   tasks:
-    - name: smoke-test
+    - name: run-platform-infra-tests
       taskSpec:
         results:
           - name: TEST_OUTPUT
             description: "Test output in Konflux standardized format"
         steps:
-          - name: smoke-test
-            image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+          - name: run-tests
+            image: registry.access.redhat.com/ubi9/nodejs-20:latest
+            env:
+              - name: PLATFORM_INFRA_ENV
+                value: prod
             script: |
               #!/bin/bash
               set -euo pipefail
@@ -32,11 +35,50 @@ spec:
               TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
               echo "========================================="
-              echo "Platform infra test pipeline - smoke test"
+              echo "Platform infrastructure tests"
+              echo "Environment: ${PLATFORM_INFRA_ENV}"
               echo "Timestamp: ${TIMESTAMP}"
-              echo "Pipeline executed successfully"
+              echo "========================================="
+
+              WORKDIR=$(mktemp -d)
+              cd "${WORKDIR}"
+
+              echo "Cloning insights-chrome..."
+              git clone --depth 1 https://github.com/RedHatInsights/insights-chrome.git .
+
+              echo "Installing dependencies..."
+              npm ci
+
+              echo "Installing Playwright..."
+              npx playwright install --with-deps chromium
+
+              echo "Running platform infrastructure tests..."
+              set +e
+              npx playwright test playwright/e2e/platform-infra/ \
+                --reporter=line 2>&1 | tee test-output.txt
+              TEST_EXIT=${PIPESTATUS[0]}
+              set -e
+
+              # Playwright line reporter prints a summary like:
+              #   X passed (Ys)
+              #   X failed (Ys)
+              SUCCESSES=$(grep -oP '^\s*\K\d+(?= passed)' test-output.txt || echo 0)
+              FAILURES=$(grep -oP '^\s*\K\d+(?= failed)' test-output.txt || echo 0)
+
+              if [ "${TEST_EXIT}" -eq 0 ]; then
+                RESULT="SUCCESS"
+                NOTE="All platform infrastructure tests passed"
+              else
+                RESULT="FAILURE"
+                NOTE="${FAILURES} test(s) failed"
+              fi
+
+              echo ""
+              echo "========================================="
+              echo "Result: ${RESULT}"
+              echo "Passed: ${SUCCESSES}, Failed: ${FAILURES}"
               echo "========================================="
 
               cat > $(results.TEST_OUTPUT.path) <<RESULT
-              {"result":"SUCCESS","timestamp":"${TIMESTAMP}","successes":1,"failures":0,"warnings":0,"note":"Smoke test passed"}
+              {"result":"${RESULT}","timestamp":"${TIMESTAMP}","successes":${SUCCESSES},"failures":${FAILURES},"warnings":0,"note":"${NOTE}"}
               RESULT

--- a/.tekton/platform-infra-tests-pipeline.yaml
+++ b/.tekton/platform-infra-tests-pipeline.yaml
@@ -27,7 +27,9 @@ spec:
             image: registry.access.redhat.com/ubi9/nodejs-20:latest
             env:
               - name: PLATFORM_INFRA_ENV
-                value: prod
+                value: stage
+              - name: CI
+                value: "true"
             script: |
               #!/bin/bash
               set -euo pipefail

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "playwright:headed": "playwright test --headed",
     "playwright:ui": "playwright test --ui",
     "playwright:debug": "playwright test --debug",
+    "playwright:platform-infra": "playwright test playwright/e2e/platform-infra/",
     "playwright:report": "playwright show-report",
     "test:playwright": "playwright test",
     "translations": "npm-run-all translations:*",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "playwright:headed": "playwright test --headed",
     "playwright:ui": "playwright test --ui",
     "playwright:debug": "playwright test --debug",
+    "playwright:platform-infra": "playwright test playwright/e2e/platform-infra/",
     "playwright:report": "playwright show-report",
     "test:playwright": "playwright test",
     "translations": "npm-run-all translations:*",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './playwright/e2e',
+  testIgnore: ['**/platform-infra/**'],
 
   /* Global setup for authentication */
   globalSetup: require.resolve('./playwright/setup/global-setup'),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './playwright/e2e',
-  testIgnore: ['**/platform-infra/**'],
+  testIgnore: process.env.PLATFORM_INFRA_ENV ? [] : ['**/platform-infra/**'],
 
   /* Global setup for authentication */
   globalSetup: require.resolve('./playwright/setup/global-setup'),

--- a/playwright/e2e/platform-infra/akamai-redirects.spec.ts
+++ b/playwright/e2e/platform-infra/akamai-redirects.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, APIRequestContext } from '@playwright/test';
+import { APIRequestContext, expect, test } from '@playwright/test';
 import { getConfig } from './route-data';
 
 const RATE_LIMIT_DELAY = 250;

--- a/playwright/e2e/platform-infra/akamai-redirects.spec.ts
+++ b/playwright/e2e/platform-infra/akamai-redirects.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { getConfig } from './route-data';
+
+const RATE_LIMIT_DELAY = 250;
+const config = getConfig();
+
+test.describe('Akamai redirects', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let requestContext: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    requestContext = await playwright.request.newContext({
+      baseURL: config.baseUrl,
+      ignoreHTTPSErrors: true,
+      ...(config.proxy && { proxy: { server: config.proxy } }),
+    });
+  });
+
+  test.afterAll(async () => {
+    await requestContext?.dispose();
+  });
+
+  for (const { oldPath, newPath } of config.redirects) {
+    test(`${oldPath} -> ${newPath}`, async () => {
+      await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY));
+
+      const response = await requestContext.get(oldPath);
+      const finalUrl = response.url();
+      const expected = `${config.baseUrl}${newPath}`;
+
+      expect(finalUrl.replace(/\/$/, '')).toBe(expected.replace(/\/$/, ''));
+    });
+  }
+});

--- a/playwright/e2e/platform-infra/google-cloud-redirects.spec.ts
+++ b/playwright/e2e/platform-infra/google-cloud-redirects.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { getConfig } from './route-data';
+
+const RATE_LIMIT_DELAY = 250;
+const config = getConfig();
+
+test.describe('OpenShift Google Cloud redirects', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let requestContext: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    requestContext = await playwright.request.newContext({
+      ignoreHTTPSErrors: true,
+      ...(config.proxy && { proxy: { server: config.proxy } }),
+    });
+  });
+
+  test.afterAll(async () => {
+    await requestContext?.dispose();
+  });
+
+  for (const { sourceUrl, expectedUrl } of config.crossHostRedirects) {
+    test(`${sourceUrl} -> ${expectedUrl}`, async () => {
+      await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY));
+
+      const response = await requestContext.get(sourceUrl);
+      const finalUrl = response.url();
+
+      expect(finalUrl.replace(/\/$/, '')).toBe(expectedUrl.replace(/\/$/, ''));
+    });
+  }
+});

--- a/playwright/e2e/platform-infra/google-cloud-redirects.spec.ts
+++ b/playwright/e2e/platform-infra/google-cloud-redirects.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, APIRequestContext } from '@playwright/test';
+import { APIRequestContext, expect, test } from '@playwright/test';
 import { getConfig } from './route-data';
 
 const RATE_LIMIT_DELAY = 250;

--- a/playwright/e2e/platform-infra/route-data.ts
+++ b/playwright/e2e/platform-infra/route-data.ts
@@ -1,0 +1,133 @@
+export interface RedirectRoute {
+  oldPath: string;
+  newPath: string;
+}
+
+export interface ReachabilityRoute {
+  path: string;
+  description: string;
+}
+
+export interface EnvironmentConfig {
+  baseUrl: string;
+  proxy?: string;
+  redirects: RedirectRoute[];
+  reachabilityRoutes: ReachabilityRoute[];
+}
+
+// Migrated from iqe-platform-ui-plugin conf/platform_ui.default.yaml
+// Some routes may be stale -- run tests and prune failures
+const stageRedirects: RedirectRoute[] = [
+  { oldPath: '/cost-management/cost-models', newPath: '/openshift/cost-management/cost-models' },
+  { oldPath: '/cost-management/infrastructure/gcp', newPath: '/openshift/cost-management/gcp' },
+  { oldPath: '/cost-management/infrastructure/azure', newPath: '/openshift/cost-management/azure' },
+  { oldPath: '/cost-management/infrastructure/aws', newPath: '/openshift/cost-management/aws' },
+  { oldPath: '/cost-management/ocp', newPath: '/openshift/cost-management/ocp' },
+  { oldPath: '/cost-management', newPath: '/openshift/cost-management' },
+  { oldPath: '/ansible/automation-analytics', newPath: '/ansible/automation-analytics' },
+  { oldPath: '/ansible/automation-analytics/automation-calculator', newPath: '/ansible/automation-analytics/automation-calculator' },
+  { oldPath: '/ansible/automation-analytics/organization-statistics', newPath: '/ansible/automation-analytics/organization-statistics' },
+  { oldPath: '/ansible/automation-analytics/job-explorer', newPath: '/ansible/automation-analytics/job-explorer' },
+  { oldPath: '/ansible/automation-analytics/clusters', newPath: '/ansible/automation-analytics/clusters' },
+  { oldPath: '/ansible/automation-analytics/notifications', newPath: '/ansible/automation-analytics/notifications' },
+  { oldPath: '/preview/settings/sources', newPath: '/settings/integrations' },
+  { oldPath: '/preview/openshift/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/preview/application-services/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/preview/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
+  { oldPath: '/preview/insights/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/preview/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
+  { oldPath: '/preview/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
+  { oldPath: '/openshift/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/application-services/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
+  { oldPath: '/insights/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
+  { oldPath: '/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
+  { oldPath: '/application-services/service-accounts', newPath: '/iam/service-accounts' },
+];
+
+const prodRedirects: RedirectRoute[] = [
+  { oldPath: '/cost-management/cost-models', newPath: '/openshift/cost-management/cost-models' },
+  { oldPath: '/cost-management/infrastructure/gcp', newPath: '/openshift/cost-management/gcp' },
+  { oldPath: '/cost-management/infrastructure/azure', newPath: '/openshift/cost-management/azure' },
+  { oldPath: '/cost-management/infrastructure/aws', newPath: '/openshift/cost-management/aws' },
+  { oldPath: '/cost-management/ocp', newPath: '/openshift/cost-management/ocp' },
+  { oldPath: '/cost-management', newPath: '/openshift/cost-management' },
+  { oldPath: '/ansible/automation-analytics', newPath: '/ansible/automation-analytics' },
+  { oldPath: '/ansible/automation-analytics/automation-calculator', newPath: '/ansible/automation-analytics/automation-calculator' },
+  { oldPath: '/ansible/automation-analytics/organization-statistics', newPath: '/ansible/automation-analytics/organization-statistics' },
+  { oldPath: '/ansible/automation-analytics/job-explorer', newPath: '/ansible/automation-analytics/job-explorer' },
+  { oldPath: '/ansible/automation-analytics/clusters', newPath: '/ansible/automation-analytics/clusters' },
+  { oldPath: '/ansible/automation-analytics/notifications', newPath: '/ansible/automation-analytics/notifications' },
+  { oldPath: '/preview/settings/sources', newPath: '/settings/integrations' },
+  { oldPath: '/preview/openshift/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/preview/application-services/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/preview/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
+  { oldPath: '/preview/insights/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/preview/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
+  { oldPath: '/preview/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
+  { oldPath: '/openshift/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/application-services/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
+  { oldPath: '/insights/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
+  { oldPath: '/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
+  { oldPath: '/application-services/service-accounts', newPath: '/iam/service-accounts' },
+];
+
+const stageReachabilityRoutes: ReachabilityRoute[] = [
+  { path: '/insights/dashboard', description: 'Insights Dashboard' },
+  { path: '/insights/advisor/recommendations', description: 'Advisor Recommendations' },
+  { path: '/insights/vulnerability/cves', description: 'Vulnerability CVEs' },
+  { path: '/insights/patch/advisories', description: 'Patch Advisories' },
+  { path: '/insights/inventory', description: 'Inventory' },
+  { path: '/openshift', description: 'OpenShift Overview' },
+  { path: '/openshift/cost-management', description: 'Cost Management' },
+  { path: '/ansible/automation-analytics', description: 'Automation Analytics' },
+  { path: '/settings/integrations', description: 'Integrations' },
+  { path: '/settings/notifications', description: 'Notifications' },
+  { path: '/iam/user-access/roles', description: 'User Access Roles' },
+  { path: '/iam/service-accounts', description: 'Service Accounts' },
+  { path: '/subscriptions/usage', description: 'Subscriptions Usage' },
+];
+
+const prodReachabilityRoutes: ReachabilityRoute[] = [
+  { path: '/insights/dashboard', description: 'Insights Dashboard' },
+  { path: '/insights/advisor/recommendations', description: 'Advisor Recommendations' },
+  { path: '/insights/vulnerability/cves', description: 'Vulnerability CVEs' },
+  { path: '/insights/patch/advisories', description: 'Patch Advisories' },
+  { path: '/insights/inventory', description: 'Inventory' },
+  { path: '/openshift', description: 'OpenShift Overview' },
+  { path: '/openshift/cost-management', description: 'Cost Management' },
+  { path: '/ansible/automation-analytics', description: 'Automation Analytics' },
+  { path: '/settings/integrations', description: 'Integrations' },
+  { path: '/settings/notifications', description: 'Notifications' },
+  { path: '/iam/user-access/roles', description: 'User Access Roles' },
+  { path: '/iam/service-accounts', description: 'Service Accounts' },
+  { path: '/subscriptions/usage', description: 'Subscriptions Usage' },
+];
+
+const STAGE_PROXY = 'http://squid.corp.redhat.com:3128';
+
+const configs: Record<string, EnvironmentConfig> = {
+  stage: {
+    baseUrl: 'https://console.stage.redhat.com',
+    proxy: STAGE_PROXY,
+    redirects: stageRedirects,
+    reachabilityRoutes: stageReachabilityRoutes,
+  },
+  prod: {
+    baseUrl: 'https://console.redhat.com',
+    redirects: prodRedirects,
+    reachabilityRoutes: prodReachabilityRoutes,
+  },
+};
+
+export function getConfig(env?: string): EnvironmentConfig {
+  const environment = env || process.env.PLATFORM_INFRA_ENV || 'stage';
+  const config = configs[environment];
+  if (!config) {
+    throw new Error(`Unknown environment: ${environment}. Expected 'stage' or 'prod'.`);
+  }
+  return config;
+}

--- a/playwright/e2e/platform-infra/route-data.ts
+++ b/playwright/e2e/platform-infra/route-data.ts
@@ -107,12 +107,12 @@ const prodReachabilityRoutes: ReachabilityRoute[] = [
   { path: '/subscriptions/usage', description: 'Subscriptions Usage' },
 ];
 
-const STAGE_PROXY = 'http://squid.corp.redhat.com:3128';
+const STAGE_PROXY = process.env.CI ? undefined : 'http://squid.corp.redhat.com:3128';
 
 const configs: Record<string, EnvironmentConfig> = {
   stage: {
     baseUrl: 'https://console.stage.redhat.com',
-    proxy: STAGE_PROXY,
+    ...(STAGE_PROXY && { proxy: STAGE_PROXY }),
     redirects: stageRedirects,
     reachabilityRoutes: stageReachabilityRoutes,
   },

--- a/playwright/e2e/platform-infra/route-data.ts
+++ b/playwright/e2e/platform-infra/route-data.ts
@@ -15,21 +15,75 @@ export interface EnvironmentConfig {
   reachabilityRoutes: ReachabilityRoute[];
 }
 
-// Migrated from iqe-platform-ui-plugin conf/platform_ui.default.yaml
-// Some routes may be stale -- run tests and prune failures
-const stageRedirects: RedirectRoute[] = [
+// Sourced from Akamai Edge Redirector policy er_console (Policy 185335, Version 55)
+// Rules targeting different hosts (openshift.googlecloud.*) or external
+// destinations (sandbox.redhat.com, qualtrics, developers.redhat.com) are
+// excluded -- those require separate test infrastructure.
+const redirects: RedirectRoute[] = [
+  // Settings to Insights
+  { oldPath: '/settings/connector', newPath: '/insights/connector' },
+  { oldPath: '/settings/connector/activation-keys', newPath: '/insights/connector/activation-keys' },
+  { oldPath: '/settings/content', newPath: '/insights/content' },
+
+  // Migration assessment to migration advisor
+  { oldPath: '/openshift/migration-assessment', newPath: '/openshift/migration-advisor' },
+
+  // Ansible Policies to Ansible Inventory
+  { oldPath: '/ansible/policies', newPath: '/ansible/inventory' },
+
+  // Insights Policies to Insights Dashboard
+  { oldPath: '/insights/policies', newPath: '/insights/dashboard' },
+
+  // Insights SAP to Dashboard
+  { oldPath: '/insights/sap', newPath: '/insights/dashboard#workloads=SAP' },
+
+  // Insights Drift to Dashboard
+  { oldPath: '/insights/drift', newPath: '/insights/dashboard' },
+
+  // Application Services ACS to OpenShift ACS
+  { oldPath: '/application-services/acs', newPath: '/openshift/acs' },
+
+  // Stonesoup to Application Pipeline
+  { oldPath: '/stonesoup', newPath: '/application-pipeline' },
+
+  // Settings Sources to Integrations
+  { oldPath: '/settings/sources', newPath: '/settings/integrations' },
+
+  // Subscriptions bundle redirects
+  { oldPath: '/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
+  { oldPath: '/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
+  { oldPath: '/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
+  { oldPath: '/subscriptions/rhel-sw', newPath: '/subscriptions/usage/rhel' },
+  { oldPath: '/insights/subscriptions/rhel', newPath: '/subscriptions/usage/rhel' },
+  { oldPath: '/openshift/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/application-services/subscriptions', newPath: '/subscriptions/usage' },
+  { oldPath: '/insights/subscriptions', newPath: '/subscriptions/usage' },
+
+  // Service Accounts
+  { oldPath: '/application-services/service-accounts', newPath: '/iam/service-accounts' },
+
+  // RBAC to User Access
+  { oldPath: '/settings/rbac', newPath: '/iam/user-access' },
+
+  // Ansible Insights to Automation Analytics
+  { oldPath: '/ansible/insights/notifications', newPath: '/ansible/automation-analytics/notifications' },
+  { oldPath: '/ansible/insights/clusters', newPath: '/ansible/automation-analytics/clusters' },
+  { oldPath: '/ansible/insights/job-explorer', newPath: '/ansible/automation-analytics/job-explorer' },
+  { oldPath: '/ansible/insights/organization-statistics', newPath: '/ansible/automation-analytics/organization-statistics' },
+  { oldPath: '/ansible/insights/savings-planner', newPath: '/ansible/automation-analytics/savings-planner' },
+  { oldPath: '/ansible/insights/reports', newPath: '/ansible/automation-analytics/reports' },
+  { oldPath: '/ansible/insights/automation-calculator', newPath: '/ansible/automation-analytics/reports/automation_calculator' },
+  { oldPath: '/ansible/insights', newPath: '/ansible/automation-analytics' },
+
+  // Cost Management
   { oldPath: '/cost-management/cost-models', newPath: '/openshift/cost-management/cost-models' },
   { oldPath: '/cost-management/infrastructure/gcp', newPath: '/openshift/cost-management/gcp' },
   { oldPath: '/cost-management/infrastructure/azure', newPath: '/openshift/cost-management/azure' },
   { oldPath: '/cost-management/infrastructure/aws', newPath: '/openshift/cost-management/aws' },
   { oldPath: '/cost-management/ocp', newPath: '/openshift/cost-management/ocp' },
   { oldPath: '/cost-management', newPath: '/openshift/cost-management' },
-  { oldPath: '/ansible/automation-analytics', newPath: '/ansible/automation-analytics' },
-  { oldPath: '/ansible/automation-analytics/automation-calculator', newPath: '/ansible/automation-analytics/automation-calculator' },
-  { oldPath: '/ansible/automation-analytics/organization-statistics', newPath: '/ansible/automation-analytics/organization-statistics' },
-  { oldPath: '/ansible/automation-analytics/job-explorer', newPath: '/ansible/automation-analytics/job-explorer' },
-  { oldPath: '/ansible/automation-analytics/clusters', newPath: '/ansible/automation-analytics/clusters' },
-  { oldPath: '/ansible/automation-analytics/notifications', newPath: '/ansible/automation-analytics/notifications' },
+
+  // Preview prefix stripping (chained with subsequent redirects)
   { oldPath: '/preview/settings/sources', newPath: '/settings/integrations' },
   { oldPath: '/preview/openshift/subscriptions', newPath: '/subscriptions/usage' },
   { oldPath: '/preview/application-services/subscriptions', newPath: '/subscriptions/usage' },
@@ -37,61 +91,9 @@ const stageRedirects: RedirectRoute[] = [
   { oldPath: '/preview/insights/subscriptions', newPath: '/subscriptions/usage' },
   { oldPath: '/preview/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
   { oldPath: '/preview/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
-  { oldPath: '/openshift/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/application-services/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
-  { oldPath: '/insights/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
-  { oldPath: '/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
-  { oldPath: '/application-services/service-accounts', newPath: '/iam/service-accounts' },
 ];
 
-const prodRedirects: RedirectRoute[] = [
-  { oldPath: '/cost-management/cost-models', newPath: '/openshift/cost-management/cost-models' },
-  { oldPath: '/cost-management/infrastructure/gcp', newPath: '/openshift/cost-management/gcp' },
-  { oldPath: '/cost-management/infrastructure/azure', newPath: '/openshift/cost-management/azure' },
-  { oldPath: '/cost-management/infrastructure/aws', newPath: '/openshift/cost-management/aws' },
-  { oldPath: '/cost-management/ocp', newPath: '/openshift/cost-management/ocp' },
-  { oldPath: '/cost-management', newPath: '/openshift/cost-management' },
-  { oldPath: '/ansible/automation-analytics', newPath: '/ansible/automation-analytics' },
-  { oldPath: '/ansible/automation-analytics/automation-calculator', newPath: '/ansible/automation-analytics/automation-calculator' },
-  { oldPath: '/ansible/automation-analytics/organization-statistics', newPath: '/ansible/automation-analytics/organization-statistics' },
-  { oldPath: '/ansible/automation-analytics/job-explorer', newPath: '/ansible/automation-analytics/job-explorer' },
-  { oldPath: '/ansible/automation-analytics/clusters', newPath: '/ansible/automation-analytics/clusters' },
-  { oldPath: '/ansible/automation-analytics/notifications', newPath: '/ansible/automation-analytics/notifications' },
-  { oldPath: '/preview/settings/sources', newPath: '/settings/integrations' },
-  { oldPath: '/preview/openshift/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/preview/application-services/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/preview/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
-  { oldPath: '/preview/insights/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/preview/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
-  { oldPath: '/preview/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
-  { oldPath: '/openshift/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/application-services/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/business-services/hybrid-committed-spend', newPath: '/subscriptions/hybrid-committed-spend' },
-  { oldPath: '/insights/subscriptions', newPath: '/subscriptions/usage' },
-  { oldPath: '/insights/subscriptions/inventory', newPath: '/subscriptions/inventory' },
-  { oldPath: '/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
-  { oldPath: '/application-services/service-accounts', newPath: '/iam/service-accounts' },
-];
-
-const stageReachabilityRoutes: ReachabilityRoute[] = [
-  { path: '/insights/dashboard', description: 'Insights Dashboard' },
-  { path: '/insights/advisor/recommendations', description: 'Advisor Recommendations' },
-  { path: '/insights/vulnerability/cves', description: 'Vulnerability CVEs' },
-  { path: '/insights/patch/advisories', description: 'Patch Advisories' },
-  { path: '/insights/inventory', description: 'Inventory' },
-  { path: '/openshift', description: 'OpenShift Overview' },
-  { path: '/openshift/cost-management', description: 'Cost Management' },
-  { path: '/ansible/automation-analytics', description: 'Automation Analytics' },
-  { path: '/settings/integrations', description: 'Integrations' },
-  { path: '/settings/notifications', description: 'Notifications' },
-  { path: '/iam/user-access/roles', description: 'User Access Roles' },
-  { path: '/iam/service-accounts', description: 'Service Accounts' },
-  { path: '/subscriptions/usage', description: 'Subscriptions Usage' },
-];
-
-const prodReachabilityRoutes: ReachabilityRoute[] = [
+const reachabilityRoutes: ReachabilityRoute[] = [
   { path: '/insights/dashboard', description: 'Insights Dashboard' },
   { path: '/insights/advisor/recommendations', description: 'Advisor Recommendations' },
   { path: '/insights/vulnerability/cves', description: 'Vulnerability CVEs' },
@@ -113,13 +115,13 @@ const configs: Record<string, EnvironmentConfig> = {
   stage: {
     baseUrl: 'https://console.stage.redhat.com',
     ...(STAGE_PROXY && { proxy: STAGE_PROXY }),
-    redirects: stageRedirects,
-    reachabilityRoutes: stageReachabilityRoutes,
+    redirects,
+    reachabilityRoutes,
   },
   prod: {
     baseUrl: 'https://console.redhat.com',
-    redirects: prodRedirects,
-    reachabilityRoutes: prodReachabilityRoutes,
+    redirects,
+    reachabilityRoutes,
   },
 };
 

--- a/playwright/e2e/platform-infra/route-data.ts
+++ b/playwright/e2e/platform-infra/route-data.ts
@@ -8,17 +8,22 @@ export interface ReachabilityRoute {
   description: string;
 }
 
+export interface CrossHostRedirectRoute {
+  sourceUrl: string;
+  expectedUrl: string;
+}
+
 export interface EnvironmentConfig {
   baseUrl: string;
   proxy?: string;
   redirects: RedirectRoute[];
+  crossHostRedirects: CrossHostRedirectRoute[];
   reachabilityRoutes: ReachabilityRoute[];
 }
 
 // Sourced from Akamai Edge Redirector policy er_console (Policy 185335, Version 55)
-// Rules targeting different hosts (openshift.googlecloud.*) or external
-// destinations (sandbox.redhat.com, qualtrics, developers.redhat.com) are
-// excluded -- those require separate test infrastructure.
+// Rules redirecting to external destinations (sandbox.redhat.com, qualtrics,
+// developers.redhat.com) are excluded.
 const redirects: RedirectRoute[] = [
   // Settings to Insights
   { oldPath: '/settings/connector', newPath: '/insights/connector' },
@@ -93,6 +98,26 @@ const redirects: RedirectRoute[] = [
   { oldPath: '/preview/insights/subscriptions/manifests', newPath: '/subscriptions/manifests' },
 ];
 
+// OpenShift Google Cloud cross-host redirects
+const crossHostRedirects: Record<string, CrossHostRedirectRoute[]> = {
+  stage: [
+    { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/overview', expectedUrl: 'https://console.stage.redhat.com/openshift/overview' },
+    { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/osd/create', expectedUrl: 'https://console.stage.redhat.com/openshift/create/osdgcp' },
+    { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/osd', expectedUrl: 'https://console.stage.redhat.com/openshift/overview/osd' },
+    { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/ocp/create', expectedUrl: 'https://console.stage.redhat.com/openshift/install/gcp' },
+    { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/list', expectedUrl: 'https://console.stage.redhat.com/openshift/cluster-list?plan_id=OSD,OCP' },
+    { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/', expectedUrl: 'https://console.stage.redhat.com/openshift/' },
+  ],
+  prod: [
+    { sourceUrl: 'https://openshift.googlecloud.redhat.com/overview', expectedUrl: 'https://console.redhat.com/openshift/overview' },
+    { sourceUrl: 'https://openshift.googlecloud.redhat.com/osd/create', expectedUrl: 'https://console.redhat.com/openshift/create/osdgcp' },
+    { sourceUrl: 'https://openshift.googlecloud.redhat.com/osd', expectedUrl: 'https://console.redhat.com/openshift/overview/osd' },
+    { sourceUrl: 'https://openshift.googlecloud.redhat.com/ocp/create', expectedUrl: 'https://console.redhat.com/openshift/install/gcp' },
+    { sourceUrl: 'https://openshift.googlecloud.redhat.com/list', expectedUrl: 'https://console.redhat.com/openshift/cluster-list?plan_id=OSD,OCP' },
+    { sourceUrl: 'https://openshift.googlecloud.redhat.com/', expectedUrl: 'https://console.redhat.com/openshift/' },
+  ],
+};
+
 const reachabilityRoutes: ReachabilityRoute[] = [
   { path: '/insights/dashboard', description: 'Insights Dashboard' },
   { path: '/insights/advisor/recommendations', description: 'Advisor Recommendations' },
@@ -116,11 +141,13 @@ const configs: Record<string, EnvironmentConfig> = {
     baseUrl: 'https://console.stage.redhat.com',
     ...(STAGE_PROXY && { proxy: STAGE_PROXY }),
     redirects,
+    crossHostRedirects: crossHostRedirects.stage,
     reachabilityRoutes,
   },
   prod: {
     baseUrl: 'https://console.redhat.com',
     redirects,
+    crossHostRedirects: crossHostRedirects.prod,
     reachabilityRoutes,
   },
 };

--- a/playwright/e2e/platform-infra/route-data.ts
+++ b/playwright/e2e/platform-infra/route-data.ts
@@ -105,7 +105,10 @@ const crossHostRedirects: Record<string, CrossHostRedirectRoute[]> = {
     { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/osd/create', expectedUrl: 'https://console.stage.redhat.com/openshift/create/osdgcp' },
     { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/osd', expectedUrl: 'https://console.stage.redhat.com/openshift/overview/osd' },
     { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/ocp/create', expectedUrl: 'https://console.stage.redhat.com/openshift/install/gcp' },
-    { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/list', expectedUrl: 'https://console.stage.redhat.com/openshift/cluster-list?plan_id=OSD,OCP' },
+    {
+      sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/list',
+      expectedUrl: 'https://console.stage.redhat.com/openshift/cluster-list?plan_id=OSD,OCP',
+    },
     { sourceUrl: 'https://openshift.googlecloud.stage.redhat.com/', expectedUrl: 'https://console.stage.redhat.com/openshift/' },
   ],
   prod: [

--- a/playwright/e2e/platform-infra/route-reachability.spec.ts
+++ b/playwright/e2e/platform-infra/route-reachability.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { getConfig } from './route-data';
+
+const RATE_LIMIT_DELAY = 250;
+const config = getConfig();
+
+test.describe('Route reachability', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let requestContext: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    requestContext = await playwright.request.newContext({
+      baseURL: config.baseUrl,
+      ignoreHTTPSErrors: true,
+      ...(config.proxy && { proxy: { server: config.proxy } }),
+    });
+  });
+
+  test.afterAll(async () => {
+    await requestContext?.dispose();
+  });
+
+  for (const { path, description } of config.reachabilityRoutes) {
+    test(`${path} (${description}) returns 200`, async () => {
+      await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY));
+
+      const response = await requestContext.get(path);
+      expect(response.status()).toBe(200);
+    });
+  }
+});

--- a/playwright/e2e/platform-infra/route-reachability.spec.ts
+++ b/playwright/e2e/platform-infra/route-reachability.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, APIRequestContext } from '@playwright/test';
+import { APIRequestContext, expect, test } from '@playwright/test';
 import { getConfig } from './route-data';
 
 const RATE_LIMIT_DELAY = 250;

--- a/playwright/setup/global-setup.ts
+++ b/playwright/setup/global-setup.ts
@@ -6,7 +6,7 @@ import { AUTH_TIMEOUT, NAVIGATION_TIMEOUT } from './constants';
 async function globalSetup(config: FullConfig) {
   const { storageState, baseURL } = config.projects[0].use;
 
-  if (!storageState) {
+  if (!storageState || !process.env.E2E_USER) {
     return;
   }
 


### PR DESCRIPTION
## Summary

- Add Playwright-based platform infrastructure tests that validate Akamai CDN redirects and key route availability against stage/prod
- Uses `APIRequestContext` (no browser needed) for fast HTTP-level testing
- Migrates 26 redirect route pairs from the legacy `iqe-platform-ui` plugin
- Adds 13 route reachability checks across major application bundles
- Environment-parameterized with squid proxy support for stage

## Context

These tests are designed to run on a schedule via a Konflux CronJob (configured in [konflux-release-data MR !20736](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/20736)). The smoke test pipeline PR is at #3649.

All 39 tests pass against stage as of 2026-08-12.

## Test plan

- [x] Run redirect tests against stage: `PLATFORM_INFRA_ENV=stage npx playwright test playwright/e2e/platform-infra/akamai-redirects.spec.ts` (26/26 passed)
- [x] Run reachability tests against stage: `PLATFORM_INFRA_ENV=stage npx playwright test playwright/e2e/platform-infra/route-reachability.spec.ts` (13/13 passed)
- [ ] Validate against prod after merge
- [ ] Wire up Slack failure notifications to #team-consoledot-experience-notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks for Akamai redirects and route availability across staging and production environments.
  * Added configurable environment selection and proxy support.
  * Added an npm command for running platform infrastructure tests.

* **Bug Fixes**
  * Improved test setup so authentication is initialized only when required credentials are configured.

* **Chores**
  * Scheduled daily staging infrastructure checks with standardized success and failure reporting.
  * Isolated platform infrastructure checks from the default Playwright test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->