### PR TITLE
fix(quickstarts): load quickstarts from learning-resources

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -85,7 +85,10 @@ const plugins = (dev = false, beta = false, restricted = false) => {
         { 'react-intl': { singleton: true, eager: true, requiredVersion: deps['react-intl'] } },
         { 'react-router-dom': { singleton: true, requiredVersion: deps['react-router-dom'] } },
         { '@openshift/dynamic-plugin-sdk': { singleton: true, requiredVersion: deps['@openshift/dynamic-plugin-sdk'] } },
-        { '@patternfly/quickstarts': { singleton: true, requiredVersion: deps['@patternfly/quickstarts'] } },
+        // FEC remotes consume this with import:false (no fallback). Chrome must
+        // actually initialize the share; declaring it is not enough. eager so it
+        // is in the host chunk before learning-resources Help Panel / QuickstartsRuntime load.
+        { '@patternfly/quickstarts': { singleton: true, eager: true, requiredVersion: deps['@patternfly/quickstarts'] } },
         { '@redhat-cloud-services/chrome': { singleton: true, requiredVersion: deps['@redhat-cloud-services/chrome'] } },
         { '@scalprum/core': { singleton: true, requiredVersion: deps['@scalprum/core'] } },
         { '@scalprum/react-core': { singleton: true, requiredVersion: deps['@scalprum/react-core'] } },

--- a/cypress/component/DegradedStateBanner.cy.tsx
+++ b/cypress/component/DegradedStateBanner.cy.tsx
@@ -47,14 +47,14 @@ describe('DegradedStateBanner', () => {
     );
   };
   it('should not render when all services healthy', () => {
-    mountBanner({ userPersonalization: false, entitlements: false, configFromCache: false, featureFlags: false });
+    mountBanner({ userPersonalization: false, entitlements: false, configFromCache: false, featureFlags: false, quickstarts: false });
 
     cy.get('[data-ouia-component-id="DegradedStateBanner"]').should('not.exist');
     cy.contains(/some services are degraded/i).should('not.exist');
   });
 
   it('should render banner with single degraded service', () => {
-    mountBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false });
+    mountBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false, quickstarts: false });
 
     cy.get('[data-ouia-component-id="DegradedStateBanner"]')
       .should('be.visible')
@@ -64,25 +64,26 @@ describe('DegradedStateBanner', () => {
   });
 
   it('should render banner with multiple degraded services', () => {
-    mountBanner({ userPersonalization: true, entitlements: true, configFromCache: false, featureFlags: false });
+    mountBanner({ userPersonalization: true, entitlements: true, configFromCache: false, featureFlags: false, quickstarts: false });
 
     cy.get('[data-ouia-component-id="DegradedStateBanner"]').should('be.visible').should('contain', 'User Preferences').should('contain', 'Entitlements');
   });
 
   it('should always show warning variant', () => {
-    mountBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false });
+    mountBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false, quickstarts: false });
 
     cy.get('[data-ouia-component-id="DegradedStateBanner"]').should('exist').should('have.attr', 'data-ouia-component-id', 'DegradedStateBanner');
   });
 
   it('should list all degraded services', () => {
-    mountBanner({ userPersonalization: true, entitlements: true, configFromCache: true, featureFlags: true });
+    mountBanner({ userPersonalization: true, entitlements: true, configFromCache: true, featureFlags: true, quickstarts: true });
 
     cy.get('[data-ouia-component-id="DegradedStateBanner"]')
       .should('be.visible')
       .should('contain', 'User Preferences')
       .should('contain', 'Entitlements')
       .should('contain', 'Navigation Configuration')
-      .should('contain', 'Feature Flags');
+      .should('contain', 'Feature Flags')
+      .should('contain', 'Quick starts');
   });
 });

--- a/cypress/component/helptopics/HelpTopicManager.cy.tsx
+++ b/cypress/component/helptopics/HelpTopicManager.cy.tsx
@@ -86,6 +86,10 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
           name: 'TestApp',
           manifestLocation: '/foo/bar.json',
         },
+        learningResources: {
+          name: 'learningResources',
+          manifestLocation: '/foo/bar.json',
+        },
       },
     })
   );
@@ -103,6 +107,10 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
 
     scalprum.current.exposedModules['TestApp#TestApp'] = {
       default: () => <div id="test-app">Test App</div>,
+    };
+
+    scalprum.current.exposedModules['learningResources#QuickstartsRuntime'] = {
+      default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     };
 
     setIsReady(true);
@@ -234,6 +242,9 @@ describe('HelpTopicManager', () => {
         entry: ['/foo/bar.js'],
       },
       virtualAssistant: {
+        entry: ['/foo/bar.js'],
+      },
+      learningResources: {
         entry: ['/foo/bar.js'],
       },
     }).as('manifest');

--- a/docs/serviceHealth.md
+++ b/docs/serviceHealth.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Chrome provides infrastructure for displaying service degradation alerts. When backend services fail (entitlements, user personalization, navigation config, feature flags), consuming apps can mark services as degraded, triggering a banner notification.
+Chrome provides infrastructure for displaying service degradation alerts. When backend services fail (entitlements, user personalization, navigation config, feature flags, quick starts), consuming apps can mark services as degraded, triggering a banner notification.
 
 ## Feature Flag
 
@@ -58,6 +58,7 @@ type ServiceHealthStatus = {
   entitlements: boolean;
   configFromCache: boolean;
   featureFlags: boolean;
+  quickstarts: boolean;
 };
 ```
 
@@ -119,4 +120,8 @@ insights.chrome.enable.degradedStateBanner();
 // To clear (returns cleanup function)
 const clear = insights.chrome.enable.degradedStateBanner();
 clear(); // Clears degraded state
+
+// Quick starts specifically
+const clearQs = insights.chrome.enable.quickstartsDegraded();
+clearQs();
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -23350,21 +23350,6 @@
       "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -23947,24 +23932,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -2,6 +2,10 @@ import { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { IntlProvider, ReactIntlErrorCode } from 'react-intl';
 import { Provider as JotaiProvider } from 'jotai';
+// Side-effect only: webpack will not put a shared module in scope unless this
+// compilation imports it. RootApp no longer imports @patternfly/quickstarts, but
+// FEC remotes (Help Panel, QuickstartsRuntime) still consume it with import:false.
+import '@patternfly/quickstarts';
 import RootApp from './components/RootApp';
 import { getEnv, trustarcScriptSetup } from './utils/common';
 import OIDCProvider from './auth/OIDCConnector/OIDCProvider';

--- a/src/components/ChromeRoute/ChromeRoute.tsx
+++ b/src/components/ChromeRoute/ChromeRoute.tsx
@@ -1,9 +1,8 @@
 import { ScalprumComponent } from '@scalprum/react-core';
-import React, { memo, useContext, useEffect, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import LoadingFallback from '../../utils/loading-fallback';
 import ErrorComponent from '../ErrorComponents/DefaultErrorComponent';
 import classNames from 'classnames';
-import { HelpTopicContext } from '@patternfly/quickstarts';
 import GatewayErrorComponent from '../ErrorComponents/GatewayErrorComponent';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
@@ -30,7 +29,6 @@ const ChromeRoute = memo(
   ({ scope, module, scopeClass, path, props, permissions }: ChromeRouteProps) => {
     const isPreview = useAtomValue(isPreviewAtom);
     const setGlobalFilterHidden = useSetAtom(globalFilterHiddenAtom);
-    const { setActiveHelpTopicByName } = useContext(HelpTopicContext);
     const gatewayError = useAtomValue(gatewayErrorAtom);
     const [isHidden, setIsHidden] = useState<boolean | null>(null);
     const currentActiveModule = useAtomValue(activeModuleAtom);
@@ -68,11 +66,8 @@ const ChromeRoute = memo(
         const mountPath = path.replace(/\/\*$/, '');
         setAppMountPathname(mountPath);
       }
-      /**
-       * TODO: Discuss default close feature of topics
-       * Topics drawer has no close button, therefore there might be an issue with opened topics after user changes route and does not clear the active topic trough the now non existing elements.
-       */
-      setActiveHelpTopicByName?.('');
+      // Help topic clearing: QuickstartsRuntime ApiPublisher calls setActiveTopic('')
+      // when activeModule (this atom) changes. Do not read HelpTopicContext here.
 
       // reset visibility function
       setIsHidden(null);

--- a/src/components/DegradedStateBanner/DegradedStateBanner.test.tsx
+++ b/src/components/DegradedStateBanner/DegradedStateBanner.test.tsx
@@ -11,15 +11,17 @@ jest.mock('@unleash/proxy-client-react', () => ({
 
 const mockedUseFlag = useFlag as jest.Mock;
 
+const healthy = (overrides: Partial<ServiceHealthStatus> = {}): ServiceHealthStatus => ({
+  userPersonalization: false,
+  entitlements: false,
+  configFromCache: false,
+  featureFlags: false,
+  quickstarts: false,
+  ...overrides,
+});
+
 describe('DegradedStateBanner', () => {
-  const renderBanner = (
-    degradedState: ServiceHealthStatus = {
-      userPersonalization: false,
-      entitlements: false,
-      configFromCache: false,
-      featureFlags: false,
-    }
-  ) => {
+  const renderBanner = (degradedState: ServiceHealthStatus = healthy()) => {
     const store = createStore();
     store.set(degradedStateAtom, degradedState);
 
@@ -47,7 +49,7 @@ describe('DegradedStateBanner', () => {
   });
 
   it('should render banner when userPersonalization is degraded', () => {
-    const { container } = renderBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false });
+    const { container } = renderBanner(healthy({ userPersonalization: true }));
 
     expect(container.textContent).toMatch(/user preferences/i);
     expect(container.textContent).toMatch(/core functionality is available/i);
@@ -55,57 +57,70 @@ describe('DegradedStateBanner', () => {
   });
 
   it('should render banner when entitlements are degraded', () => {
-    const { container } = renderBanner({ userPersonalization: false, entitlements: true, configFromCache: false, featureFlags: false });
+    const { container } = renderBanner(healthy({ entitlements: true }));
 
     expect(container.textContent).toMatch(/entitlements/i);
   });
 
   it('should render banner when configFromCache is degraded', () => {
-    const { container } = renderBanner({ userPersonalization: false, entitlements: false, configFromCache: true, featureFlags: false });
+    const { container } = renderBanner(healthy({ configFromCache: true }));
 
     expect(container.textContent).toMatch(/navigation configuration/i);
   });
 
   it('should render banner when featureFlags are degraded', () => {
-    const { container } = renderBanner({ userPersonalization: false, entitlements: false, configFromCache: false, featureFlags: true });
+    const { container } = renderBanner(healthy({ featureFlags: true }));
 
     expect(container.textContent).toMatch(/feature flags/i);
   });
 
+  it('should render banner when quickstarts are degraded', () => {
+    const { container } = renderBanner(healthy({ quickstarts: true }));
+
+    expect(container.textContent).toMatch(/quick starts/i);
+  });
+
   it('should list multiple degraded services', () => {
-    const { container } = renderBanner({ userPersonalization: true, entitlements: true, configFromCache: false, featureFlags: false });
+    const { container } = renderBanner(healthy({ userPersonalization: true, entitlements: true }));
 
     expect(container.textContent).toMatch(/user preferences/i);
     expect(container.textContent).toMatch(/entitlements/i);
   });
 
   it('should list all degraded services when all are degraded', () => {
-    const { container } = renderBanner({ userPersonalization: true, entitlements: true, configFromCache: true, featureFlags: true });
+    const { container } = renderBanner(
+      healthy({
+        userPersonalization: true,
+        entitlements: true,
+        configFromCache: true,
+        featureFlags: true,
+        quickstarts: true,
+      })
+    );
 
     expect(container.textContent).toMatch(/user preferences/i);
     expect(container.textContent).toMatch(/entitlements/i);
     expect(container.textContent).toMatch(/navigation configuration/i);
     expect(container.textContent).toMatch(/feature flags/i);
+    expect(container.textContent).toMatch(/quick starts/i);
   });
 
   it('should always show warning variant', () => {
-    const { container } = renderBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false });
+    const { container } = renderBanner(healthy({ userPersonalization: true }));
 
-    // Verify warning variant (PatternFly v6 Banner)
     expect(container.textContent).toMatch(/user preferences/i);
     expect(container.querySelector('[class*="pf-m-warning"]')).toBeInTheDocument();
   });
 
   it('should have accessible screen reader text', () => {
-    renderBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false });
+    renderBanner(healthy({ userPersonalization: true }));
 
-    // PatternFly Banner adds sr-only text via screenReaderText prop
     expect(document.querySelector('.pf-v5-screen-reader, .pf-v6-screen-reader')).toBeInTheDocument();
   });
 
   it('should not render when feature flag disabled', () => {
     mockedUseFlag.mockReturnValue(false);
-    const { container } = renderBanner({ userPersonalization: true, entitlements: false, configFromCache: false, featureFlags: false });
+    const { container } = renderBanner(healthy({ userPersonalization: true }));
 
     expect(container.firstChild).toBeNull();
   });

--- a/src/components/DegradedStateBanner/DegradedStateBanner.tsx
+++ b/src/components/DegradedStateBanner/DegradedStateBanner.tsx
@@ -22,6 +22,7 @@ const DegradedStateBanner = () => {
     entitlements: messages.degradedServiceEntitlements,
     configFromCache: messages.degradedServiceConfigFromCache,
     featureFlags: messages.degradedServiceFeatureFlags,
+    quickstarts: messages.degradedServiceQuickstarts,
   };
 
   const degradedServices: string[] = [];
@@ -29,6 +30,7 @@ const DegradedStateBanner = () => {
   if (serviceHealth.entitlements) degradedServices.push(intl.formatMessage(serviceNameMap.entitlements));
   if (serviceHealth.configFromCache) degradedServices.push(intl.formatMessage(serviceNameMap.configFromCache));
   if (serviceHealth.featureFlags) degradedServices.push(intl.formatMessage(serviceNameMap.featureFlags));
+  if (serviceHealth.quickstarts) degradedServices.push(intl.formatMessage(serviceNameMap.quickstarts));
 
   const serviceList = degradedServices.join(', ');
   const prefix = intl.formatMessage(messages.degradedStateBannerPrefix);

--- a/src/components/Header/Tools.test.tsx
+++ b/src/components/Header/Tools.test.tsx
@@ -128,6 +128,7 @@ const defaultFlags: Record<string, boolean> = {
   'platform.sources.integrations': false,
   'platform.rbac.workspaces': false,
   'platform.chrome.help-panel': false,
+  'platform.chrome.learning-resources-quickstarts': false,
   'platform.chrome.ask-redhat-help': false,
   'platform.learning-resources.global-learning-resources': false,
   'platform.chrome.itless': false,

--- a/src/components/QuickstartsCatalogRoute/QuickstartsCatalogRoute.test.tsx
+++ b/src/components/QuickstartsCatalogRoute/QuickstartsCatalogRoute.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { useFlag } from '@unleash/proxy-client-react';
+import { ScalprumComponent } from '@scalprum/react-core';
+import QuickstartCatalogRoute from './QuickstartsCatalogRoute';
+import { LEARNING_RESOURCES_QUICKSTARTS_FLAG, LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY } from '../RootApp/useLearningResourcesQuickstarts';
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: jest.fn(() => false),
+}));
+
+jest.mock('@scalprum/react-core', () => ({
+  ScalprumComponent: jest.fn(() => <div data-testid="remote-catalog" />),
+}));
+
+jest.mock('../QuickStart/LazyQuickStartCatalog', () => ({
+  LazyQuickStartCatalog: () => <div data-testid="legacy-catalog" />,
+}));
+
+jest.mock('../../hooks/useBundle', () => ({
+  getUrl: () => 'insights',
+}));
+
+const mockedUseFlag = useFlag as jest.Mock;
+const MockedScalprumComponent = ScalprumComponent as jest.Mock;
+
+const renderRoute = () =>
+  render(
+    <IntlProvider locale="en">
+      <QuickstartCatalogRoute />
+    </IntlProvider>
+  );
+
+describe('QuickstartsCatalogRoute', () => {
+  beforeEach(() => {
+    mockedUseFlag.mockReturnValue(false);
+    window.localStorage.removeItem(LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY);
+    MockedScalprumComponent.mockClear();
+  });
+
+  afterEach(() => {
+    window.localStorage.removeItem(LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY);
+  });
+
+  it('uses leftover Chrome catalog when the flag is off', () => {
+    renderRoute();
+
+    expect(screen.getByTestId('legacy-catalog')).toBeInTheDocument();
+    expect(screen.queryByTestId('remote-catalog')).not.toBeInTheDocument();
+    expect(mockedUseFlag).toHaveBeenCalledWith(LEARNING_RESOURCES_QUICKSTARTS_FLAG);
+  });
+
+  it('loads learning-resources QuickStartCatalog when the Unleash flag is on', () => {
+    mockedUseFlag.mockReturnValue(true);
+    renderRoute();
+
+    expect(screen.getByTestId('remote-catalog')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-catalog')).not.toBeInTheDocument();
+    const props = MockedScalprumComponent.mock.calls[0][0];
+    expect(props.scope).toBe('learningResources');
+    expect(props.module).toBe('./QuickStartCatalog');
+  });
+
+  it('loads the remote catalog when localStorage override is set', () => {
+    window.localStorage.setItem(LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY, 'true');
+    renderRoute();
+
+    expect(screen.getByTestId('remote-catalog')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-catalog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/QuickstartsCatalogRoute/QuickstartsCatalogRoute.tsx
+++ b/src/components/QuickstartsCatalogRoute/QuickstartsCatalogRoute.tsx
@@ -1,28 +1,25 @@
-import React from 'react';
-import QuickStartCatalog from '../QuickStart/QuickStartCatalog';
+import React, { Fragment } from 'react';
+import { ScalprumComponent } from '@scalprum/react-core';
 import { useIntl } from 'react-intl';
 import messages from '../../locales/Messages';
 import { getUrl } from '../../hooks/useBundle';
-import { useAtom } from 'jotai';
-import { quickstartsDisabledAtom } from '../../state/atoms/quickstartsAtom';
+import LoadingFallback from '../../utils/loading-fallback';
 
 const QuickstartCatalogRoute = () => {
   const intl = useIntl();
   const bundle = getUrl('bundle');
-  const disabled = useAtom(quickstartsDisabledAtom);
-
-  if (disabled) {
-    return (
-      <div>
-        <h2>{intl.formatMessage(messages.unableToLoadQuickstartsContent)}</h2>
-      </div>
-    );
-  }
 
   return (
     <div>
       <h2>{intl.formatMessage(messages.thereWillBeACatalgPage, { bundle })}</h2>
-      <QuickStartCatalog />
+      <ScalprumComponent
+        scope="learningResources"
+        module="./QuickStartCatalog"
+        fallback={LoadingFallback}
+        ErrorComponent={<Fragment />}
+        title={intl.formatMessage(messages.quickStarts)}
+        hint={intl.formatMessage(messages.learnHowTo)}
+      />
     </div>
   );
 };

--- a/src/components/QuickstartsCatalogRoute/QuickstartsCatalogRoute.tsx
+++ b/src/components/QuickstartsCatalogRoute/QuickstartsCatalogRoute.tsx
@@ -4,22 +4,31 @@ import { useIntl } from 'react-intl';
 import messages from '../../locales/Messages';
 import { getUrl } from '../../hooks/useBundle';
 import LoadingFallback from '../../utils/loading-fallback';
+import { useLearningResourcesQuickstarts } from '../RootApp/useLearningResourcesQuickstarts';
+import { LazyQuickStartCatalog } from '../QuickStart/LazyQuickStartCatalog';
 
 const QuickstartCatalogRoute = () => {
   const intl = useIntl();
   const bundle = getUrl('bundle');
+  const useRemote = useLearningResourcesQuickstarts();
+  const title = intl.formatMessage(messages.quickStarts);
+  const hint = intl.formatMessage(messages.learnHowTo);
 
   return (
     <div>
       <h2>{intl.formatMessage(messages.thereWillBeACatalgPage, { bundle })}</h2>
-      <ScalprumComponent
-        scope="learningResources"
-        module="./QuickStartCatalog"
-        fallback={LoadingFallback}
-        ErrorComponent={<Fragment />}
-        title={intl.formatMessage(messages.quickStarts)}
-        hint={intl.formatMessage(messages.learnHowTo)}
-      />
+      {useRemote ? (
+        <ScalprumComponent
+          scope="learningResources"
+          module="./QuickStartCatalog"
+          fallback={LoadingFallback}
+          ErrorComponent={<Fragment />}
+          title={title}
+          hint={hint}
+        />
+      ) : (
+        <LazyQuickStartCatalog title={title} hint={hint} />
+      )}
     </div>
   );
 };

--- a/src/components/RootApp/LegacyQuickstartsRuntime.tsx
+++ b/src/components/RootApp/LegacyQuickstartsRuntime.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { HelpTopic, HelpTopicContainer, HelpTopicContext, QuickStart, QuickStartContainer, QuickStartContainerProps } from '@patternfly/quickstarts';
+import { ChromeAPI, EnableTopicsArgs } from '@redhat-cloud-services/types';
+import { useAtomValue, useSetAtom } from 'jotai';
+import useQuickstartsStates from '../QuickStart/useQuickstartsStates';
+import useHelpTopicState from '../QuickStart/useHelpTopicState';
+import useHelpTopicManager from '../QuickStart/useHelpTopicManager';
+import validateQuickstart from '../QuickStart/quickstartValidation';
+import { LazyQuickStartCatalog } from '../QuickStart/LazyQuickStartCatalog';
+import useQuickstartLinkStore, { createQuickstartLinkMarkupExtension } from '../../hooks/useQuickstarLinksStore';
+import { addQuickstartToAppAtom, clearQuickstartsAtom, populateQuickstartsAppAtom, quickstartsAtom } from '../../state/atoms/quickstartsAtom';
+import { LiveQuickstartsAPI } from '../../state/atoms/remoteQuickstartsAtom';
+
+export type LegacyQuickstartsRuntimeProps = {
+  accountId?: string;
+  activeModule?: string;
+  children?: React.ReactNode;
+  onApiReady?: (api: { quickstartsAPI: LiveQuickstartsAPI; helpTopicsAPI: ChromeAPI['helpTopics'] }) => void;
+  onActiveQuickStartChanged?: (id: string) => void;
+};
+
+function isStringArray(arr: EnableTopicsArgs): arr is string[] {
+  return typeof arr[0] === 'string';
+}
+
+type ApiPublisherProps = {
+  baseHelpTopicsAPI: ReturnType<typeof useHelpTopicState>;
+  quickstartsAPI: LiveQuickstartsAPI;
+  activeModule?: string;
+  onApiReady?: LegacyQuickstartsRuntimeProps['onApiReady'];
+};
+
+const ApiPublisher = ({ baseHelpTopicsAPI, quickstartsAPI, activeModule, onApiReady }: ApiPublisherProps) => {
+  const { setFilteredHelpTopics } = useContext(HelpTopicContext);
+  const internalFilteredTopics = useRef<HelpTopic[]>([]);
+  const { setActiveTopic } = useHelpTopicManager(baseHelpTopicsAPI);
+
+  const enableTopics = useCallback(
+    async (...names: EnableTopicsArgs) => {
+      let internalNames: string[] = [];
+      let shouldAppend = false;
+      if (isStringArray(names)) {
+        internalNames = names;
+      } else {
+        internalNames = names[0].names;
+        shouldAppend = !!names[0].append;
+      }
+      return baseHelpTopicsAPI.enableTopics(...internalNames).then((res) => {
+        internalFilteredTopics.current = shouldAppend
+          ? [...internalFilteredTopics.current, ...res.filter((topic) => !internalFilteredTopics.current.find(({ name }) => name === topic.name))]
+          : res;
+        setFilteredHelpTopics?.(internalFilteredTopics.current);
+        return res;
+      });
+    },
+    [baseHelpTopicsAPI, setFilteredHelpTopics]
+  );
+
+  const disableTopics = useCallback(
+    (...topicsNames: string[]) => {
+      baseHelpTopicsAPI.disableTopics(...topicsNames);
+      internalFilteredTopics.current = internalFilteredTopics.current.filter((topic) => !topicsNames.includes(topic.name));
+      setFilteredHelpTopics?.(internalFilteredTopics.current);
+    },
+    [baseHelpTopicsAPI, setFilteredHelpTopics]
+  );
+
+  const closeHelpTopic = useCallback(() => {
+    setActiveTopic('');
+  }, [setActiveTopic]);
+
+  const fullHelpTopicsAPI: ChromeAPI['helpTopics'] = useMemo(
+    () => ({
+      addHelpTopics: baseHelpTopicsAPI.addHelpTopics,
+      enableTopics,
+      disableTopics,
+      setActiveTopic,
+      closeHelpTopic,
+    }),
+    [baseHelpTopicsAPI.addHelpTopics, enableTopics, disableTopics, setActiveTopic, closeHelpTopic]
+  );
+
+  useEffect(() => {
+    onApiReady?.({ quickstartsAPI, helpTopicsAPI: fullHelpTopicsAPI });
+  }, [onApiReady, quickstartsAPI, fullHelpTopicsAPI]);
+
+  useEffect(() => {
+    setActiveTopic('');
+  }, [activeModule]);
+
+  return null;
+};
+
+/**
+ * Flag-off fallback: leftover Chrome QuickStart implementation.
+ * Same onApiReady contract as the learning-resources remote.
+ */
+const LegacyQuickstartsRuntime = ({ accountId, activeModule, children, onApiReady, onActiveQuickStartChanged }: LegacyQuickstartsRuntimeProps) => {
+  const quickstartLinkStore = useQuickstartLinkStore();
+  const { activateQuickstart, allQuickStartStates, setAllQuickStartStates, activeQuickStartID, setActiveQuickStartID } = useQuickstartsStates(accountId);
+  const baseHelpTopicsAPI = useHelpTopicState();
+  const quickstartsData = useAtomValue(quickstartsAtom);
+  const quickStarts = useMemo(() => Object.values(quickstartsData).flat(), [quickstartsData]);
+  const clearQuickstarts = useSetAtom(clearQuickstartsAtom);
+  const populateQuickstarts = useSetAtom(populateQuickstartsAppAtom);
+  const addQuickstartToApp = useSetAtom(addQuickstartToAppAtom);
+
+  useEffect(() => {
+    clearQuickstarts(activeQuickStartID);
+  }, [activeModule]);
+
+  useEffect(() => {
+    onActiveQuickStartChanged?.(activeQuickStartID);
+  }, [activeQuickStartID]);
+
+  const updateQuickStarts = useCallback(
+    (key: string, qs: QuickStart[]) => {
+      populateQuickstarts({ app: key, quickstarts: qs });
+    },
+    [populateQuickstarts]
+  );
+
+  const addQuickstart = useCallback(
+    (key: string, qs: QuickStart): boolean => {
+      if (validateQuickstart(key, qs)) {
+        addQuickstartToApp({ app: key, quickstart: qs });
+        return true;
+      }
+      return false;
+    },
+    [addQuickstartToApp]
+  );
+
+  const quickstartsAPI: LiveQuickstartsAPI = useMemo(
+    () => ({
+      version: 1,
+      set: updateQuickStarts,
+      activateQuickstart,
+      add: addQuickstart,
+      toggle: setActiveQuickStartID,
+      Catalog: LazyQuickStartCatalog,
+      updateQuickStarts,
+    }),
+    [activateQuickstart, setActiveQuickStartID, updateQuickStarts, addQuickstart]
+  );
+
+  const quickStartProps: QuickStartContainerProps = {
+    quickStarts,
+    activeQuickStartID,
+    allQuickStartStates,
+    setActiveQuickStartID: setActiveQuickStartID as QuickStartContainerProps['setActiveQuickStartID'],
+    setAllQuickStartStates: setAllQuickStartStates as unknown as QuickStartContainerProps['setAllQuickStartStates'],
+    showCardFooters: false,
+    language: 'en',
+    alwaysShowTaskReview: true,
+    markdown: {
+      extensions: [createQuickstartLinkMarkupExtension(quickstartLinkStore)],
+    },
+  };
+
+  return (
+    <QuickStartContainer {...quickStartProps}>
+      <HelpTopicContainer helpTopics={baseHelpTopicsAPI.helpTopics}>
+        <ApiPublisher baseHelpTopicsAPI={baseHelpTopicsAPI} quickstartsAPI={quickstartsAPI} activeModule={activeModule} onApiReady={onApiReady} />
+        {children}
+      </HelpTopicContainer>
+    </QuickStartContainer>
+  );
+};
+
+export default LegacyQuickstartsRuntime;

--- a/src/components/RootApp/QuickstartsRuntimeMount.test.tsx
+++ b/src/components/RootApp/QuickstartsRuntimeMount.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { Provider as JotaiProvider, createStore } from 'jotai';
+import { useFlag } from '@unleash/proxy-client-react';
+import { ScalprumComponent } from '@scalprum/react-core';
+import QuickstartsRuntimeMount, {
+  LEARNING_RESOURCES_QUICKSTARTS_FLAG,
+  LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY,
+  REMOTE_QUICKSTARTS_LOAD_TIMEOUT_MS,
+} from './QuickstartsRuntimeMount';
+import ChromeAuthContext from '../../auth/ChromeAuthContext';
+import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
+import { degradedStateAtom } from '../../state/atoms/degradedStateAtom';
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: jest.fn(() => false),
+}));
+
+jest.mock('@scalprum/react-core', () => ({
+  ScalprumComponent: jest.fn(({ children }: { children?: React.ReactNode }) => <div data-testid="remote-runtime">{children}</div>),
+}));
+
+jest.mock('./LegacyQuickstartsRuntime', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <div data-testid="legacy-runtime">{children}</div>,
+}));
+
+const mockedUseFlag = useFlag as jest.Mock;
+const MockedScalprumComponent = ScalprumComponent as jest.Mock;
+
+const chromeAuth = {
+  user: {
+    identity: {
+      internal: { account_id: '123' },
+    },
+  },
+};
+
+const renderMount = () => {
+  const store = createStore();
+  store.set(activeModuleAtom, 'insights');
+  store.set(degradedStateAtom, {
+    userPersonalization: false,
+    entitlements: false,
+    configFromCache: false,
+    featureFlags: false,
+    quickstarts: false,
+  });
+  return {
+    store,
+    ...render(
+      <JotaiProvider store={store}>
+        <ChromeAuthContext.Provider value={chromeAuth as never}>
+          <QuickstartsRuntimeMount>
+            <span>shell-child</span>
+          </QuickstartsRuntimeMount>
+        </ChromeAuthContext.Provider>
+      </JotaiProvider>
+    ),
+  };
+};
+
+describe('QuickstartsRuntimeMount', () => {
+  beforeEach(() => {
+    mockedUseFlag.mockReturnValue(false);
+    window.localStorage.removeItem(LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY);
+    MockedScalprumComponent.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    window.localStorage.removeItem(LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY);
+  });
+
+  it('uses leftover Chrome providers when the flag is off', () => {
+    const { store } = renderMount();
+
+    expect(screen.getByTestId('legacy-runtime')).toBeInTheDocument();
+    expect(screen.getByText('shell-child')).toBeInTheDocument();
+    expect(screen.queryByTestId('remote-runtime')).not.toBeInTheDocument();
+    expect(mockedUseFlag).toHaveBeenCalledWith(LEARNING_RESOURCES_QUICKSTARTS_FLAG);
+    expect(store.get(degradedStateAtom).quickstarts).toBe(false);
+  });
+
+  it('loads learning-resources QuickstartsRuntime when the Unleash flag is on', () => {
+    mockedUseFlag.mockReturnValue(true);
+    renderMount();
+
+    expect(screen.getByTestId('remote-runtime')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-runtime')).not.toBeInTheDocument();
+    expect(MockedScalprumComponent).toHaveBeenCalled();
+    const props = MockedScalprumComponent.mock.calls[0][0];
+    expect(props.scope).toBe('learningResources');
+    expect(props.module).toBe('./QuickstartsRuntime');
+    expect(props.accountId).toBe('123');
+  });
+
+  it('loads the remote when localStorage override is set', () => {
+    window.localStorage.setItem(LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY, 'true');
+    renderMount();
+
+    expect(screen.getByTestId('remote-runtime')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-runtime')).not.toBeInTheDocument();
+  });
+
+  it('marks quickstarts degraded if the remote never becomes ready', () => {
+    mockedUseFlag.mockReturnValue(true);
+    jest.useFakeTimers();
+    const { store } = renderMount();
+
+    expect(store.get(degradedStateAtom).quickstarts).toBe(false);
+    act(() => {
+      jest.advanceTimersByTime(REMOTE_QUICKSTARTS_LOAD_TIMEOUT_MS);
+    });
+    expect(store.get(degradedStateAtom).quickstarts).toBe(true);
+  });
+
+  it('clears degraded state when onApiReady fires', () => {
+    mockedUseFlag.mockReturnValue(true);
+    const { store } = renderMount();
+    const props = MockedScalprumComponent.mock.calls[0][0];
+
+    act(() => {
+      store.set(degradedStateAtom, { ...store.get(degradedStateAtom), quickstarts: true });
+      props.onApiReady({
+        quickstartsAPI: { version: 1 },
+        helpTopicsAPI: {},
+      });
+    });
+
+    expect(store.get(degradedStateAtom).quickstarts).toBe(false);
+  });
+});

--- a/src/components/RootApp/QuickstartsRuntimeMount.tsx
+++ b/src/components/RootApp/QuickstartsRuntimeMount.tsx
@@ -1,0 +1,118 @@
+import React, { Component, ReactNode, useCallback, useContext, useEffect, useRef } from 'react';
+import { ScalprumComponent } from '@scalprum/react-core';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { ChromeAPI } from '@redhat-cloud-services/types';
+import ChromeAuthContext from '../../auth/ChromeAuthContext';
+import chromeStore from '../../state/chromeStore';
+import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
+import { setServiceDegradedAtom } from '../../state/atoms/degradedStateAtom';
+import { LiveQuickstartsAPI, liveHelpTopicsAPIRef, liveQuickstartsAPIRef, remoteActiveQuickStartIDAtom } from '../../state/atoms/remoteQuickstartsAtom';
+import LegacyQuickstartsRuntime from './LegacyQuickstartsRuntime';
+import { useLearningResourcesQuickstarts } from './useLearningResourcesQuickstarts';
+
+export {
+  LEARNING_RESOURCES_QUICKSTARTS_FLAG,
+  LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY,
+  useLearningResourcesQuickstarts,
+} from './useLearningResourcesQuickstarts';
+export const REMOTE_QUICKSTARTS_LOAD_TIMEOUT_MS = 5000;
+
+function setQuickstartsDegraded(degraded: boolean) {
+  chromeStore.set(setServiceDegradedAtom, { service: 'quickstarts', degraded });
+}
+
+class QuickstartsRuntimeBoundary extends Component<{ children: ReactNode; fallback: ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch(error: unknown) {
+    console.error('Quickstarts runtime failed:', error);
+    setQuickstartsDegraded(true);
+  }
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
+const QuickstartsRemoteError = ({ children }: { children?: ReactNode; error?: unknown }) => {
+  const setServiceDegraded = useSetAtom(setServiceDegradedAtom);
+  useEffect(() => {
+    setServiceDegraded({ service: 'quickstarts', degraded: true });
+    return () => {
+      setServiceDegraded({ service: 'quickstarts', degraded: false });
+    };
+  }, [setServiceDegraded]);
+  return <>{children}</>;
+};
+
+const QuickstartsRuntimeMount = ({ children }: { children: ReactNode }) => {
+  const { user } = useContext(ChromeAuthContext);
+  const activeModule = useAtomValue(activeModuleAtom);
+  const setRemoteActiveQSID = useSetAtom(remoteActiveQuickStartIDAtom);
+  const setServiceDegraded = useSetAtom(setServiceDegradedAtom);
+  const useRemote = useLearningResourcesQuickstarts();
+  const apiReadyRef = useRef(false);
+
+  const handleApiReady = useCallback(
+    (api: { quickstartsAPI: LiveQuickstartsAPI; helpTopicsAPI: ChromeAPI['helpTopics'] }) => {
+      apiReadyRef.current = true;
+      liveQuickstartsAPIRef.current = api.quickstartsAPI;
+      liveHelpTopicsAPIRef.current = api.helpTopicsAPI;
+      setServiceDegraded({ service: 'quickstarts', degraded: false });
+    },
+    [setServiceDegraded]
+  );
+
+  const handleActiveQSChanged = useCallback(
+    (id: string) => {
+      setRemoteActiveQSID(id);
+    },
+    [setRemoteActiveQSID]
+  );
+
+  useEffect(() => {
+    if (!useRemote) {
+      return;
+    }
+    apiReadyRef.current = false;
+    const timeout = window.setTimeout(() => {
+      if (!apiReadyRef.current) {
+        setServiceDegraded({ service: 'quickstarts', degraded: true });
+      }
+    }, REMOTE_QUICKSTARTS_LOAD_TIMEOUT_MS);
+    return () => window.clearTimeout(timeout);
+  }, [useRemote, setServiceDegraded]);
+
+  const accountId = user?.identity?.internal?.account_id;
+
+  if (!useRemote) {
+    return (
+      <LegacyQuickstartsRuntime accountId={accountId} activeModule={activeModule} onApiReady={handleApiReady} onActiveQuickStartChanged={handleActiveQSChanged}>
+        {children}
+      </LegacyQuickstartsRuntime>
+    );
+  }
+
+  return (
+    <QuickstartsRuntimeBoundary fallback={children}>
+      <ScalprumComponent
+        scope="learningResources"
+        module="./QuickstartsRuntime"
+        ErrorComponent={<QuickstartsRemoteError>{children}</QuickstartsRemoteError>}
+        fallback={children}
+        accountId={accountId}
+        activeModule={activeModule}
+        onApiReady={handleApiReady}
+        onActiveQuickStartChanged={handleActiveQSChanged}
+      >
+        {children}
+      </ScalprumComponent>
+    </QuickstartsRuntimeBoundary>
+  );
+};
+
+export default QuickstartsRuntimeMount;

--- a/src/components/RootApp/RootApp.tsx
+++ b/src/components/RootApp/RootApp.tsx
@@ -1,14 +1,9 @@
-import React, { Suspense, memo, useContext, useEffect, useMemo } from 'react';
+import { Suspense, memo, useContext, useEffect } from 'react';
 import { unstable_HistoryRouter as HistoryRouter, HistoryRouterProps } from 'react-router-dom';
-import { HelpTopicContainer, QuickStart, QuickStartContainer, QuickStartContainerProps } from '@patternfly/quickstarts';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import chromeHistory from '../../utils/chromeHistory';
 import { FeatureFlagsProvider } from '../FeatureFlags';
 import ScalprumRoot from './ScalprumRoot';
-import { LazyQuickStartCatalog } from '../QuickStart/LazyQuickStartCatalog';
-import useQuickstartsStates from '../QuickStart/useQuickstartsStates';
-import useHelpTopicState from '../QuickStart/useHelpTopicState';
-import validateQuickstart from '../QuickStart/quickstartValidation';
 import SegmentProvider from '../../analytics/SegmentProvider';
 import { ITLess, chunkLoadErrorRefreshKey } from '../../utils/common';
 import { lazyWithRetry } from '../../utils/chunkLoadErrorUtils';
@@ -20,8 +15,6 @@ import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 import { scalprumConfigAtom } from '../../state/atoms/scalprumConfigAtom';
 import { useInitVisibleBundles } from '../../state/atoms/visibleBundlesAtom';
 import { isDebuggerEnabledAtom } from '../../state/atoms/debuggerModalatom';
-import { addQuickstartToAppAtom, clearQuickstartsAtom, populateQuickstartsAppAtom, quickstartsAtom } from '../../state/atoms/quickstartsAtom';
-import useQuickstartLinkStore, { createQuickstartLinkMarkupExtension } from '../../hooks/useQuickstarLinksStore';
 
 const NotEntitledModal = lazyWithRetry(() => import('../NotEntitledModal'));
 const Debugger = lazyWithRetry(() => import('../Debugger'));
@@ -31,27 +24,15 @@ const VisibleBundlesInitializer = () => {
   return null;
 };
 
-const RootApp = memo(({ accountId }: { accountId?: string }) => {
-  const quickstartLinkStore = useQuickstartLinkStore();
+const RootApp = memo(() => {
   const config = useAtomValue(scalprumConfigAtom);
-  const { activateQuickstart, allQuickStartStates, setAllQuickStartStates, activeQuickStartID, setActiveQuickStartID } = useQuickstartsStates(accountId);
-  const { helpTopics, addHelpTopics, disableTopics, enableTopics } = useHelpTopicState();
   const activeModule = useAtomValue(activeModuleAtom);
-  const quickstartsData = useAtomValue(quickstartsAtom);
-  const quickStarts = useMemo(() => Object.values(quickstartsData).flat(), [quickstartsData]);
-  const clearQuickstarts = useSetAtom(clearQuickstartsAtom);
-  const populateQuickstarts = useSetAtom(populateQuickstartsAppAtom);
-  const addQuickstartToApp = useSetAtom(addQuickstartToAppAtom);
 
   useEffect(() => {
-    clearQuickstarts(activeQuickStartID);
     if (activeModule) {
       let timeout: NodeJS.Timeout;
       const moduleStorageKey = `${chunkLoadErrorRefreshKey}-${activeModule}`;
       if (localStorage.getItem(moduleStorageKey) === 'true') {
-        // The localStorage should either be true or null. A false value
-        // can cause infinite loops. The timeout will remove the value after
-        // ten seconds
         timeout = setTimeout(() => {
           localStorage.removeItem(moduleStorageKey);
         }, 10_000);
@@ -63,73 +44,16 @@ const RootApp = memo(({ accountId }: { accountId?: string }) => {
       };
     }
   }, [activeModule]);
-  /**
-   * Updates the available quick starts
-   *
-   * Usage example:
-   * const { quickStarts } = useChrome();
-   * quickStarts.set('applicationServices', quickStartsArray)
-   *
-   * @param {string} key App identifier
-   * @param {array} qs Array of quick starts
-   */
-  const updateQuickStarts = (key: string, qs: QuickStart[]) => {
-    populateQuickstarts({ app: key, quickstarts: qs });
-  };
-
-  const addQuickstart = (key: string, qs: QuickStart): boolean => {
-    if (validateQuickstart(key, qs)) {
-      addQuickstartToApp({ app: key, quickstart: qs });
-      return true;
-    }
-    return false;
-  };
-
-  const quickStartProps: QuickStartContainerProps = {
-    quickStarts,
-    activeQuickStartID,
-    allQuickStartStates,
-    setActiveQuickStartID: setActiveQuickStartID as QuickStartContainerProps['setActiveQuickStartID'],
-    setAllQuickStartStates: setAllQuickStartStates as unknown as QuickStartContainerProps['setAllQuickStartStates'],
-    showCardFooters: false,
-    language: 'en',
-    alwaysShowTaskReview: true,
-    markdown: {
-      extensions: [createQuickstartLinkMarkupExtension(quickstartLinkStore)],
-    },
-  };
-
-  const helpTopicsAPI = {
-    addHelpTopics,
-    disableTopics,
-    enableTopics,
-  };
-
-  const quickstartsAPI = {
-    version: 1,
-    set: updateQuickStarts,
-    activateQuickstart,
-    add: addQuickstart,
-    toggle: setActiveQuickStartID,
-    Catalog: LazyQuickStartCatalog,
-    updateQuickStarts,
-  };
 
   return (
     <HistoryRouter history={chromeHistory as unknown as HistoryRouterProps['history']}>
       <SegmentProvider>
         <FeatureFlagsProvider>
           <VisibleBundlesInitializer />
-          {/* <CrossRequestNotifier /> */}
           <Suspense fallback={null}>
             <NotEntitledModal />
           </Suspense>
-          <Suspense fallback={null}></Suspense>
-          <QuickStartContainer {...quickStartProps}>
-            <HelpTopicContainer helpTopics={helpTopics}>
-              <ScalprumRoot config={config} quickstartsAPI={quickstartsAPI} helpTopicsAPI={helpTopicsAPI} />
-            </HelpTopicContainer>
-          </QuickStartContainer>
+          <ScalprumRoot config={config} />
         </FeatureFlagsProvider>
       </SegmentProvider>
     </HistoryRouter>
@@ -149,7 +73,7 @@ const AuthRoot = () => {
       <Suspense fallback={null}>
         {user?.identity?.account_number && !ITLess() && isDebuggerEnabled && ReactDOM.createPortal(<Debugger user={user} />, document.body)}
       </Suspense>
-      <RootApp accountId={user?.identity?.internal?.account_id} />
+      <RootApp />
     </>
   );
 };

--- a/src/components/RootApp/ScalprumRoot.test.tsx
+++ b/src/components/RootApp/ScalprumRoot.test.tsx
@@ -21,6 +21,7 @@ jest.mock('@scalprum/react-core', () => {
       mockScalprumProviderProps = props;
       return actual.ScalprumProvider(props);
     },
+    ScalprumComponent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   };
 });
 
@@ -232,19 +233,6 @@ describe('ScalprumRoot', () => {
   const initialProps = {
     cookieElement: null,
     setCookieElement: () => undefined,
-    helpTopicsAPI: {
-      addHelpTopics: jest.fn(),
-      disableTopics: jest.fn(),
-      enableTopics: jest.fn(),
-    },
-    quickstartsAPI: {
-      version: 1,
-      set: jest.fn(),
-      toggle: jest.fn(),
-
-      Catalog: () => <div></div>,
-      activateQuickstart: jest.fn(),
-    },
   };
 
   beforeAll(() => {

--- a/src/components/RootApp/ScalprumRoot.test.tsx
+++ b/src/components/RootApp/ScalprumRoot.test.tsx
@@ -9,6 +9,11 @@ import { ChromeAPI } from '@redhat-cloud-services/types';
 import { NavItem, Navigation } from '../../@types/types';
 import { ScalprumConfig } from '../../state/atoms/scalprumConfigAtom';
 
+jest.mock('./QuickstartsRuntimeMount', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
 jest.mock('../Footer/Footer', () => () => null);
 
 let mockScalprumProviderProps: ScalprumProviderConfigurableProps<{ chrome: ChromeAPI }> | undefined;

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -120,9 +120,9 @@ const ScalprumRoot = memo(
   () => {
     return (
       <ChromeProvider>
+        <QuickstartsRuntimeMount>
         <BetaSwitcher />
         <DegradedStateBanner />
-        <QuickstartsRuntimeMount>
         <Routes>
           <Route index path="/" element={<DefaultLayout Footer={<ChromeFooter />} />} />
           <Route

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment, ReactNode, Suspense, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { Component, ReactNode, Suspense, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { PluginManifest, RemotePluginManifest } from '@openshift/dynamic-plugin-sdk';
 import { ScalprumComponent, ScalprumProvider, ScalprumProviderConfigurableProps } from '@scalprum/react-core';
 import { Route, Routes } from 'react-router-dom';
@@ -40,7 +40,7 @@ import useDPAL from '../../analytics/useDpal';
 import { selectedTagsAtom } from '../../state/atoms/globalFilterAtom';
 import useAmplitude from '../../analytics/useAmplitude';
 import usePf5Styles from '../../hooks/usePf5Styles';
-import { liveQuickstartsAPIRef, liveHelpTopicsAPIRef, remoteActiveQuickStartIDAtom } from '../../state/atoms/remoteQuickstartsAtom';
+import { LiveQuickstartsAPI, liveHelpTopicsAPIRef, liveQuickstartsAPIRef, remoteActiveQuickStartIDAtom } from '../../state/atoms/remoteQuickstartsAtom';
 
 const ProductSelection = lazyWithRetry(() => import('../Stratosphere/ProductSelection'));
 const Lightwell = lazyWithRetry(() => import('../../layouts/Lightwell'));
@@ -57,10 +57,7 @@ const useGlobalFilter = (callback: (selectedTags?: FlagTagsFilter) => any) => {
   return callback(selectedTags);
 };
 
-class QuickstartsRuntimeBoundary extends Component<
-  { children: ReactNode; fallback: ReactNode },
-  { hasError: boolean }
-> {
+class QuickstartsRuntimeBoundary extends Component<{ children: ReactNode; fallback: ReactNode }, { hasError: boolean }> {
   state = { hasError: false };
   static getDerivedStateFromError() {
     return { hasError: true };
@@ -83,13 +80,10 @@ const QuickstartsRuntimeMount = ({ children }: { children: ReactNode }) => {
   const activeModule = useAtomValue(activeModuleAtom);
   const setRemoteActiveQSID = useSetAtom(remoteActiveQuickStartIDAtom);
 
-  const handleApiReady = useCallback(
-    (api: { quickstartsAPI: ChromeAPI['quickStarts']; helpTopicsAPI: ChromeAPI['helpTopics'] }) => {
-      liveQuickstartsAPIRef.current = api.quickstartsAPI;
-      liveHelpTopicsAPIRef.current = api.helpTopicsAPI;
-    },
-    []
-  );
+  const handleApiReady = useCallback((api: { quickstartsAPI: LiveQuickstartsAPI; helpTopicsAPI: ChromeAPI['helpTopics'] }) => {
+    liveQuickstartsAPIRef.current = api.quickstartsAPI;
+    liveHelpTopicsAPIRef.current = api.helpTopicsAPI;
+  }, []);
 
   const handleActiveQSChanged = useCallback(
     (id: string) => {
@@ -121,47 +115,47 @@ const ScalprumRoot = memo(
     return (
       <ChromeProvider>
         <QuickstartsRuntimeMount>
-        <BetaSwitcher />
-        <DegradedStateBanner />
-        <Routes>
-          <Route index path="/" element={<DefaultLayout Footer={<ChromeFooter />} />} />
-          <Route
-            path="/connect/products"
-            element={
-              <Suspense fallback={LoadingFallback}>
-                <ProductSelection />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/allservices"
-            element={
-              <Suspense fallback={LoadingFallback}>
-                <AllServices Footer={<ChromeFooter />} />
-              </Suspense>
-            }
-          />
-          {!ITLess() && (
+          <BetaSwitcher />
+          <DegradedStateBanner />
+          <Routes>
+            <Route index path="/" element={<DefaultLayout Footer={<ChromeFooter />} />} />
             <Route
-              path="/favoritedservices"
+              path="/connect/products"
               element={
                 <Suspense fallback={LoadingFallback}>
-                  <FavoritedServices Footer={<ChromeFooter />} />
+                  <ProductSelection />
                 </Suspense>
               }
             />
-          )}
-          <Route path="/security" element={<DefaultLayout />} />
-          <Route
-            path={`${LIGHTWELL_PATH}/*`}
-            element={
-              <Suspense fallback={LoadingFallback}>
-                <Lightwell />
-              </Suspense>
-            }
-          />
-          <Route path="*" element={<DefaultLayout Sidebar={Navigation} />} />
-        </Routes>
+            <Route
+              path="/allservices"
+              element={
+                <Suspense fallback={LoadingFallback}>
+                  <AllServices Footer={<ChromeFooter />} />
+                </Suspense>
+              }
+            />
+            {!ITLess() && (
+              <Route
+                path="/favoritedservices"
+                element={
+                  <Suspense fallback={LoadingFallback}>
+                    <FavoritedServices Footer={<ChromeFooter />} />
+                  </Suspense>
+                }
+              />
+            )}
+            <Route path="/security" element={<DefaultLayout />} />
+            <Route
+              path={`${LIGHTWELL_PATH}/*`}
+              element={
+                <Suspense fallback={LoadingFallback}>
+                  <Lightwell />
+                </Suspense>
+              }
+            />
+            <Route path="*" element={<DefaultLayout Sidebar={Navigation} />} />
+          </Routes>
         </QuickstartsRuntimeMount>
       </ChromeProvider>
     );
@@ -176,7 +170,7 @@ export type ChromeApiRootProps = {
   config: ScalprumConfig;
 };
 
-const delegatedQuickstartsAPI = {
+const delegatedQuickstartsAPI: LiveQuickstartsAPI = {
   version: 1,
   set: (...args: Parameters<ChromeAPI['quickStarts']['set']>) => liveQuickstartsAPIRef.current?.set(...args),
   activateQuickstart: (name: string) => liveQuickstartsAPIRef.current?.activateQuickstart(name) ?? Promise.resolve(),
@@ -185,16 +179,14 @@ const delegatedQuickstartsAPI = {
     const Catalog = liveQuickstartsAPIRef.current?.Catalog;
     return Catalog ? <Catalog {...props} /> : null;
   }) as ChromeAPI['quickStarts']['Catalog'],
-  updateQuickStarts: (key: string, quickstarts: unknown[]) =>
-    (liveQuickstartsAPIRef.current as any)?.updateQuickStarts(key, quickstarts),
-  add: (key: string, qs: unknown) =>
-    (liveQuickstartsAPIRef.current as any)?.add?.(key, qs) ?? false,
-} as ChromeAPI['quickStarts'];
+  updateQuickStarts: (key: string, quickstarts: unknown[]) => liveQuickstartsAPIRef.current?.updateQuickStarts?.(key, quickstarts),
+  add: (key: string, qs: unknown) => liveQuickstartsAPIRef.current?.add?.(key, qs) ?? false,
+};
 
 const delegatedHelpTopicsAPI: ChromeAPI['helpTopics'] = {
   addHelpTopics: (...args) => liveHelpTopicsAPIRef.current?.addHelpTopics(...args),
   disableTopics: (...args) => liveHelpTopicsAPIRef.current?.disableTopics(...args),
-  enableTopics: (...args: any[]) => liveHelpTopicsAPIRef.current?.enableTopics(...args) ?? Promise.resolve([]),
+  enableTopics: (...args: Parameters<ChromeAPI['helpTopics']['enableTopics']>) => liveHelpTopicsAPIRef.current?.enableTopics(...args) ?? Promise.resolve([]),
   setActiveTopic: (...args) => liveHelpTopicsAPIRef.current?.setActiveTopic(...args) ?? Promise.resolve(),
   closeHelpTopic: () => liveHelpTopicsAPIRef.current?.closeHelpTopic(),
 };

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -1,9 +1,8 @@
-import { Suspense, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { Component, Fragment, ReactNode, Suspense, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { PluginManifest, RemotePluginManifest } from '@openshift/dynamic-plugin-sdk';
-import { ScalprumProvider, ScalprumProviderConfigurableProps } from '@scalprum/react-core';
+import { ScalprumComponent, ScalprumProvider, ScalprumProviderConfigurableProps } from '@scalprum/react-core';
 import { Route, Routes } from 'react-router-dom';
-import { HelpTopic, HelpTopicContext } from '@patternfly/quickstarts';
-import { ChromeAPI, EnableTopicsArgs } from '@redhat-cloud-services/types';
+import { ChromeAPI } from '@redhat-cloud-services/types';
 import { ChromeProvider } from '@redhat-cloud-services/chrome';
 import { useAtomValue, useSetAtom } from 'jotai';
 import chromeHistory from '../../utils/chromeHistory';
@@ -13,10 +12,9 @@ import FavoritedServices from '../../layouts/FavoritedServices';
 import historyListener from '../../utils/historyListener';
 import SegmentContext from '../../analytics/SegmentContext';
 import LoadingFallback from '../../utils/loading-fallback';
-import { FlagTagsFilter, HelpTopicsAPI, QuickstartsApi } from '../../@types/types';
+import { FlagTagsFilter } from '../../@types/types';
 import { createChromeContext } from '../../chrome/create-chrome';
 import Navigation from '../Navigation';
-import useHelpTopicManager from '../QuickStart/useHelpTopicManager';
 import ChromeFooter from '../Footer/Footer';
 import updateSharedScope from '../../chrome/update-shared-scope';
 import useBundleVisitDetection from '../../hooks/useBundleVisitDetection';
@@ -42,6 +40,8 @@ import useDPAL from '../../analytics/useDpal';
 import { selectedTagsAtom } from '../../state/atoms/globalFilterAtom';
 import useAmplitude from '../../analytics/useAmplitude';
 import usePf5Styles from '../../hooks/usePf5Styles';
+import { liveQuickstartsAPIRef, liveHelpTopicsAPIRef, remoteActiveQuickStartIDAtom } from '../../state/atoms/remoteQuickstartsAtom';
+
 const ProductSelection = lazyWithRetry(() => import('../Stratosphere/ProductSelection'));
 const Lightwell = lazyWithRetry(() => import('../../layouts/Lightwell'));
 
@@ -57,12 +57,72 @@ const useGlobalFilter = (callback: (selectedTags?: FlagTagsFilter) => any) => {
   return callback(selectedTags);
 };
 
+class QuickstartsRuntimeBoundary extends Component<
+  { children: ReactNode; fallback: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch(error: unknown) {
+    console.error('Quickstarts runtime failed:', error);
+  }
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
+const PassThrough = ({ children }: { children?: ReactNode; error?: unknown }) => <>{children}</>;
+
+const QuickstartsRuntimeMount = ({ children }: { children: ReactNode }) => {
+  const { user } = useContext(ChromeAuthContext);
+  const activeModule = useAtomValue(activeModuleAtom);
+  const setRemoteActiveQSID = useSetAtom(remoteActiveQuickStartIDAtom);
+
+  const handleApiReady = useCallback(
+    (api: { quickstartsAPI: ChromeAPI['quickStarts']; helpTopicsAPI: ChromeAPI['helpTopics'] }) => {
+      liveQuickstartsAPIRef.current = api.quickstartsAPI;
+      liveHelpTopicsAPIRef.current = api.helpTopicsAPI;
+    },
+    []
+  );
+
+  const handleActiveQSChanged = useCallback(
+    (id: string) => {
+      setRemoteActiveQSID(id);
+    },
+    [setRemoteActiveQSID]
+  );
+
+  return (
+    <QuickstartsRuntimeBoundary fallback={children}>
+      <ScalprumComponent
+        scope="learningResources"
+        module="./QuickstartsRuntime"
+        ErrorComponent={<PassThrough>{children}</PassThrough>}
+        fallback={children}
+        accountId={user?.identity?.internal?.account_id}
+        activeModule={activeModule}
+        onApiReady={handleApiReady}
+        onActiveQuickStartChanged={handleActiveQSChanged}
+      >
+        {children}
+      </ScalprumComponent>
+    </QuickstartsRuntimeBoundary>
+  );
+};
+
 const ScalprumRoot = memo(
   () => {
     return (
       <ChromeProvider>
         <BetaSwitcher />
         <DegradedStateBanner />
+        <QuickstartsRuntimeMount>
         <Routes>
           <Route index path="/" element={<DefaultLayout Footer={<ChromeFooter />} />} />
           <Route
@@ -92,7 +152,6 @@ const ScalprumRoot = memo(
             />
           )}
           <Route path="/security" element={<DefaultLayout />} />
-          {/* TODO: Temporary hardcoded route for content-sources-frontend authed experience (RHCLOUD-48921). Revisit for a longer-term approach. */}
           <Route
             path={`${LIGHTWELL_PATH}/*`}
             element={
@@ -103,6 +162,7 @@ const ScalprumRoot = memo(
           />
           <Route path="*" element={<DefaultLayout Sidebar={Navigation} />} />
         </Routes>
+        </QuickstartsRuntimeMount>
       </ChromeProvider>
     );
     // no props, no need to ever render based on parent changes
@@ -114,18 +174,37 @@ ScalprumRoot.displayName = 'MemoizedScalprumRoot';
 
 export type ChromeApiRootProps = {
   config: ScalprumConfig;
-  helpTopicsAPI: HelpTopicsAPI;
-  quickstartsAPI: QuickstartsApi;
 };
 
-const ChromeApiRoot = ({ config, helpTopicsAPI, quickstartsAPI }: ChromeApiRootProps) => {
+const delegatedQuickstartsAPI = {
+  version: 1,
+  set: (...args: Parameters<ChromeAPI['quickStarts']['set']>) => liveQuickstartsAPIRef.current?.set(...args),
+  activateQuickstart: (name: string) => liveQuickstartsAPIRef.current?.activateQuickstart(name) ?? Promise.resolve(),
+  toggle: (...args: Parameters<ChromeAPI['quickStarts']['toggle']>) => liveQuickstartsAPIRef.current?.toggle(...args),
+  Catalog: ((props: Record<string, unknown>) => {
+    const Catalog = liveQuickstartsAPIRef.current?.Catalog;
+    return Catalog ? <Catalog {...props} /> : null;
+  }) as ChromeAPI['quickStarts']['Catalog'],
+  updateQuickStarts: (key: string, quickstarts: unknown[]) =>
+    (liveQuickstartsAPIRef.current as any)?.updateQuickStarts(key, quickstarts),
+  add: (key: string, qs: unknown) =>
+    (liveQuickstartsAPIRef.current as any)?.add?.(key, qs) ?? false,
+} as ChromeAPI['quickStarts'];
+
+const delegatedHelpTopicsAPI: ChromeAPI['helpTopics'] = {
+  addHelpTopics: (...args) => liveHelpTopicsAPIRef.current?.addHelpTopics(...args),
+  disableTopics: (...args) => liveHelpTopicsAPIRef.current?.disableTopics(...args),
+  enableTopics: (...args: any[]) => liveHelpTopicsAPIRef.current?.enableTopics(...args) ?? Promise.resolve([]),
+  setActiveTopic: (...args) => liveHelpTopicsAPIRef.current?.setActiveTopic(...args) ?? Promise.resolve(),
+  closeHelpTopic: () => liveHelpTopicsAPIRef.current?.closeHelpTopic(),
+};
+
+const ChromeApiRoot = ({ config }: ChromeApiRootProps) => {
   const chromeAuth = useContext(ChromeAuthContext);
   const mutableChromeApi = useRef<ChromeAPI>(undefined);
   const isPreview = useAtomValue(isPreviewAtom);
   const addNavListener = useSetAtom(addNavListenerAtom);
   const deleteNavListener = useSetAtom(deleteNavListenerAtom);
-  const { setFilteredHelpTopics } = useContext(HelpTopicContext);
-  const internalFilteredTopics = useRef<HelpTopic[]>([]);
   const { analytics } = useContext(SegmentContext);
   const registerModule = useSetAtom(onRegisterModuleWriteAtom);
   const activeModule = useAtomValue(activeModuleAtom);
@@ -166,53 +245,11 @@ const ChromeApiRoot = ({ config, helpTopicsAPI, quickstartsAPI }: ChromeApiRootP
     setPageOptions(pageOptions);
   }, []);
 
-  const { setActiveTopic } = useHelpTopicManager(helpTopicsAPI);
-
-  function isStringArray(arr: EnableTopicsArgs): arr is string[] {
-    return typeof arr[0] === 'string';
-  }
-  async function enableTopics(...names: EnableTopicsArgs) {
-    let internalNames: string[] = [];
-    let shouldAppend = false;
-    if (isStringArray(names)) {
-      internalNames = names;
-    } else {
-      internalNames = names[0].names;
-      shouldAppend = !!names[0].append;
-    }
-    return helpTopicsAPI.enableTopics(...internalNames).then((res) => {
-      internalFilteredTopics.current = shouldAppend
-        ? [...internalFilteredTopics.current, ...res.filter((topic) => !internalFilteredTopics.current.find(({ name }) => name === topic.name))]
-        : res;
-      setFilteredHelpTopics?.(internalFilteredTopics.current);
-      return res;
-    });
-  }
-
-  function disableTopics(...topicsNames: string[]) {
-    helpTopicsAPI.disableTopics(...topicsNames);
-    internalFilteredTopics.current = internalFilteredTopics.current.filter((topic) => !topicsNames.includes(topic.name));
-    setFilteredHelpTopics?.(internalFilteredTopics.current);
-  }
-
-  const helpTopicsChromeApi = useMemo(
-    () => ({
-      ...helpTopicsAPI,
-      setActiveTopic,
-      enableTopics,
-      disableTopics,
-      closeHelpTopic: () => {
-        setActiveTopic('');
-      },
-    }),
-    []
-  );
-
   useMemo(() => {
     mutableChromeApi.current = createChromeContext({
       analytics: analytics!,
-      helpTopics: helpTopicsChromeApi,
-      quickstartsAPI,
+      helpTopics: delegatedHelpTopicsAPI,
+      quickstartsAPI: delegatedQuickstartsAPI,
       useGlobalFilter,
       setPageMetadata,
       chromeAuth,
@@ -242,8 +279,6 @@ const ChromeApiRoot = ({ config, helpTopicsAPI, quickstartsAPI }: ChromeApiRootP
       },
       pluginSDKOptions: {
         pluginLoaderOptions: {
-          // sharedScope: scope,
-          // Chrome only ever loads remote plugin manifests (fed-mods.json); pass through anything else untouched.
           transformPluginManifest: (manifest) =>
             isRemotePluginManifest(manifest) ? (transformScalprumManifest(manifest, config) as typeof manifest) : manifest,
         },

--- a/src/components/RootApp/ScalprumRoot.tsx
+++ b/src/components/RootApp/ScalprumRoot.tsx
@@ -1,6 +1,6 @@
-import React, { Component, ReactNode, Suspense, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { Suspense, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { PluginManifest, RemotePluginManifest } from '@openshift/dynamic-plugin-sdk';
-import { ScalprumComponent, ScalprumProvider, ScalprumProviderConfigurableProps } from '@scalprum/react-core';
+import { ScalprumProvider, ScalprumProviderConfigurableProps } from '@scalprum/react-core';
 import { Route, Routes } from 'react-router-dom';
 import { ChromeAPI } from '@redhat-cloud-services/types';
 import { ChromeProvider } from '@redhat-cloud-services/chrome';
@@ -35,12 +35,14 @@ import useHandlePendoScopeUpdate from '../../hooks/useHandlePendoScopeUpdate';
 import { activeModuleAtom } from '../../state/atoms/activeModuleAtom';
 import { ScalprumConfig } from '../../state/atoms/scalprumConfigAtom';
 import transformScalprumManifest from './transformScalprumManifest';
+import QuickstartsRuntimeMount from './QuickstartsRuntimeMount';
 import { segmentPageOptionsAtom } from '../../state/atoms/segmentPageOptionsAtom';
 import useDPAL from '../../analytics/useDpal';
 import { selectedTagsAtom } from '../../state/atoms/globalFilterAtom';
 import useAmplitude from '../../analytics/useAmplitude';
 import usePf5Styles from '../../hooks/usePf5Styles';
-import { LiveQuickstartsAPI, liveHelpTopicsAPIRef, liveQuickstartsAPIRef, remoteActiveQuickStartIDAtom } from '../../state/atoms/remoteQuickstartsAtom';
+import { LiveQuickstartsAPI, liveHelpTopicsAPIRef, liveQuickstartsAPIRef } from '../../state/atoms/remoteQuickstartsAtom';
+import type { QuickStart } from '@patternfly/quickstarts';
 
 const ProductSelection = lazyWithRetry(() => import('../Stratosphere/ProductSelection'));
 const Lightwell = lazyWithRetry(() => import('../../layouts/Lightwell'));
@@ -55,59 +57,6 @@ const useGlobalFilter = (callback: (selectedTags?: FlagTagsFilter) => any) => {
   }, [selectedTags, callback]);
 
   return callback(selectedTags);
-};
-
-class QuickstartsRuntimeBoundary extends Component<{ children: ReactNode; fallback: ReactNode }, { hasError: boolean }> {
-  state = { hasError: false };
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-  componentDidCatch(error: unknown) {
-    console.error('Quickstarts runtime failed:', error);
-  }
-  render() {
-    if (this.state.hasError) {
-      return this.props.fallback;
-    }
-    return this.props.children;
-  }
-}
-
-const PassThrough = ({ children }: { children?: ReactNode; error?: unknown }) => <>{children}</>;
-
-const QuickstartsRuntimeMount = ({ children }: { children: ReactNode }) => {
-  const { user } = useContext(ChromeAuthContext);
-  const activeModule = useAtomValue(activeModuleAtom);
-  const setRemoteActiveQSID = useSetAtom(remoteActiveQuickStartIDAtom);
-
-  const handleApiReady = useCallback((api: { quickstartsAPI: LiveQuickstartsAPI; helpTopicsAPI: ChromeAPI['helpTopics'] }) => {
-    liveQuickstartsAPIRef.current = api.quickstartsAPI;
-    liveHelpTopicsAPIRef.current = api.helpTopicsAPI;
-  }, []);
-
-  const handleActiveQSChanged = useCallback(
-    (id: string) => {
-      setRemoteActiveQSID(id);
-    },
-    [setRemoteActiveQSID]
-  );
-
-  return (
-    <QuickstartsRuntimeBoundary fallback={children}>
-      <ScalprumComponent
-        scope="learningResources"
-        module="./QuickstartsRuntime"
-        ErrorComponent={<PassThrough>{children}</PassThrough>}
-        fallback={children}
-        accountId={user?.identity?.internal?.account_id}
-        activeModule={activeModule}
-        onApiReady={handleApiReady}
-        onActiveQuickStartChanged={handleActiveQSChanged}
-      >
-        {children}
-      </ScalprumComponent>
-    </QuickstartsRuntimeBoundary>
-  );
 };
 
 const ScalprumRoot = memo(
@@ -179,8 +128,8 @@ const delegatedQuickstartsAPI: LiveQuickstartsAPI = {
     const Catalog = liveQuickstartsAPIRef.current?.Catalog;
     return Catalog ? <Catalog {...props} /> : null;
   }) as ChromeAPI['quickStarts']['Catalog'],
-  updateQuickStarts: (key: string, quickstarts: unknown[]) => liveQuickstartsAPIRef.current?.updateQuickStarts?.(key, quickstarts),
-  add: (key: string, qs: unknown) => liveQuickstartsAPIRef.current?.add?.(key, qs) ?? false,
+  updateQuickStarts: (key: string, quickstarts: QuickStart[]) => liveQuickstartsAPIRef.current?.updateQuickStarts?.(key, quickstarts),
+  add: (key: string, qs: QuickStart) => liveQuickstartsAPIRef.current?.add?.(key, qs) ?? false,
 };
 
 const delegatedHelpTopicsAPI: ChromeAPI['helpTopics'] = {

--- a/src/components/RootApp/useLearningResourcesQuickstarts.ts
+++ b/src/components/RootApp/useLearningResourcesQuickstarts.ts
@@ -1,0 +1,14 @@
+import { useFlag } from '@unleash/proxy-client-react';
+
+export const LEARNING_RESOURCES_QUICKSTARTS_FLAG = 'platform.chrome.learning-resources-quickstarts';
+export const LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY = 'chrome:experimental:lr-quickstarts';
+
+export function useLearningResourcesQuickstarts() {
+  const fromUnleash = useFlag(LEARNING_RESOURCES_QUICKSTARTS_FLAG);
+  try {
+    const fromLocal = window.localStorage?.getItem(LEARNING_RESOURCES_QUICKSTARTS_STORAGE_KEY) === 'true';
+    return Boolean(fromUnleash || fromLocal);
+  } catch {
+    return Boolean(fromUnleash);
+  }
+}

--- a/src/hooks/useDegradedState.test.ts
+++ b/src/hooks/useDegradedState.test.ts
@@ -21,6 +21,7 @@ describe('useDegradedState', () => {
       entitlements: false,
       configFromCache: false,
       featureFlags: false,
+      quickstarts: false,
     });
     mockedUseFlag.mockReturnValue(false);
   });
@@ -39,6 +40,7 @@ describe('useDegradedState', () => {
       entitlements: false,
       configFromCache: false,
       featureFlags: false,
+      quickstarts: false,
     });
     expect(result.current.isAnyServiceDegraded).toBe(false);
     expect(result.current.isBannerEnabled).toBe(false);
@@ -86,6 +88,15 @@ describe('useDegradedState', () => {
     const { result } = renderHook(() => useDegradedState(), { wrapper });
 
     expect(result.current.serviceHealth.featureFlags).toBe(true);
+    expect(result.current.isAnyServiceDegraded).toBe(true);
+  });
+
+  it('should detect degraded quickstarts service', () => {
+    store.set(setServiceDegradedAtom, { service: 'quickstarts', degraded: true });
+
+    const { result } = renderHook(() => useDegradedState(), { wrapper });
+
+    expect(result.current.serviceHealth.quickstarts).toBe(true);
     expect(result.current.isAnyServiceDegraded).toBe(true);
   });
 

--- a/src/layouts/AllServices.test.tsx
+++ b/src/layouts/AllServices.test.tsx
@@ -105,6 +105,7 @@ const renderAllServices = (flagOverrides: Record<string, boolean> = {}) => {
   const defaultFlags: Record<string, boolean> = {
     'platform.chrome.notifications-drawer': false,
     'platform.chrome.help-panel': false,
+    'platform.chrome.learning-resources-quickstarts': false,
     'platform.chrome.allservices.redesign': false,
   };
 

--- a/src/layouts/Lightwell.test.tsx
+++ b/src/layouts/Lightwell.test.tsx
@@ -83,6 +83,7 @@ const renderLightwell = (flagOverrides: Record<string, boolean> = {}, initialRou
   const defaultFlags: Record<string, boolean> = {
     'platform.chrome.notifications-drawer': false,
     'platform.chrome.help-panel': false,
+    'platform.chrome.learning-resources-quickstarts': false,
   };
 
   const flags = { ...defaultFlags, ...flagOverrides };

--- a/src/locales/Messages.ts
+++ b/src/locales/Messages.ts
@@ -703,4 +703,9 @@ export default defineMessages({
     description: 'Label for feature flags service',
     defaultMessage: 'Feature Flags',
   },
+  degradedServiceQuickstarts: {
+    id: 'degradedServiceQuickstarts',
+    description: 'Label for quickstarts / learning-resources runtime',
+    defaultMessage: 'Quick starts',
+  },
 });

--- a/src/sass/pf-6-assets.scss
+++ b/src/sass/pf-6-assets.scss
@@ -4,5 +4,6 @@
 @use '~@patternfly/patternfly/utilities/Spacing/spacing.scss';
 @use '~@patternfly/patternfly/patternfly-charts.scss';
 
-// Quick starts
+// Keep in Chrome's pf-v6 bundle. Federated CSS chunks 404 through the Chrome proxy.
+// Help Panel also imports this file; do not drop the global link.
 @use '~@patternfly/quickstarts/dist/quickstarts.min';

--- a/src/sass/pf-6-assets.scss
+++ b/src/sass/pf-6-assets.scss
@@ -4,6 +4,7 @@
 @use '~@patternfly/patternfly/utilities/Spacing/spacing.scss';
 @use '~@patternfly/patternfly/patternfly-charts.scss';
 
-// Keep in Chrome's pf-v6 bundle. Federated CSS chunks 404 through the Chrome proxy.
-// Help Panel also imports this file; do not drop the global link.
+// Keep in Chrome's pf-v6.css. The global Quick Start drawer needs these rules at
+// Chrome boot. Do not move this to a learning-resources CSS chunk — MiniCssExtract
+// + module federation 404s that file through the Chrome proxy (ChunkLoadError).
 @use '~@patternfly/quickstarts/dist/quickstarts.min';

--- a/src/state/atoms/degradedStateAtom.test.ts
+++ b/src/state/atoms/degradedStateAtom.test.ts
@@ -10,6 +10,7 @@ describe('degradedStateAtom', () => {
       entitlements: false,
       configFromCache: false,
       featureFlags: false,
+      quickstarts: false,
     });
   });
 
@@ -51,6 +52,14 @@ describe('degradedStateAtom', () => {
     expect(state.entitlements).toBe(false);
     expect(state.configFromCache).toBe(false);
     expect(state.featureFlags).toBe(true);
+  });
+
+  it('should update quickstarts status', () => {
+    const store = createStore();
+    store.set(setServiceDegradedAtom, { service: 'quickstarts', degraded: true });
+    const state = store.get(degradedStateAtom);
+    expect(state.quickstarts).toBe(true);
+    expect(state.userPersonalization).toBe(false);
   });
 
   it('should update multiple services independently', () => {
@@ -97,6 +106,7 @@ describe('degradedStateAtom', () => {
     store.set(setServiceDegradedAtom, { service: 'entitlements', degraded: true });
     store.set(setServiceDegradedAtom, { service: 'configFromCache', degraded: true });
     store.set(setServiceDegradedAtom, { service: 'featureFlags', degraded: true });
+    store.set(setServiceDegradedAtom, { service: 'quickstarts', degraded: true });
     expect(store.get(isAnyServiceDegradedAtom)).toBe(true);
   });
 

--- a/src/state/atoms/degradedStateAtom.ts
+++ b/src/state/atoms/degradedStateAtom.ts
@@ -5,6 +5,7 @@ export type ServiceHealthStatus = {
   entitlements: boolean;
   configFromCache: boolean;
   featureFlags: boolean;
+  quickstarts: boolean;
 };
 
 const initialState: ServiceHealthStatus = {
@@ -12,6 +13,7 @@ const initialState: ServiceHealthStatus = {
   entitlements: false,
   configFromCache: false,
   featureFlags: false,
+  quickstarts: false,
 };
 
 export const degradedStateAtom = atom<ServiceHealthStatus>(initialState);

--- a/src/state/atoms/remoteQuickstartsAtom.ts
+++ b/src/state/atoms/remoteQuickstartsAtom.ts
@@ -1,0 +1,7 @@
+import { atom } from 'jotai';
+import { ChromeAPI } from '@redhat-cloud-services/types';
+
+export const liveQuickstartsAPIRef: { current: ChromeAPI['quickStarts'] | null } = { current: null };
+export const liveHelpTopicsAPIRef: { current: ChromeAPI['helpTopics'] | null } = { current: null };
+
+export const remoteActiveQuickStartIDAtom = atom<string>('');

--- a/src/state/atoms/remoteQuickstartsAtom.ts
+++ b/src/state/atoms/remoteQuickstartsAtom.ts
@@ -1,7 +1,13 @@
 import { atom } from 'jotai';
 import { ChromeAPI } from '@redhat-cloud-services/types';
 
-export const liveQuickstartsAPIRef: { current: ChromeAPI['quickStarts'] | null } = { current: null };
+/** Runtime extras (`add`, `updateQuickStarts`) exist on the live object but not on public ChromeAPI. */
+export type LiveQuickstartsAPI = ChromeAPI['quickStarts'] & {
+  add?: (key: string, qs: unknown) => boolean;
+  updateQuickStarts?: (key: string, quickstarts: unknown[]) => void;
+};
+
+export const liveQuickstartsAPIRef: { current: LiveQuickstartsAPI | null } = { current: null };
 export const liveHelpTopicsAPIRef: { current: ChromeAPI['helpTopics'] | null } = { current: null };
 
 export const remoteActiveQuickStartIDAtom = atom<string>('');

--- a/src/state/atoms/remoteQuickstartsAtom.ts
+++ b/src/state/atoms/remoteQuickstartsAtom.ts
@@ -1,10 +1,11 @@
 import { atom } from 'jotai';
+import { QuickStart } from '@patternfly/quickstarts';
 import { ChromeAPI } from '@redhat-cloud-services/types';
 
 /** Runtime extras (`add`, `updateQuickStarts`) exist on the live object but not on public ChromeAPI. */
 export type LiveQuickstartsAPI = ChromeAPI['quickStarts'] & {
-  add?: (key: string, qs: unknown) => boolean;
-  updateQuickStarts?: (key: string, quickstarts: unknown[]) => void;
+  add?: (key: string, qs: QuickStart) => boolean;
+  updateQuickStarts?: (key: string, quickstarts: QuickStart[]) => void;
 };
 
 export const liveQuickstartsAPIRef: { current: LiveQuickstartsAPI | null } = { current: null };

--- a/src/state/chromeStore.ts
+++ b/src/state/chromeStore.ts
@@ -45,6 +45,7 @@ chromeStore.set(degradedStateAtom, {
   entitlements: false,
   configFromCache: false,
   featureFlags: false,
+  quickstarts: false,
 });
 
 // globally handle subscription to activeModuleAtom

--- a/src/utils/debugFunctions.ts
+++ b/src/utils/debugFunctions.ts
@@ -28,11 +28,20 @@ const debugFunctions = {
   segmentDev: () => functionBuilder('chrome:analytics:dev', true),
   intlDebug: () => functionBuilder('chrome:intl:debug', true),
   sentryDebug: () => functionBuilder('chrome:sentry:debug', true),
+  learningResourcesQuickstarts: () => functionBuilder('chrome:experimental:lr-quickstarts', true),
   degradedStateBanner: () => {
     chromeStore.set(setServiceDegradedAtom, { service: 'userPersonalization', degraded: true });
     console.log('✓ Degraded state banner triggered (user personalization degraded)');
     return () => {
       chromeStore.set(setServiceDegradedAtom, { service: 'userPersonalization', degraded: false });
+      console.log('✓ Degraded state banner cleared');
+    };
+  },
+  quickstartsDegraded: () => {
+    chromeStore.set(setServiceDegradedAtom, { service: 'quickstarts', degraded: true });
+    console.log('✓ Degraded state banner triggered (quickstarts degraded)');
+    return () => {
+      chromeStore.set(setServiceDegradedAtom, { service: 'quickstarts', degraded: false });
       console.log('✓ Degraded state banner cleared');
     };
   },

--- a/src/utils/useNavigation.ts
+++ b/src/utils/useNavigation.ts
@@ -1,12 +1,12 @@
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { BLOCK_CLEAR_GATEWAY_ERROR } from './common';
-import { QuickStartContext } from '@patternfly/quickstarts';
 import { NavItem, Navigation } from '../@types/types';
 import { clearGatewayErrorAtom } from '../state/atoms/gatewayErrorAtom';
 import { navigationAtom, setNavigationSegmentAtom } from '../state/atoms/navigationAtom';
 import { useVisibleBundles, useVisibleBundlesError } from '../state/atoms/visibleBundlesAtom';
+import { remoteActiveQuickStartIDAtom } from '../state/atoms/remoteQuickstartsAtom';
 
 function cleanNavItemsHref(navItem: NavItem) {
   const result = { ...navItem };
@@ -20,9 +20,6 @@ function cleanNavItemsHref(navItem: NavItem) {
   }
 
   if (typeof result.href === 'string') {
-    /**
-     * Remove traling "/" from  the link
-     */
     result.href = result.href.replace(/\/$/, '');
   }
 
@@ -47,22 +44,20 @@ const useNavigation = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { pathname } = location;
-  const { activeQuickStartID } = useContext(QuickStartContext);
   const currentNamespace = pathname.split('/')[1];
   const navigation = useAtomValue(navigationAtom);
   const schema = navigation[currentNamespace];
   const setNavigationSegment = useSetAtom(setNavigationSegmentAtom);
   const [noNav, setNoNav] = useState(false);
 
-  /**
-   * We need a side effect to get the value into the mutation observer closure
-   */
+  const activeQuickStartID = useAtomValue(remoteActiveQuickStartIDAtom);
   const activeQSId = useRef<undefined | string>('');
   const activeLocation = useRef({});
+
   useEffect(() => {
     activeQSId.current = activeQuickStartID;
     activeLocation.current = location;
-  }, [activeQuickStartID]);
+  }, [activeQuickStartID, location]);
 
   const registerLocationObserver = (initialPathname: string, schema: Navigation) => {
     let prevPathname = initialPathname;
@@ -73,9 +68,6 @@ const useNavigation = () => {
         if (newPathname !== prevPathname) {
           prevPathname = newPathname;
           setNavigationSegment({ schema, segment: currentNamespace, pathname: prevPathname });
-          /**
-           * Clean gateway error on URL change
-           */
           if (localStorage.getItem(BLOCK_CLEAR_GATEWAY_ERROR) !== 'true') {
             clearGatewayError();
           }


### PR DESCRIPTION
### Description

<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->
Chrome no longer wraps `RootApp` in PatternFly `QuickStartContainer` / `HelpTopicContainer`. Those providers now load from learning-resources via Scalprum (`scope="learningResources"`, `module="./QuickstartsRuntime"`), so a quickstarts failure cannot take down Chrome init.

`useChrome().quickStarts` and `useChrome().helpTopics` keep the same shape. Chrome forwards through refs once the remote calls `onApiReady`. Tenants do not need to change.

[RHCLOUD-48691](https://redhat.atlassian.net/browse/RHCLOUD-48691)

---

### Screenshots

<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

---

### Anything reviewers should know?
Merge this PR after learning-resources PR [#363](https://github.com/RedHatInsights/learning-resources/pull/363)

<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist

- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure

<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-48691]: https://redhat.atlassian.net/browse/RHCLOUD-48691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a Learning Resources quick-start catalog, controlled by a feature flag or local override.
- Preserved the existing quick-start catalog when the new experience is disabled.
- Added runtime support for quick-start and help-topic interactions.

## Bug Fixes
- Quick starts now appear in service health monitoring and degraded-state notifications.
- Added timeout and error handling when the remote catalog cannot load.

## Documentation
- Updated service health documentation with quick-start status and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->