### PR TITLE
feat(logo): Switch lightwell icons based on theme

### DIFF
--- a/src/components/AllServicesDropdown/LightwellServicesLink.test.tsx
+++ b/src/components/AllServicesDropdown/LightwellServicesLink.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider as JotaiProvider, createStore } from 'jotai';
 import NavContext from '../Navigation/navContext';
 import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 import { moduleRoutesAtom } from '../../state/atoms/chromeModuleAtom';
+import { _resetDarkModeStore, getDarkModeStore } from '../../state/stores/darkModeStore';
 import LightwellServicesLink from './LightwellServicesLink';
 
 const renderWithProviders = () => {
@@ -34,6 +35,10 @@ const renderWithProviders = () => {
 };
 
 describe('LightwellServicesLink', () => {
+  beforeEach(() => {
+    _resetDarkModeStore();
+  });
+
   it('should render the Lightwell label', () => {
     renderWithProviders();
     expect(screen.getByText('Lightwell')).toBeInTheDocument();
@@ -51,13 +56,30 @@ describe('LightwellServicesLink', () => {
     expect(link).toHaveAttribute('data-ouia-component-id', 'AllServices-Dropdown-Lightwell');
   });
 
-  it('should render the Lightwell icon using the logomark', () => {
+  it('should render the light Lightwell icon by default', () => {
     const { container } = renderWithProviders();
     const icon = container.querySelector('img[src*="lightwell-logomark"]');
     expect(icon).toBeInTheDocument();
-    expect(icon).toHaveAttribute('src', '/apps/frontend-assets/partners-icons/lightwell-logomark.svg');
+    expect(icon).toHaveAttribute('src', '/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg');
     expect(icon).toHaveAttribute('width', '22');
     expect(icon).toHaveAttribute('height', '22');
+  });
+
+  it('should switch Lightwell icon when the dark mode store updates', () => {
+    const { container } = renderWithProviders();
+    expect(container.querySelector('img')).toHaveAttribute('src', '/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg');
+
+    act(() => {
+      getDarkModeStore().updateState('SET_DARK');
+    });
+
+    expect(container.querySelector('img')).toHaveAttribute('src', '/apps/frontend-assets/partners-icons/lightwell-logomark-dark.svg');
+
+    act(() => {
+      getDarkModeStore().updateState('SET_LIGHT');
+    });
+
+    expect(container.querySelector('img')).toHaveAttribute('src', '/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg');
   });
 
   it('should make the entire content clickable as a single link', () => {

--- a/src/components/AllServicesDropdown/LightwellServicesLink.tsx
+++ b/src/components/AllServicesDropdown/LightwellServicesLink.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import ChromeLink from '../ChromeLink';
 import { Split, SplitItem } from '@patternfly/react-core/dist/dynamic/layouts/Split';
+import { useDarkModeStore } from '../../state/stores/darkModeStore';
 
-/**
- * Lightwell icon using the official logomark from frontend-assets.
- */
-const LightwellIcon = () => <img src="/apps/frontend-assets/partners-icons/lightwell-logomark.svg" alt="" width="22" height="22" />;
+const LIGHTWELL_LOGO_DARK = '/apps/frontend-assets/partners-icons/lightwell-logomark-dark.svg';
+const LIGHTWELL_LOGO_LIGHT = '/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg';
+
+const LightwellIcon = () => {
+  const { isDark } = useDarkModeStore();
+  const src = isDark ? LIGHTWELL_LOGO_DARK : LIGHTWELL_LOGO_LIGHT;
+  return <img src={src} alt="" width="22" height="22" />;
+};
 
 const LightwellServicesLink = () => {
   return (

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -114,6 +114,7 @@ describe('Header Lightwell mode', () => {
     const { container } = renderHeader(true);
     const lightwellLogo = container.querySelector('img[alt="Lightwell Logo"]');
     expect(lightwellLogo).toBeTruthy();
+    expect(lightwellLogo?.getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg');
   });
 
   it('should render search toolbar group when not in Lightwell mode', () => {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -82,9 +82,6 @@ const MemoizedHeader = memo(
 
     const { hideNav, isNavOpen, setIsNavOpen } = breadcrumbsProps || {};
 
-    const rootElementClasses = Array.from(document?.documentElement?.classList);
-    const theme = rootElementClasses.includes('pf-v6-theme-dark') ? 'dark' : 'light';
-
     return (
       <Fragment>
         <MastheadMain>
@@ -98,7 +95,7 @@ const MemoizedHeader = memo(
                 <ChromeLink {...props} {...(isLightwellHeader ? { href: '/lightwell' } : { appId: 'landing', href: '/' })} />
               )}
             >
-              <Logo theme={theme} />
+              <Logo />
             </MastheadLogo>
             {isLightwellHeader ? (
               <ChromeLink href="/lightwell" className="chr-c-masthead__lightwell-title pf-v6-u-font-size-xl pf-v6-u-mt-xs chr-m-plain">

--- a/src/components/Header/Logo.test.tsx
+++ b/src/components/Header/Logo.test.tsx
@@ -1,52 +1,77 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { Provider, createStore } from 'jotai';
 import Logo from './Logo';
 import { layoutLightwellHeaderAtom } from '../../state/atoms/releaseAtom';
-import { describe, expect, it } from '@jest/globals';
+import { _resetDarkModeStore, getDarkModeStore } from '../../state/stores/darkModeStore';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
-const renderLogo = (options: { theme?: 'light' | 'dark'; lightwellHeader?: boolean } = {}) => {
-  const { theme, lightwellHeader = false } = options;
+const renderLogo = (options: { lightwellHeader?: boolean } = {}) => {
+  const { lightwellHeader = false } = options;
   const store = createStore();
   store.set(layoutLightwellHeaderAtom, lightwellHeader);
 
   return render(
     <Provider store={store}>
-      <Logo {...(theme ? { theme } : {})} />
+      <Logo />
     </Provider>
   );
 };
 
 describe('Logo', () => {
+  beforeEach(() => {
+    _resetDarkModeStore();
+  });
+
   it('should render logo by default', () => {
     renderLogo();
     const img = screen.getByAltText('Red Hat Logo');
     expect(img).toBeTruthy();
-    expect(img.getAttribute('src')).not.toBe('/apps/frontend-assets/partners-icons/lightwell-logomark.svg');
+    expect(img.getAttribute('src')).not.toContain('lightwell-logomark');
   });
 
   it('should render Red Hat logo for both themes (not Lightwell)', () => {
     // SVG imports resolve to identical 'test-file-stub' via fileMock.js — cannot distinguish light vs dark in Jest
-    const { unmount } = renderLogo({ theme: 'dark' });
-    const darkImg = screen.getByAltText('Red Hat Logo');
-    expect(darkImg.getAttribute('src')).not.toBe('/apps/frontend-assets/partners-icons/lightwell-logomark.svg');
+    const { unmount } = renderLogo();
+    const lightImg = screen.getByAltText('Red Hat Logo');
+    expect(lightImg.getAttribute('src')).not.toContain('lightwell-logomark');
     unmount();
 
-    renderLogo({ theme: 'light' });
-    const lightImg = screen.getByAltText('Red Hat Logo');
-    expect(lightImg.getAttribute('src')).not.toBe('/apps/frontend-assets/partners-icons/lightwell-logomark.svg');
+    getDarkModeStore().updateState('SET_DARK');
+    renderLogo();
+    const darkImg = screen.getByAltText('Red Hat Logo');
+    expect(darkImg.getAttribute('src')).not.toContain('lightwell-logomark');
   });
 
-  it('should render Lightwell logo and alt text when layoutLightwellHeaderAtom is true', () => {
+  it('should render light Lightwell logo by default when layoutLightwellHeaderAtom is true', () => {
     renderLogo({ lightwellHeader: true });
     const img = screen.getByAltText('Lightwell Logo');
-    expect(img.getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark.svg');
+    expect(img.getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg');
   });
 
-  it('should use Lightwell logo regardless of theme prop when in Lightwell mode', () => {
-    renderLogo({ theme: 'dark', lightwellHeader: true });
+  it('should render dark Lightwell logo when dark mode is active', () => {
+    getDarkModeStore().updateState('SET_DARK');
+    renderLogo({ lightwellHeader: true });
     const img = screen.getByAltText('Lightwell Logo');
-    expect(img.getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark.svg');
+    expect(img.getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark-dark.svg');
+  });
+
+  it('should switch Lightwell logo when the dark mode store updates', () => {
+    renderLogo({ lightwellHeader: true });
+    const img = screen.getByAltText('Lightwell Logo');
+    expect(img.getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg');
+
+    act(() => {
+      getDarkModeStore().updateState('SET_DARK');
+    });
+
+    expect(screen.getByAltText('Lightwell Logo').getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark-dark.svg');
+
+    act(() => {
+      getDarkModeStore().updateState('SET_LIGHT');
+    });
+
+    expect(screen.getByAltText('Lightwell Logo').getAttribute('src')).toBe('/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg');
   });
 
   it('should have chr-c-brand className', () => {

--- a/src/components/Header/Logo.tsx
+++ b/src/components/Header/Logo.tsx
@@ -4,17 +4,19 @@ import darkThemeLogo from '../../../static/images/logo-dark.svg';
 import { Brand } from '@patternfly/react-core/dist/dynamic/components/Brand';
 import { layoutLightwellHeaderAtom } from '../../state/atoms/releaseAtom';
 import { useAtomValue } from 'jotai';
+import { useDarkModeStore } from '../../state/stores/darkModeStore';
 
-interface LogoProps {
-  theme?: 'light' | 'dark';
-}
+const LIGHTWELL_LOGO_DARK = '/apps/frontend-assets/partners-icons/lightwell-logomark-dark.svg';
+const LIGHTWELL_LOGO_LIGHT = '/apps/frontend-assets/partners-icons/lightwell-logomark-light.svg';
 
-const LIGHTWELL_LOGO = '/apps/frontend-assets/partners-icons/lightwell-logomark.svg';
-
-const Logo = ({ theme = 'light' }: LogoProps) => {
+const Logo = () => {
   const isLightwellHeader = useAtomValue(layoutLightwellHeaderAtom);
+  const { isDark } = useDarkModeStore();
 
-  const src = isLightwellHeader ? LIGHTWELL_LOGO : theme === 'light' ? lightThemeLogo : darkThemeLogo;
+  const lightwellLogo = isDark ? LIGHTWELL_LOGO_DARK : LIGHTWELL_LOGO_LIGHT;
+  const rhLogo = isDark ? darkThemeLogo : lightThemeLogo;
+
+  const src = isLightwellHeader ? lightwellLogo : rhLogo;
   const alt = isLightwellHeader ? 'Lightwell Logo' : 'Red Hat Logo';
 
   return <Brand className="chr-c-brand" src={src} alt={alt} heights={{ default: '37px' }} />;


### PR DESCRIPTION
Use light and dark-themed icons. Use useDarkModeStore as the previous approach did not updated when theme was changed. Also add the same logic into All Services dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lightwell and Red Hat header logos now automatically switch between light and dark variants based on the selected theme.
  * Lightwell service links and masthead branding display the appropriate logo for improved visibility across themes.

* **Bug Fixes**
  * Corrected logo asset selection to keep branding consistent across light and dark modes.

* **Tests**
  * Added coverage for default logo rendering and dynamic theme switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->