### PR TITLE
feat: integrate WorkspaceSelector into chrome masthead

### DIFF
--- a/cypress/component/WorkspaceSelector/WorkspaceSelector.cy.tsx
+++ b/cypress/component/WorkspaceSelector/WorkspaceSelector.cy.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Provider as JotaiProvider } from 'jotai';
+import { IntlProvider } from 'react-intl';
+import WorkspaceSelector from '../../../src/components/WorkspaceSelector/WorkspaceSelector';
+import chromeStore from '../../../src/state/chromeStore';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <IntlProvider locale="en">
+    <JotaiProvider store={chromeStore}>{children}</JotaiProvider>
+  </IntlProvider>
+);
+
+describe('WorkspaceSelector', () => {
+  it('should not render when feature flag is disabled', () => {
+    cy.mount(
+      <Wrapper>
+        <WorkspaceSelector />
+      </Wrapper>
+    );
+    cy.get('[data-testid="workspace-selector"]').should('not.exist');
+  });
+});

--- a/cypress/component/WorkspaceSelector/WorkspaceSelector.cy.tsx
+++ b/cypress/component/WorkspaceSelector/WorkspaceSelector.cy.tsx
@@ -1,12 +1,31 @@
 import React from 'react';
 import { Provider as JotaiProvider } from 'jotai';
+import { FlagProvider } from '@unleash/proxy-client-react';
 import { IntlProvider } from 'react-intl';
 import WorkspaceSelector from '../../../src/components/WorkspaceSelector/WorkspaceSelector';
 import chromeStore from '../../../src/state/chromeStore';
 
+const mockUnleashConfig = {
+  url: 'http://localhost:4242/api/frontend',
+  clientKey: 'test-key',
+  appName: 'test-app',
+  refreshInterval: 0,
+  disableRefresh: true,
+  bootstrap: [
+    {
+      name: 'platform.chrome.workspace-global_selector',
+      enabled: false,
+      variant: { name: 'disabled', enabled: false },
+      impressionData: false,
+    },
+  ],
+};
+
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <IntlProvider locale="en">
-    <JotaiProvider store={chromeStore}>{children}</JotaiProvider>
+    <FlagProvider config={mockUnleashConfig}>
+      <JotaiProvider store={chromeStore}>{children}</JotaiProvider>
+    </FlagProvider>
   </IntlProvider>
 );
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -77,6 +77,7 @@ const MemoizedHeader = memo(
       setSearchOpen(isOpen);
     };
     const isITLess = useFlag('platform.chrome.itless');
+    const isWorkspaceSelectorEnabled = useFlag('platform.chrome.workspace-global_selector');
     const isLightwellHeader = useAtomValue(layoutLightwellHeaderAtom);
 
     const userReady = hasUser({ orgId, username, accountNumber, email });
@@ -126,7 +127,7 @@ const MemoizedHeader = memo(
                     <ContextSwitcher orgId={orgId} isInternal={isInternal} className="data-hj-suppress sentry-mask" />
                   </ToolbarItem>
                 )}
-                {userReady && !isITLess && (
+                {userReady && !isITLess && isWorkspaceSelectorEnabled && (
                   <ToolbarItem className="pf-v6-m-hidden pf-v6-m-visible-on-xl">
                     <WorkspaceSelector />
                   </ToolbarItem>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -20,6 +20,7 @@ import { Breadcrumbsprops } from '../Breadcrumbs/Breadcrumbs';
 import useWindowWidth from '../../hooks/useWindowWidth';
 import ChromeAuthContext, { ChromeAuthContextValue } from '../../auth/ChromeAuthContext';
 import { layoutLightwellHeaderAtom } from '../../state/atoms/releaseAtom';
+import WorkspaceSelector from '../WorkspaceSelector';
 
 export type SettingsGroupConfig = {
   showPreview?: boolean;
@@ -123,6 +124,11 @@ const MemoizedHeader = memo(
                 {userReady && !isITLess && (
                   <ToolbarItem className="pf-v6-m-hidden pf-v6-m-visible-on-xl">
                     <ContextSwitcher orgId={orgId} isInternal={isInternal} className="data-hj-suppress sentry-mask" />
+                  </ToolbarItem>
+                )}
+                {userReady && !isITLess && (
+                  <ToolbarItem className="pf-v6-m-hidden pf-v6-m-visible-on-xl">
+                    <WorkspaceSelector />
                   </ToolbarItem>
                 )}
               </ToolbarGroup>

--- a/src/components/WorkspaceSelector/WorkspaceSelector.test.tsx
+++ b/src/components/WorkspaceSelector/WorkspaceSelector.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Provider, createStore } from 'jotai';
+import WorkspaceSelector from './WorkspaceSelector';
+import { selectedWorkspaceAtom } from '../../state/atoms/workspaceSelectorAtom';
+
+type WorkspaceSelectorRemoteProps = {
+  onSelect?: (workspace: { id?: string; name?: string }) => void;
+  scope?: string;
+  module?: string;
+  ErrorComponent?: React.ReactElement;
+  fallback?: React.ReactNode;
+  menuWidth?: string;
+};
+
+const mockUseFlag = jest.fn().mockReturnValue(false);
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: (...args: unknown[]) => mockUseFlag(...args),
+}));
+
+let capturedProps: WorkspaceSelectorRemoteProps | null = null;
+jest.mock('@scalprum/react-core', () => ({
+  ScalprumComponent: (props: WorkspaceSelectorRemoteProps) => {
+    capturedProps = props;
+    return <div data-testid="scalprum-mock">ScalprumComponent</div>;
+  },
+}));
+
+jest.mock('../Routes/SilentErrorBoundary', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@patternfly/react-core/dist/dynamic/components/Skeleton', () => ({
+  Skeleton: () => <div data-testid="skeleton-mock">Loading...</div>,
+}));
+
+const renderComponent = () => {
+  const store = createStore();
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <WorkspaceSelector />
+      </Provider>
+    ),
+  };
+};
+
+describe('WorkspaceSelector', () => {
+  beforeEach(() => {
+    mockUseFlag.mockReturnValue(false);
+    capturedProps = null;
+  });
+
+  it('should return null when feature flag is disabled', () => {
+    const { container } = renderComponent();
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should render ScalprumComponent when feature flag is enabled', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderComponent();
+    expect(screen.getByTestId('workspace-selector')).toBeTruthy();
+    expect(screen.getByTestId('scalprum-mock')).toBeTruthy();
+  });
+
+  it('should pass correct scope and module to ScalprumComponent', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderComponent();
+    expect(capturedProps?.scope).toBe('rbac');
+    expect(capturedProps?.module).toBe('./modules/WorkspaceSelector');
+  });
+
+  it('should check the correct feature flag name', () => {
+    renderComponent();
+    expect(mockUseFlag).toHaveBeenCalledWith('platform.chrome.workspace-global_selector');
+  });
+
+  it('should pass ErrorComponent for silent failure', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderComponent();
+    expect(capturedProps?.ErrorComponent).toBeDefined();
+  });
+
+  it('should pass a fallback for loading state', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderComponent();
+    expect(capturedProps?.fallback).toBeDefined();
+  });
+
+  it('should update selectedWorkspaceAtom when onSelect is called', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { store } = renderComponent();
+    capturedProps?.onSelect?.({ id: 'ws-1', name: 'Production' });
+    expect(store.get(selectedWorkspaceAtom)).toEqual({ id: 'ws-1', name: 'Production' });
+  });
+
+  it('should not update atom when workspace has missing fields', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { store } = renderComponent();
+    capturedProps?.onSelect?.({ id: 'ws-1' });
+    expect(store.get(selectedWorkspaceAtom)).toBeUndefined();
+  });
+});

--- a/src/components/WorkspaceSelector/WorkspaceSelector.test.tsx
+++ b/src/components/WorkspaceSelector/WorkspaceSelector.test.tsx
@@ -5,7 +5,7 @@ import WorkspaceSelector from './WorkspaceSelector';
 import { selectedWorkspaceAtom } from '../../state/atoms/workspaceSelectorAtom';
 
 type WorkspaceSelectorRemoteProps = {
-  onSelect?: (workspace: { id?: string; name?: string }) => void;
+  onSelect?: (item: { workspace?: { id?: string; name?: string } }) => void;
   scope?: string;
   module?: string;
   ErrorComponent?: React.ReactElement;
@@ -92,14 +92,21 @@ describe('WorkspaceSelector', () => {
   it('should update selectedWorkspaceAtom when onSelect is called', () => {
     mockUseFlag.mockReturnValue(true);
     const { store } = renderComponent();
-    capturedProps?.onSelect?.({ id: 'ws-1', name: 'Production' });
+    capturedProps?.onSelect?.({ workspace: { id: 'ws-1', name: 'Production' } });
     expect(store.get(selectedWorkspaceAtom)).toEqual({ id: 'ws-1', name: 'Production' });
   });
 
   it('should not update atom when workspace has missing fields', () => {
     mockUseFlag.mockReturnValue(true);
     const { store } = renderComponent();
-    capturedProps?.onSelect?.({ id: 'ws-1' });
+    capturedProps?.onSelect?.({ workspace: { id: 'ws-1' } });
+    expect(store.get(selectedWorkspaceAtom)).toBeUndefined();
+  });
+
+  it('should not update atom when workspace field is missing entirely', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { store } = renderComponent();
+    capturedProps?.onSelect?.({});
     expect(store.get(selectedWorkspaceAtom)).toBeUndefined();
   });
 });

--- a/src/components/WorkspaceSelector/WorkspaceSelector.tsx
+++ b/src/components/WorkspaceSelector/WorkspaceSelector.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from '@patternfly/react-core/dist/dynamic/components/Skeleto
 import SilentErrorBoundary from '../Routes/SilentErrorBoundary';
 import { SelectedWorkspace, selectedWorkspaceAtom } from '../../state/atoms/workspaceSelectorAtom';
 
-const WorkspaceSelector = () => {
+const WorkspaceSelector = (): React.JSX.Element | null => {
   const isWorkspaceSelectorEnabled = useFlag('platform.chrome.workspace-global_selector');
   const setSelectedWorkspace = useSetAtom(selectedWorkspaceAtom);
 

--- a/src/components/WorkspaceSelector/WorkspaceSelector.tsx
+++ b/src/components/WorkspaceSelector/WorkspaceSelector.tsx
@@ -1,0 +1,44 @@
+import React, { Fragment, useCallback } from 'react';
+import { useFlag } from '@unleash/proxy-client-react';
+import { useSetAtom } from 'jotai';
+import { ScalprumComponent, ScalprumComponentProps } from '@scalprum/react-core';
+import { Skeleton } from '@patternfly/react-core/dist/dynamic/components/Skeleton';
+import SilentErrorBoundary from '../Routes/SilentErrorBoundary';
+import { SelectedWorkspace, selectedWorkspaceAtom } from '../../state/atoms/workspaceSelectorAtom';
+
+const WorkspaceSelector = () => {
+  const isWorkspaceSelectorEnabled = useFlag('platform.chrome.workspace-global_selector');
+  const setSelectedWorkspace = useSetAtom(selectedWorkspaceAtom);
+
+  const onSelect = useCallback(
+    (workspace: { id?: string; name?: string }) => {
+      if (workspace.id && workspace.name) {
+        setSelectedWorkspace({ id: workspace.id, name: workspace.name } satisfies SelectedWorkspace);
+      }
+    },
+    [setSelectedWorkspace]
+  );
+
+  if (!isWorkspaceSelectorEnabled) {
+    return null;
+  }
+
+  const workspaceSelectorProps: ScalprumComponentProps = {
+    scope: 'rbac',
+    module: './modules/WorkspaceSelector',
+    fallback: <Skeleton width="200px" screenreaderText="Loading workspace selector" />,
+    ErrorComponent: <Fragment />,
+    onSelect,
+    menuWidth: 'max-content',
+  };
+
+  return (
+    <SilentErrorBoundary>
+      <div className="pf-v6-u-display-flex pf-v6-u-align-items-center" data-testid="workspace-selector">
+        <ScalprumComponent {...workspaceSelectorProps} />
+      </div>
+    </SilentErrorBoundary>
+  );
+};
+
+export default WorkspaceSelector;

--- a/src/components/WorkspaceSelector/WorkspaceSelector.tsx
+++ b/src/components/WorkspaceSelector/WorkspaceSelector.tsx
@@ -11,8 +11,9 @@ const WorkspaceSelector = (): React.JSX.Element | null => {
   const setSelectedWorkspace = useSetAtom(selectedWorkspaceAtom);
 
   const onSelect = useCallback(
-    (workspace: { id?: string; name?: string }) => {
-      if (workspace.id && workspace.name) {
+    (item: { workspace?: { id?: string; name?: string } }) => {
+      const workspace = item.workspace;
+      if (workspace?.id && workspace?.name) {
         setSelectedWorkspace({ id: workspace.id, name: workspace.name } satisfies SelectedWorkspace);
       }
     },

--- a/src/components/WorkspaceSelector/index.ts
+++ b/src/components/WorkspaceSelector/index.ts
@@ -1,0 +1,2 @@
+export { default } from './WorkspaceSelector';
+export type { SelectedWorkspace } from '../../state/atoms/workspaceSelectorAtom';

--- a/src/state/atoms/workspaceSelectorAtom.ts
+++ b/src/state/atoms/workspaceSelectorAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from 'jotai';
+
+export interface SelectedWorkspace {
+  id: string;
+  name: string;
+}
+
+export const selectedWorkspaceAtom = atom<SelectedWorkspace | undefined>(undefined);

--- a/src/state/chromeStore.ts
+++ b/src/state/chromeStore.ts
@@ -13,6 +13,7 @@ import { notificationDrawerExpandedAtom } from './atoms/notificationDrawerAtom';
 import { segmentPageOptionsAtom } from './atoms/segmentPageOptionsAtom';
 import { virtualAssistantShowAssistantAtom } from './atoms/virtualAssistantAtom';
 import { degradedStateAtom } from './atoms/degradedStateAtom';
+import { selectedWorkspaceAtom } from './atoms/workspaceSelectorAtom';
 
 const chromeStore = createStore();
 
@@ -35,6 +36,8 @@ chromeStore.set(drawerPanelContentAtom, undefined);
 chromeStore.set(notificationDrawerExpandedAtom, false);
 
 chromeStore.set(virtualAssistantShowAssistantAtom, false);
+
+chromeStore.set(selectedWorkspaceAtom, undefined);
 
 // analytics data
 chromeStore.set(segmentPageOptionsAtom, {});


### PR DESCRIPTION
### Description

This PR integrates the WorkspaceSelector into the Insights Chrome masthead behind the `platform.chrome.workspace-global_selector` feature flag. When enabled, the selector is rendered in the header using the RBAC module federation remote, with a loading skeleton and silent error boundary for graceful fallback.

It also adds state handling for the selected workspace via Jotai and includes unit/Cypress coverage for the enabled, disabled, loading, and selection-update flows.

[RHCLOUD-48802](https://issues.redhat.com/browse/RHCLOUD-48802)

---

### Screenshots

<img width="1108" height="635" alt="image" src="https://github.com/user-attachments/assets/c2e931e7-d2a3-406a-9bc6-dc485320eb3b" />

---

### Anything reviewers should know?

- The WorkspaceSelector is only shown when `platform.chrome.workspace-global_selector` is enabled.
- Loading and error states are intentionally lightweight to match existing chrome masthead behavior.
- The selector is hidden on smaller viewports and only appears at xl+ like other masthead controls.
- The selected workspace is only written to state when both `id` and `name` are present.

---

### Checklist

- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure

Goose using gpt-5.4-mini

[RHCLOUD-48802]: https://redhat.atlassian.net/browse/RHCLOUD-48802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a workspace selector to the authenticated header on extra-large screens.
  - Workspace selection is available when enabled by the feature flag.
  - The selected workspace is retained for use across the Chrome interface.
  - Added loading and graceful error handling while the selector loads.

- **Tests**
  - Added coverage for feature-flag behavior, workspace selection, loading states, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->