### PR TITLE
feat: Skip inventory RBAC call when hbi.rbac-v2 flag is enabled

### DIFF
--- a/src/components/GlobalFilter/GlobalFilter.test.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.test.tsx
@@ -83,7 +83,13 @@ describe('GlobalFilterWrapper', () => {
   });
 
   it('should skip getUserPermissions when rbac.workspaces flag is enabled', async () => {
-    mockedUseFlag.mockReturnValue(true);
+    mockedUseFlag.mockImplementation((flag: string) => flag === 'platform.rbac.workspaces');
+    render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
+  });
+
+  it('should skip getUserPermissions when hbi.rbac-v2 flag is enabled', async () => {
+    mockedUseFlag.mockImplementation((flag: string) => flag === 'hbi.rbac-v2');
     render(<GlobalFilterWrapper />, { wrapper: Wrapper });
     await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
   });

--- a/src/components/GlobalFilter/GlobalFilter.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.tsx
@@ -177,6 +177,7 @@ const GlobalFilterWrapper = () => {
   const { pathname } = useLocation();
   const { getUserPermissions } = useContext(InternalChromeContext);
   const isRbacV2 = useFlag('platform.rbac.workspaces');
+  const isHbiRbacV2 = useFlag('hbi.rbac-v2');
   const hideGlobalFilterFlag = useFlag('platform.chrome.hide.global-filter');
 
   // FIXME: Clean up the global filter display flag
@@ -193,7 +194,7 @@ const GlobalFilterWrapper = () => {
   }, [isLanding, isAllowed, isGlobalFilterDisabled, hideGlobalFilterFlag, globalFilterRemoved]);
 
   useEffect(() => {
-    if (isRbacV2) {
+    if (isRbacV2 || isHbiRbacV2) {
       setHasAccess(false);
       return;
     }
@@ -213,7 +214,7 @@ const GlobalFilterWrapper = () => {
     return () => {
       mounted = false;
     };
-  }, [isRbacV2]);
+  }, [isRbacV2, isHbiRbacV2]);
   return isGlobalFilterEnabled && chromeAuth.ready ? <GlobalFilter hasAccess={hasAccess} /> : null;
 };
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

[RHCLOUD-50296](https://redhat.atlassian.net/browse/RHCLOUD-50296)

HBI is migrating from RBAC to Kessel for access checks. The GlobalFilterWrapper was unconditionally calling /access/?application=inventory on every page load, even when the legacy RBAC response is no longer meaningful. This adds the hbi.rbac-v2 feature flag check alongside the existing platform.rbac.workspaces guard to skip the call for users on the new access model.

---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

https://redhat-internal.slack.com/archives/C064X43CMLK/p1786459021301489

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Claude Code

[RHCLOUD-50296]: https://redhat.atlassian.net/browse/RHCLOUD-50296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access controls so global filtering is disabled when workspace-based or enhanced role-based access settings are enabled.
  * Ensured access behavior updates correctly when these settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->