### PR TITLE
Fix: Potential fix for access inventory call before flags loaded

### DIFF
--- a/src/auth/fetchPermissions.test.js
+++ b/src/auth/fetchPermissions.test.js
@@ -93,4 +93,50 @@ describe('fetchPermissions', () => {
 
     unleashClientExists.mockReturnValue(false);
   });
+
+  it('should skip inventory RBAC call when hbi.rbac-v2 flag is enabled', async () => {
+    unleashClientExists.mockReturnValue(true);
+    getUnleashClient.mockReturnValue({
+      isEnabled: jest.fn((flag) => flag === 'hbi.rbac-v2'),
+    });
+
+    const result = await fetchPermissions('uSeRtOkEn', 'inventory', true);
+
+    expect(result).toEqual([]);
+    expect(global.rbacApiCalled).toEqual(0);
+
+    unleashClientExists.mockReturnValue(false);
+  });
+
+  it('should invalidate cached inventory results when hbi.rbac-v2 becomes enabled', async () => {
+    // First call caches inventory permissions with flag disabled
+    const result1 = await fetchPermissions('uSeRtOkEn', 'inventory');
+    expect(result1).toEqual(mockedRbac.data);
+    expect(global.rbacApiCalled).toEqual(1);
+
+    // Enable hbi.rbac-v2 flag
+    unleashClientExists.mockReturnValue(true);
+    getUnleashClient.mockReturnValue({
+      isEnabled: jest.fn((flag) => flag === 'hbi.rbac-v2'),
+    });
+
+    // Second call should return empty despite cache
+    const result2 = await fetchPermissions('uSeRtOkEn', 'inventory');
+    expect(result2).toEqual([]);
+
+    unleashClientExists.mockReturnValue(false);
+  });
+
+  it('should still allow non-inventory RBAC calls when only hbi.rbac-v2 is enabled', async () => {
+    unleashClientExists.mockReturnValue(true);
+    getUnleashClient.mockReturnValue({
+      isEnabled: jest.fn((flag) => flag === 'hbi.rbac-v2'),
+    });
+
+    await fetchPermissions('uSeRtOkEn', 'sources', true);
+
+    expect(global.rbacApiCalled).toEqual(1);
+
+    unleashClientExists.mockReturnValue(false);
+  });
 });

--- a/src/auth/fetchPermissions.test.js
+++ b/src/auth/fetchPermissions.test.js
@@ -93,4 +93,51 @@ describe('fetchPermissions', () => {
 
     unleashClientExists.mockReturnValue(false);
   });
+
+  it('should skip inventory RBAC call when hbi.rbac-v2 flag is enabled', async () => {
+    unleashClientExists.mockReturnValue(true);
+    getUnleashClient.mockReturnValue({
+      isEnabled: jest.fn((flag) => flag === 'hbi.rbac-v2'),
+    });
+
+    const result = await fetchPermissions('uSeRtOkEn', 'inventory', true);
+
+    expect(result).toEqual([]);
+    expect(global.rbacApiCalled).toEqual(0);
+
+    unleashClientExists.mockReturnValue(false);
+  });
+
+  it('should invalidate cached inventory results when hbi.rbac-v2 becomes enabled', async () => {
+    // First call caches inventory permissions with flag disabled
+    const result1 = await fetchPermissions('uSeRtOkEn', 'inventory');
+    expect(result1).toEqual(mockedRbac.data);
+    expect(global.rbacApiCalled).toEqual(1);
+
+    // Enable hbi.rbac-v2 flag
+    unleashClientExists.mockReturnValue(true);
+    getUnleashClient.mockReturnValue({
+      isEnabled: jest.fn((flag) => flag === 'hbi.rbac-v2'),
+    });
+
+    // Second call should return empty despite cache, without making another API call
+    const result2 = await fetchPermissions('uSeRtOkEn', 'inventory');
+    expect(result2).toEqual([]);
+    expect(global.rbacApiCalled).toEqual(1);
+
+    unleashClientExists.mockReturnValue(false);
+  });
+
+  it('should still allow non-inventory RBAC calls when only hbi.rbac-v2 is enabled', async () => {
+    unleashClientExists.mockReturnValue(true);
+    getUnleashClient.mockReturnValue({
+      isEnabled: jest.fn((flag) => flag === 'hbi.rbac-v2'),
+    });
+
+    await fetchPermissions('uSeRtOkEn', 'sources', true);
+
+    expect(global.rbacApiCalled).toEqual(1);
+
+    unleashClientExists.mockReturnValue(false);
+  });
 });

--- a/src/auth/fetchPermissions.test.js
+++ b/src/auth/fetchPermissions.test.js
@@ -120,9 +120,10 @@ describe('fetchPermissions', () => {
       isEnabled: jest.fn((flag) => flag === 'hbi.rbac-v2'),
     });
 
-    // Second call should return empty despite cache
+    // Second call should return empty despite cache, without making another API call
     const result2 = await fetchPermissions('uSeRtOkEn', 'inventory');
     expect(result2).toEqual([]);
+    expect(global.rbacApiCalled).toEqual(1);
 
     unleashClientExists.mockReturnValue(false);
   });

--- a/src/auth/fetchPermissions.ts
+++ b/src/auth/fetchPermissions.ts
@@ -14,6 +14,10 @@ const fetchPermissions = async (_userToken: string, app = '') => {
     return [];
   }
 
+  if (app === 'inventory' && unleashClientExists() && getUnleashClient().isEnabled('hbi.rbac-v2')) {
+    return [];
+  }
+
   try {
     const resp = await rbacApi.getPrincipalAccess({
       limit: perPage,
@@ -56,6 +60,9 @@ export const createFetchPermissionsWatcher = (getUser: () => Promise<void | Chro
     }
     if (typeof currentCall?.[app] === 'undefined' || bypassCache) {
       currentCall[app] = await fetchPermissions(userToken, app);
+    }
+    if (app === 'inventory' && currentCall[app]?.length && unleashClientExists() && getUnleashClient().isEnabled('hbi.rbac-v2')) {
+      currentCall[app] = [];
     }
     return currentCall?.[app] || [];
   };

--- a/src/components/GlobalFilter/GlobalFilter.test.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider as JotaiProvider, createStore } from 'jotai';
-import { useFlag } from '@unleash/proxy-client-react';
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 import GlobalFilterWrapper from './GlobalFilter';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
 import InternalChromeContext from '../../utils/internalChromeContext';
@@ -11,6 +11,7 @@ import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 
 jest.mock('@unleash/proxy-client-react', () => ({
   useFlag: jest.fn(() => false),
+  useFlagsStatus: jest.fn(() => ({ flagsReady: true, flagsError: false })),
 }));
 
 jest.mock('../../utils/common', () => ({
@@ -38,6 +39,7 @@ jest.mock('@redhat-cloud-services/frontend-components/FilterHooks', () => ({
 }));
 
 const mockedUseFlag = useFlag as jest.Mock;
+const mockedUseFlagsStatus = useFlagsStatus as jest.Mock;
 
 const mockGetUserPermissions = jest.fn(() => Promise.resolve([{ permission: 'inventory:hosts:read' }]));
 
@@ -92,6 +94,28 @@ describe('GlobalFilterWrapper', () => {
     mockedUseFlag.mockImplementation((flag: string) => flag === 'hbi.rbac-v2');
     render(<GlobalFilterWrapper />, { wrapper: Wrapper });
     await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
+  });
+
+  it('should not call getUserPermissions before feature flags are ready', async () => {
+    mockedUseFlagsStatus.mockReturnValue({ flagsReady: false, flagsError: false });
+    render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
+  });
+
+  it('should not call getUserPermissions when flags fail to load', async () => {
+    mockedUseFlagsStatus.mockReturnValue({ flagsReady: false, flagsError: true });
+    render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
+  });
+
+  it('should call getUserPermissions after feature flags become ready', async () => {
+    mockedUseFlagsStatus.mockReturnValue({ flagsReady: false, flagsError: false });
+    const { rerender } = render(<GlobalFilterWrapper />, { wrapper: Wrapper });
+    await waitFor(() => expect(mockGetUserPermissions).not.toHaveBeenCalled());
+
+    mockedUseFlagsStatus.mockReturnValue({ flagsReady: true, flagsError: false });
+    rerender(<GlobalFilterWrapper />);
+    await waitFor(() => expect(mockGetUserPermissions).toHaveBeenCalledWith('inventory'));
   });
 
   it('should hide the global filter when platform.chrome.hide.global-filter is enabled', async () => {

--- a/src/components/GlobalFilter/GlobalFilter.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.tsx
@@ -11,7 +11,7 @@ import { getInitialFilterState } from './getInitialFilterState';
 import { isGlobalFilterAllowed } from '../../utils/common';
 import InternalChromeContext from '../../utils/internalChromeContext';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
-import { useFlag } from '@unleash/proxy-client-react';
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   globalFilterDataAtom,
@@ -179,6 +179,7 @@ const GlobalFilterWrapper = () => {
   const isRbacV2 = useFlag('platform.rbac.workspaces');
   const isHbiRbacV2 = useFlag('hbi.rbac-v2');
   const hideGlobalFilterFlag = useFlag('platform.chrome.hide.global-filter');
+  const { flagsReady } = useFlagsStatus();
 
   // FIXME: Clean up the global filter display flag
   const isLanding = pathname === '/';
@@ -199,6 +200,10 @@ const GlobalFilterWrapper = () => {
       return;
     }
 
+    if (!flagsReady) {
+      return;
+    }
+
     let mounted = true;
     const fetchPermissions = async () => {
       const permissions = await getUserPermissions?.('inventory');
@@ -214,7 +219,7 @@ const GlobalFilterWrapper = () => {
     return () => {
       mounted = false;
     };
-  }, [isRbacV2, isHbiRbacV2]);
+  }, [isRbacV2, isHbiRbacV2, flagsReady]);
   return isGlobalFilterEnabled && chromeAuth.ready ? <GlobalFilter hasAccess={hasAccess} /> : null;
 };
 

--- a/src/components/GlobalFilter/GlobalFilter.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.tsx
@@ -179,7 +179,7 @@ const GlobalFilterWrapper = () => {
   const isRbacV2 = useFlag('platform.rbac.workspaces');
   const isHbiRbacV2 = useFlag('hbi.rbac-v2');
   const hideGlobalFilterFlag = useFlag('platform.chrome.hide.global-filter');
-  const { flagsReady, flagsError } = useFlagsStatus();
+  const { flagsReady } = useFlagsStatus();
 
   // FIXME: Clean up the global filter display flag
   const isLanding = pathname === '/';

--- a/src/components/GlobalFilter/GlobalFilter.tsx
+++ b/src/components/GlobalFilter/GlobalFilter.tsx
@@ -11,7 +11,7 @@ import { getInitialFilterState } from './getInitialFilterState';
 import { isGlobalFilterAllowed } from '../../utils/common';
 import InternalChromeContext from '../../utils/internalChromeContext';
 import ChromeAuthContext from '../../auth/ChromeAuthContext';
-import { useFlag } from '@unleash/proxy-client-react';
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   globalFilterDataAtom,
@@ -179,6 +179,7 @@ const GlobalFilterWrapper = () => {
   const isRbacV2 = useFlag('platform.rbac.workspaces');
   const isHbiRbacV2 = useFlag('hbi.rbac-v2');
   const hideGlobalFilterFlag = useFlag('platform.chrome.hide.global-filter');
+  const { flagsReady, flagsError } = useFlagsStatus();
 
   // FIXME: Clean up the global filter display flag
   const isLanding = pathname === '/';
@@ -199,6 +200,10 @@ const GlobalFilterWrapper = () => {
       return;
     }
 
+    if (!flagsReady) {
+      return;
+    }
+
     let mounted = true;
     const fetchPermissions = async () => {
       const permissions = await getUserPermissions?.('inventory');
@@ -214,7 +219,7 @@ const GlobalFilterWrapper = () => {
     return () => {
       mounted = false;
     };
-  }, [isRbacV2, isHbiRbacV2]);
+  }, [isRbacV2, isHbiRbacV2, flagsReady]);
   return isGlobalFilterEnabled && chromeAuth.ready ? <GlobalFilter hasAccess={hasAccess} /> : null;
 };
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

Potential fix for access inventory calls happening before unleash flags load. As per this slack thread: https://redhat-internal.slack.com/archives/C064X43CMLK/p1786459021301489 

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:


#### After:


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updated inventory permission handling when the relevant feature is enabled.
  * Global filtering now waits for feature flags to finish loading before requesting permissions.

* **Bug Fixes**
  * Prevented premature permission requests while feature flags are loading or unavailable.
  * Ensured cached inventory permissions are cleared when updated handling is enabled.
  * Continued permission requests for non-inventory applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->