### PR TITLE
feat(Lightwell): Enaforce the same visual on all screen sizes

### DIFF
--- a/src/layouts/Lightwell.scss
+++ b/src/layouts/Lightwell.scss
@@ -1,25 +1,15 @@
 @use '~@patternfly/patternfly/sass-utilities/scss-variables' as *;
 
-// At xl+ (≥1200px), PF6 Page switches to a 2-column sidebar+main grid
-// and the masthead uses CSS subgrid. Lightwell has no sidebar, so force
-// single-column layout with a dedicated "subnav" row to keep the horizontal
-// navigation outside the page card. The --pf-v6-c-page--*--GridArea variable
-// overrides are critical: without
-// them, the drawer references a "sidebar" grid area that doesn't exist in
-// our 1-column template, causing the browser to create implicit columns.
-@media (min-width: $pf-v6-global--breakpoint--xl) {
-  .pf-v6-c-page.chr-c-page--lightwell {
-    grid-template-areas: 'header' 'subnav' 'main';
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto 1fr;
-    --pf-v6-c-page--masthead--main-container--GridArea: main;
-    --pf-v6-c-page__main-container--GridArea: main;
+.pf-v6-c-page.chr-c-page--lightwell {
+  grid-template-areas: 'header' 'subnav' 'main';
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto 1fr;
 
-    > .pf-v6-c-masthead {
-      // Prevent subgrid — keep inline masthead layout
-      --pf-v6-c-masthead--m-display-inline--GridTemplateColumns: min-content 1fr;
+  --pf-v6-c-page--masthead--main-container--GridArea: main;
+  --pf-v6-c-page__main-container--GridArea: main;
 
-      grid-template-columns: min-content 1fr;
-    }
+  > .pf-v6-c-masthead {
+    // Prevent subgrid — keep inline masthead layout
+    --pf-v6-c-masthead--m-display-inline--GridTemplateColumns: min-content 1fr;
   }
 }


### PR DESCRIPTION
The current css forced the horizontal navigation to jump to the bottom of the page on smaller screens. Otherwise the behavior and visuals stays the same.

Fixes: LWLP-911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Lightwell page layout across all screen sizes.
  * Ensured the header, subnavigation, and main content maintain a consistent single-column arrangement on smaller viewports.
  * Refined masthead layout behavior for a more reliable responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->