### PR TITLE
fix(breadcrumbs): anchor to chrome tree

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -349,4 +349,20 @@ describe('Breadcrumbs', () => {
     process.env.NODE_ENV = originalEnv;
     jest.restoreAllMocks();
   });
+
+  describe('Module Federation Exports', () => {
+    it('should force webpack to include breadcrumb hooks via void reference', async () => {
+      // Import the Breadcrumbs component module to ensure void references execute
+      await import('./Breadcrumbs');
+
+      // Verify hooks are importable (not tree-shaken)
+      const useBreadcrumbsModule = await import('../../hooks/useBreadcrumbs');
+      const useReplaceBreadcrumbsModule = await import('../../hooks/useReplaceBreadcrumbs');
+
+      expect(useBreadcrumbsModule.default).toBeDefined();
+      expect(typeof useBreadcrumbsModule.default).toBe('function');
+      expect(useReplaceBreadcrumbsModule.default).toBeDefined();
+      expect(typeof useReplaceBreadcrumbsModule.default).toBe('function');
+    });
+  });
 });

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -13,6 +13,8 @@ import ChromeLink from '../ChromeLink/ChromeLink';
 import classNames from 'classnames';
 import BreadcrumbsFavorites from './BreadcrumbsFavorites';
 import useFavoritePagesWrapper from '../../hooks/useFavoritePagesWrapper';
+import useBreadcrumbs from '../../hooks/useBreadcrumbs';
+import useReplaceBreadcrumbs from '../../hooks/useReplaceBreadcrumbs';
 import {
   appBreadcrumbOverrideAtom,
   appBreadcrumbSegmentsAtom,
@@ -21,6 +23,11 @@ import {
   breadcrumbReplaceModeAtom,
 } from '../../state/atoms/breadcrumbAtom';
 import { normalizePathname } from '../../utils/breadcrumbUtils';
+
+// Force webpack to treat breadcrumb hooks as used exports so the module cache
+// includes them when remote modules load them via Module Federation.
+void useBreadcrumbs;
+void useReplaceBreadcrumbs;
 
 export type Breadcrumbsprops = {
   isNavOpen?: boolean;


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

Anchors breadcrumb hook toforce it to be included in the webpack build. Similar to https://github.com/RedHatInsights/insights-chrome/pull/3604

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:


#### After:


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component loading reliability in federated applications.
  - Ensured breadcrumb functionality remains available when components are loaded dynamically.
  - Added coverage to verify breadcrumb behavior remains intact across supported loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->