### PR TITLE
fix(auth): strip sso parameters

### DIFF
--- a/src/auth/OIDCConnector/utils.test.ts
+++ b/src/auth/OIDCConnector/utils.test.ts
@@ -1,0 +1,94 @@
+import { AuthContextProps } from 'react-oidc-context';
+import { login, sanitizeRedirectUri } from './utils';
+import { OIDC_RESERVED_PARAMS } from '../../utils/consts';
+
+describe('sanitizeRedirectUri', () => {
+  afterEach(() => {
+    jsdomReset();
+  });
+
+  it('strips every OIDC-reserved param from the query string', () => {
+    const query = OIDC_RESERVED_PARAMS.map((p) => `${p}=x`).join('&');
+    const result = sanitizeRedirectUri(`https://console.redhat.com/insights?${query}`);
+    expect(result).toBe('https://console.redhat.com/insights');
+  });
+
+  it('strips every OIDC-reserved param from the fragment', () => {
+    const fragment = OIDC_RESERVED_PARAMS.map((p) => `${p}=x`).join('&');
+    const result = sanitizeRedirectUri(`https://console.redhat.com/insights#${fragment}`);
+    expect(result).toBe('https://console.redhat.com/insights');
+  });
+
+  it('strips reserved params from a mixed query + fragment while keeping legit content', () => {
+    const result = sanitizeRedirectUri('https://console.redhat.com/insights?from-aws=1&state=abc&code=xyz#workloads=a&session_state=1&tags=b');
+    expect(result).toBe('https://console.redhat.com/insights?from-aws=1#workloads=a&tags=b');
+  });
+
+  it('preserves legitimate query params (noauth, from-aws)', () => {
+    const url = 'https://console.redhat.com/insights?from-aws=1&noauth=tok';
+    expect(sanitizeRedirectUri(url)).toBe(url);
+  });
+
+  it('preserves a legitimate global-filter fragment', () => {
+    const url = 'https://console.redhat.com/insights#workloads=a&tags=b';
+    expect(sanitizeRedirectUri(url)).toBe(url);
+  });
+
+  it('preserves a plain #anchor fragment', () => {
+    const url = 'https://console.redhat.com/insights#dashboard';
+    expect(sanitizeRedirectUri(url)).toBe(url);
+  });
+
+  it('does not leave a dangling # when the fragment becomes empty', () => {
+    const result = sanitizeRedirectUri('https://console.redhat.com/insights#code=abc&state=def');
+    expect(result).toBe('https://console.redhat.com/insights');
+    expect(result).not.toContain('#');
+  });
+
+  it('is a no-op for an already-clean URL', () => {
+    const url = 'https://console.redhat.com/insights/dashboard?from-azure=1';
+    expect(sanitizeRedirectUri(url)).toBe(url);
+  });
+
+  it('is idempotent', () => {
+    const dirty = 'https://console.redhat.com/insights?state=abc&from-gcp=1#code=xyz&workloads=a';
+    const once = sanitizeRedirectUri(dirty);
+    expect(sanitizeRedirectUri(once)).toBe(once);
+  });
+
+  it('defaults to location.href when no argument is passed', () => {
+    jsdomReconfigure({ url: 'https://console.redhat.com/insights?state=abc&from-aws=1' });
+    expect(sanitizeRedirectUri()).toBe('https://console.redhat.com/insights?from-aws=1');
+  });
+});
+
+describe('login', () => {
+  const buildAuth = () =>
+    ({
+      signinRedirect: jest.fn(() => Promise.resolve()),
+    }) as unknown as AuthContextProps;
+
+  afterEach(() => {
+    jsdomReset();
+    jest.clearAllMocks();
+  });
+
+  it('sanitizes the redirect_uri before sending it to SSO', () => {
+    const auth = buildAuth();
+    login(auth, [], 'https://console.redhat.com/insights?state=abc&code=xyz&from-aws=1');
+    expect(auth.signinRedirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirect_uri: 'https://console.redhat.com/insights?from-aws=1',
+      })
+    );
+  });
+
+  it('leaves a clean redirect_uri unchanged and still passes scope + nonce', () => {
+    const auth = buildAuth();
+    login(auth, [], 'https://console.redhat.com/insights');
+    const arg = (auth.signinRedirect as jest.Mock).mock.calls[0][0] as { redirect_uri: string; scope: string; nonce: string };
+    expect(arg.redirect_uri).toBe('https://console.redhat.com/insights');
+    expect(arg.scope).toContain('openid');
+    expect(arg.nonce).toEqual(expect.any(String));
+  });
+});

--- a/src/auth/OIDCConnector/utils.ts
+++ b/src/auth/OIDCConnector/utils.ts
@@ -1,6 +1,6 @@
 import { AuthContextProps } from 'react-oidc-context';
 import { ITLess, LOGIN_SCOPES_STORAGE_KEY, deleteLocalStorageItems } from '../../utils/common';
-import { GLOBAL_FILTER_KEY, OFFLINE_REDIRECT_STORAGE_KEY } from '../../utils/consts';
+import { GLOBAL_FILTER_KEY, OFFLINE_REDIRECT_STORAGE_KEY, OIDC_RESERVED_PARAMS } from '../../utils/consts';
 import Cookies from 'js-cookie';
 import logger from '../logger';
 import createUUID from './createUUID';
@@ -59,6 +59,36 @@ export async function logout(auth: AuthContextProps, bounce?: boolean) {
   }
 }
 
+/**
+ * Removes OIDC-reserved parameters from a URL so they are never forwarded to Red Hat
+ * SSO inside an outgoing `redirect_uri`. SSO rejects authorization requests whose
+ * redirect_uri contains any of these (see {@link OIDC_RESERVED_PARAMS}); they leak in
+ * via the back button, a copy-pasted URL, or an interrupted auth cycle.
+ *
+ * Only the reserved params are stripped — legitimate params survive the login
+ * round-trip: query params (e.g. `noauth`, `from-aws`) and fragment content
+ * (e.g. global-filter `workloads`/`tags`, or a plain `#anchor`).
+ */
+export function sanitizeRedirectUri(href: string = location.href): string {
+  const url = new URL(href);
+  const reserved: readonly string[] = OIDC_RESERVED_PARAMS;
+
+  // strip reserved params from the query string
+  reserved.forEach((param) => url.searchParams.delete(param));
+
+  // strip reserved params from the fragment while keeping legit fragment content
+  // (e.g. global-filter `workloads`/`tags`) and plain `#anchor` values intact
+  if (url.hash) {
+    const kept = url.hash
+      .replace(/^#/, '')
+      .split('&')
+      .filter((entry) => entry.length > 0 && !reserved.includes(entry.split('=')[0]));
+    url.hash = kept.join('&');
+  }
+
+  return url.toString();
+}
+
 export function login(auth: AuthContextProps, requiredScopes: string[] = [], redirectUri = location.href) {
   log('Logging in');
   // Redirect to login
@@ -74,7 +104,9 @@ export function login(auth: AuthContextProps, requiredScopes: string[] = [], red
   localStorage.setItem(LOGIN_SCOPES_STORAGE_KEY, JSON.stringify(scope));
   // KC scopes are delimited by a space character, hence the join(' ')
   return auth.signinRedirect({
-    redirect_uri: redirectUri,
+    // sanitize here so both the default (location.href) and any explicitly-passed
+    // redirectUri are stripped of OIDC-reserved params before reaching SSO
+    redirect_uri: sanitizeRedirectUri(redirectUri),
     scope: scope.join(' '),
     nonce: createUUID(),
   });

--- a/src/auth/offline.test.ts
+++ b/src/auth/offline.test.ts
@@ -84,6 +84,14 @@ describe('offline', () => {
     expect(localStorage.getItem(OFFLINE_REDIRECT_STORAGE_KEY)).toEqual(redirectUri);
   });
 
+  it('strips OIDC-reserved params from the offline redirect but keeps the noauth token', () => {
+    const base = 'https://console.redhat.com/insights?state=abc&code=xyz&from-aws=1';
+    const offlineRedirectUrl = prepareOfflineRedirect(base);
+    expect(offlineRedirectUrl).toEqual(`https://console.redhat.com/insights?from-aws=1&noauth=${offlineToken}`);
+    expect(offlineRedirectUrl).not.toContain('state=');
+    expect(offlineRedirectUrl).not.toContain('code=');
+  });
+
   it('postbackUrlSetup does nothing if URL does not contain offline token', () => {
     postbackUrlSetup();
     expect(pushStateSpy).not.toHaveBeenCalled();

--- a/src/auth/offline.ts
+++ b/src/auth/offline.ts
@@ -1,4 +1,4 @@
-import { OFFLINE_REDIRECT_STORAGE_KEY, noAuthParam, offlineToken } from '../utils/consts';
+import { OFFLINE_REDIRECT_STORAGE_KEY, OIDC_RESERVED_PARAMS, noAuthParam, offlineToken } from '../utils/consts';
 import axios, { AxiosResponse } from 'axios';
 
 export type OfflineTokenResponse = {
@@ -116,6 +116,8 @@ export function postbackUrlSetup() {
 export function prepareOfflineRedirect(base = window.location.href) {
   const url = new URL(base);
   url.hash = '';
+  // strip OIDC-reserved params so they are not forwarded to SSO in the redirect_uri
+  OIDC_RESERVED_PARAMS.forEach((param) => url.searchParams.delete(param));
   url.searchParams.delete(noAuthParam);
   url.searchParams.append(noAuthParam, offlineToken);
   const redirectUri = url.toString().replace('/?', '?');

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -4,6 +4,30 @@ import { Listener } from '@redhat-cloud-services/frontend-components-utilities/M
 
 export const noAuthParam = 'noauth';
 export const offlineToken = '2402500adeacc30eb5c5a8a5e2e0ec1f';
+
+/**
+ * OIDC-reserved parameters that must never be forwarded to Red Hat SSO inside an
+ * outgoing `redirect_uri`. SSO rejects authorization requests whose redirect_uri
+ * contains any of these (they are meant to appear only on the callback URL SSO
+ * returns to us). They can leak into `location.href` via the back button, a
+ * copy-pasted URL, or an interrupted auth cycle, so we strip them before building
+ * a redirect_uri. See `sanitizeRedirectUri` in src/auth/OIDCConnector/utils.ts.
+ */
+export const OIDC_RESERVED_PARAMS = [
+  'access_token',
+  'code',
+  'error',
+  'error_description',
+  'expires_in',
+  'id_token',
+  'iss',
+  'kc_action',
+  'kc_action_status',
+  'response',
+  'session_state',
+  'state',
+  'token_type',
+] as const;
 export const GLOBAL_FILTER_KEY = 'chrome:global-filter';
 export const GLOBAL_FILTER_UPDATE = 'GLOBAL_FILTER_UPDATE';
 export const HYDRA_ENDPOINT = '/hydra/rest/se/sessions';


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

[RHCLOUD-XXXXX](https://issues.redhat.com/browse/RHCLOUD-XXXXX)

Tested locally, seems to not affect auth flow.

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:


#### After:


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized login and offline redirect URLs by removing OIDC callback parameters.
  * Preserved legitimate query parameters, URL fragments, scopes, nonces, and offline authentication tokens.
  * Applied consistent cleanup to both default and explicitly provided redirect URLs.
  * Prevented empty fragments and stale callback details from being carried into redirects.

* **Tests**
  * Added coverage for query strings, fragments, empty fragments, repeated sanitization, default URLs, and redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->