### PR TITLE
feat(breadcrumbs): allow apps to drop last segment

### DIFF
--- a/docs/breadcrumbs-design.md
+++ b/docs/breadcrumbs-design.md
@@ -93,6 +93,22 @@ useRemoteHook({
 });
 ```
 
+An app can opt in to dropping Chrome's final breadcrumb when it supplies its
+own breadcrumb trail:
+
+```tsx
+useRemoteHook({
+  scope: 'chrome',
+  module: './breadcrumbs/useReplaceBreadcrumbs',
+  args: [breadcrumbs, { dropLastChromeSegment: true }],
+});
+```
+
+With this option, Chrome drops its final segment whenever the app supplies a
+non-empty breadcrumb trail and Chrome has more than one segment. If Chrome has
+only the HCC root segment, Chrome preserves it. The default is `false`, so
+existing apps keep Chrome's normal breadcrumb behavior unless they opt in.
+
 **Rule of thumb:** If each route knows its own title → use `useBreadcrumbs`. If you compute the full array → use `useReplaceBreadcrumbs`.
 
 ## Accessing application breadcrumbs API
@@ -193,8 +209,8 @@ There will be a single point of management in an application. It does not mean i
 
 The source code API example:
 
-| declare function useReplaceBreadcrumbs(breadcrumbs: AppBreadcrumbSegment[]): void; //Replace the entire node array where AppBreadcrumbSegment = { pathname: string; title: string; options?: NavigateOptions } useReplaceBreadcrumbs(\[ { pathname: ‘/application/path’, title: ‘A parent title’ }, { pathname: ‘/application/path/leaf’, title: ‘A leaf title’ }, \]); |
-| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| declare function useReplaceBreadcrumbs(breadcrumbs: AppBreadcrumbSegment[], options?: { dropLastChromeSegment?: boolean }): void; //Replace the entire node array where AppBreadcrumbSegment = { pathname: string; title: string; options?: NavigateOptions } useReplaceBreadcrumbs(\[ { pathname: ‘/application/path’, title: ‘A parent title’ }, { pathname: ‘/application/path/leaf’, title: ‘A leaf title’ }, \]); |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## Consumption Constraint
 
@@ -273,6 +289,10 @@ It can be expected that the application and Chrome breadcrumbs will have a confl
 ### Disabling the last visible Chrome segment
 
 If an application uses the “useBreadcrumbs” or “replaceBreadcrumbs” API, we generate the Chrome segments normally, but during rendering it will omit the last segment that was discovered by Chrome and **is not equal to the application mount pathname.** Any path segment after the application mount point is an application nested route and has to be handled by the application.
+
+`useReplaceBreadcrumbs` can opt in to dropping the final Chrome segment. This
+is for apps whose breadcrumb trail should start directly after the HCC root.
+Without the option, the default mount-preserving behavior remains unchanged.
 
 Switching the application will reset the default Chrome breadcrumbs behavior until the API is called again. We can be 100% sure the hooks are called always after the breadcrumbs reset because of how the module loading works. There is no risk of disabling the behavior after the initial hook calls and invalid breadcrumbs state.
 

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Breadcrumbs from './Breadcrumbs';
-import { _resetBreadcrumbStore, getBreadcrumbStore } from '../../state/stores/breadcrumbStore';
+import { _resetBreadcrumbStore, getBreadcrumbStore, setDropLastChromeSegment } from '../../state/stores/breadcrumbStore';
 import { useFlag } from '@unleash/proxy-client-react';
 
 // Controllable store ref — the outer Breadcrumbs consumes the store through the
@@ -45,6 +45,7 @@ const seedIncremental = (entries: [string, { title: string; options?: any }][]) 
   entries.forEach(([pathname, entry]) => getBreadcrumbStore().updateState('SET_BREADCRUMB', { pathname, entry }));
 };
 const seedAppMount = (mount: string) => getBreadcrumbStore().updateState('SET_APP_MOUNT_PATHNAME', mount);
+const seedDropLastChromeSegment = (enabled: boolean) => setDropLastChromeSegment(enabled);
 
 describe('Breadcrumbs', () => {
   const renderBreadcrumbs = (initialEntries: string[] = ['/']) => {
@@ -302,6 +303,49 @@ describe('Breadcrumbs', () => {
     expect(screen.getByText('Advisor')).toBeInTheDocument();
     expect(screen.getByText('System 123')).toBeInTheDocument();
     expect(screen.queryByText('Systems')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    { pathname: '/lightwell', title: 'Lightwell Repositories' },
+    { pathname: '/lightwell/beacon/details', title: 'Lightwell Beacon Details' },
+  ])('should drop the final Chrome segment for an opted-in app at $pathname', ({ pathname, title }) => {
+    mockUseBreadcrumbsLinks.mockReturnValue([
+      { title: 'Red Hat Hybrid Cloud Console', href: '/' },
+      { title: 'Lightwell', href: '/lightwell' },
+    ]);
+
+    seedReplace([{ pathname, title }]);
+    seedDropLastChromeSegment(true);
+
+    renderBreadcrumbs([pathname]);
+
+    expect(screen.getByText('Red Hat Hybrid Cloud Console')).toBeInTheDocument();
+    expect(screen.getByText(title)).toBeInTheDocument();
+    expect(screen.queryByText('Lightwell')).not.toBeInTheDocument();
+  });
+
+  it('should preserve the sole Chrome root segment when an app opts in', () => {
+    mockUseBreadcrumbsLinks.mockReturnValue([{ title: 'Red Hat Hybrid Cloud Console', href: '/' }]);
+
+    seedReplace([{ pathname: '/lightwell/beacon', title: 'Lightwell Beacon' }]);
+    seedDropLastChromeSegment(true);
+
+    renderBreadcrumbs(['/lightwell/beacon']);
+
+    expect(screen.getByText('Red Hat Hybrid Cloud Console')).toBeInTheDocument();
+    expect(screen.getByText('Lightwell Beacon')).toBeInTheDocument();
+  });
+
+  it('should keep the Chrome mount segment for a child path by default', () => {
+    mockUseBreadcrumbsLinks.mockReturnValue([{ title: 'Settings', href: '/settings' }]);
+
+    seedReplace([{ pathname: '/settings/users', title: 'Users' }]);
+    seedAppMount('/settings');
+
+    renderBreadcrumbs(['/settings/users']);
+
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Users')).toBeInTheDocument();
   });
 
   it('should warn about duplicate hrefs with conflicting titles in dev mode', () => {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -36,14 +36,16 @@ type BreadcrumbSegment = {
 /**
  * Merge Chrome-native breadcrumb segments with app-provided segments.
  *
- * Chrome segments are ALWAYS present. App segments are purely additive: when the
- * app provides nothing (`finalAppSegments` empty) the result is exactly the Chrome
- * segments — identical to the pre-app-breadcrumbs behavior.
+ * Chrome segments are normally always present and app segments are additive. An
+ * app can opt into dropping the final Chrome segment. When the app provides
+ * nothing (`finalAppSegments` empty), the result is exactly the Chrome
+ * segments, identical to the pre-app-breadcrumbs behavior.
  */
 function mergeBreadcrumbSegments(
   chromeSegments: ChromeBreadcrumbSegment[],
   finalAppSegments: AppBreadcrumbSegment[],
-  appMountPathname: string | undefined
+  appMountPathname: string | undefined,
+  dropLastChromeSegment: boolean
 ): BreadcrumbSegment[] {
   if (finalAppSegments.length === 0) {
     return chromeSegments.map((seg) => ({
@@ -53,17 +55,21 @@ function mergeBreadcrumbSegments(
     }));
   }
 
-  // Omit last chrome segment if:
-  // 1. App breadcrumbs exist
-  // 2. Last chrome segment is NOT the app mount pathname (design requirement)
-  // 3. App's first breadcrumb matches or extends the last chrome segment (prevents gaps)
-  // appMountPathname is set by ChromeRoute from the route path (e.g., '/settings', '/insights/advisor')
   const lastChromeSegment = chromeSegments[chromeSegments.length - 1];
   const firstAppSegment = finalAppSegments[0];
 
-  // Check if app's first breadcrumb matches or extends (immediate child only) the last Chrome segment
-  let shouldDropLastChromeSegment = false;
-  if (chromeSegments.length > 1 && appMountPathname && lastChromeSegment?.href !== appMountPathname && firstAppSegment && lastChromeSegment?.href) {
+  // An opted-in app owns the app trail and can omit Chrome's final segment.
+  let shouldDropLastChromeSegment = dropLastChromeSegment && chromeSegments.length > 1;
+  if (
+    !shouldDropLastChromeSegment &&
+    chromeSegments.length > 1 &&
+    appMountPathname &&
+    lastChromeSegment?.href !== appMountPathname &&
+    firstAppSegment &&
+    lastChromeSegment?.href
+  ) {
+    // Default behavior: drop the last Chrome segment when the app starts at
+    // that segment or its immediate child, while preserving the app mount page.
     const normalizedAppFirst = normalizePathname(firstAppSegment.pathname);
     const normalizedChromeLast = normalizePathname(lastChromeSegment.href);
 
@@ -190,7 +196,7 @@ const BreadcrumbsView = ({ segments }: { segments: BreadcrumbSegment[] }) => {
  * app provided no breadcrumbs, the merge returns the Chrome segments unchanged.
  */
 const BreadcrumbsWithApp = ({ store, chromeSegments, pathname }: { store: BreadcrumbStore; chromeSegments: ChromeBreadcrumbSegment[]; pathname: string }) => {
-  const { storage, replaceMode, override, appMountPathname } = useGetState(store);
+  const { storage, replaceMode, override, appMountPathname, dropLastChromeSegment } = useGetState(store);
 
   // Sync pathname before paint to prevent breadcrumb flicker on navigation
   useLayoutEffect(() => {
@@ -203,8 +209,8 @@ const BreadcrumbsWithApp = ({ store, chromeSegments, pathname }: { store: Breadc
   );
 
   const segments = useMemo<BreadcrumbSegment[]>(
-    () => mergeBreadcrumbSegments(chromeSegments, appSegments, appMountPathname),
-    [chromeSegments, appSegments, appMountPathname]
+    () => mergeBreadcrumbSegments(chromeSegments, appSegments, appMountPathname, dropLastChromeSegment),
+    [chromeSegments, appSegments, appMountPathname, dropLastChromeSegment]
   );
 
   return <BreadcrumbsView segments={segments} />;

--- a/src/hooks/useReplaceBreadcrumbs.test.ts
+++ b/src/hooks/useReplaceBreadcrumbs.test.ts
@@ -61,6 +61,18 @@ describe('useReplaceBreadcrumbs', () => {
     expect(getState().override).toEqual(breadcrumbs);
   });
 
+  it('should set and clear the drop-final Chrome segment option', () => {
+    const breadcrumbs = [{ pathname: '/lightwell', title: 'Lightwell Repositories' }];
+
+    const { unmount } = renderHook(() => useReplaceBreadcrumbs(breadcrumbs, { dropLastChromeSegment: true }));
+
+    expect(getState().dropLastChromeSegment).toBe(true);
+
+    unmount();
+
+    expect(getState().dropLastChromeSegment).toBe(false);
+  });
+
   it('should disable replace mode on unmount', () => {
     const breadcrumbs = [{ pathname: '/insights/advisor/systems', title: 'Systems' }];
 

--- a/src/hooks/useReplaceBreadcrumbs.ts
+++ b/src/hooks/useReplaceBreadcrumbs.ts
@@ -1,7 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { useFlag } from '@unleash/proxy-client-react';
-import { getBreadcrumbStore, setOverride, setReplaceMode } from '../state/stores/breadcrumbStore';
+import { getBreadcrumbStore, setDropLastChromeSegment, setOverride, setReplaceMode } from '../state/stores/breadcrumbStore';
 import { type AppBreadcrumbSegment, normalizePathname } from '../utils/breadcrumbUtils';
+
+export type ReplaceBreadcrumbsOptions = {
+  /** Drop the final Chrome segment when this app supplies breadcrumbs. */
+  dropLastChromeSegment?: boolean;
+};
 
 /**
  * Hook for replacing the entire app breadcrumb array
@@ -9,6 +14,7 @@ import { type AppBreadcrumbSegment, normalizePathname } from '../utils/breadcrum
  * Disables the incremental storage system
  *
  * @param breadcrumbs - Array of breadcrumb segments with pathname, title, and optional NavigateOptions
+ * @param options - Optional behavior for merging app and Chrome breadcrumbs
  *
  * Exposed as a federated module via Scalprum:
  * @example
@@ -24,15 +30,16 @@ import { type AppBreadcrumbSegment, normalizePathname } from '../utils/breadcrum
  *   useRemoteHook({
  *     scope: 'chrome',
  *     module: './breadcrumbs/useReplaceBreadcrumbs',
- *     args: [breadcrumbs],
+ *     args: [breadcrumbs, { dropLastChromeSegment: true }],
  *   });
  *
  *   return <div>...</div>;
  * }
  * ```
  */
-function useReplaceBreadcrumbs(breadcrumbs: AppBreadcrumbSegment[]): void {
+function useReplaceBreadcrumbs(breadcrumbs: AppBreadcrumbSegment[], options?: ReplaceBreadcrumbsOptions): void {
   const isEnabled = useFlag('platform.chrome.app-breadcrumbs');
+  const dropLastChromeSegment = options?.dropLastChromeSegment ?? false;
   const breadcrumbsRef = useRef(breadcrumbs);
 
   // Stabilize breadcrumbs via JSON.stringify, with fallback for circular refs
@@ -83,12 +90,14 @@ function useReplaceBreadcrumbs(breadcrumbs: AppBreadcrumbSegment[]): void {
 
     setReplaceMode(true);
     setOverride(breadcrumbsRef.current);
+    setDropLastChromeSegment(dropLastChromeSegment);
 
     return () => {
       setReplaceMode(false);
       setOverride([]);
+      setDropLastChromeSegment(false);
     };
-  }, [breadcrumbsKey, isEnabled]);
+  }, [breadcrumbsKey, isEnabled, dropLastChromeSegment]);
 }
 
 export default useReplaceBreadcrumbs;

--- a/src/state/stores/breadcrumbStore.test.ts
+++ b/src/state/stores/breadcrumbStore.test.ts
@@ -6,6 +6,7 @@ import {
   removeBreadcrumb,
   setAppMountPathname,
   setBreadcrumb,
+  setDropLastChromeSegment,
   setOverride,
   setPathname,
   setReplaceMode,
@@ -30,6 +31,7 @@ describe('breadcrumbStore', () => {
       expect(state.override).toEqual([]);
       expect(state.pathname).toBe('/');
       expect(state.appMountPathname).toBeUndefined();
+      expect(state.dropLastChromeSegment).toBe(false);
     });
   });
 
@@ -112,6 +114,13 @@ describe('breadcrumbStore', () => {
     });
   });
 
+  describe('SET_DROP_LAST_CHROME_SEGMENT', () => {
+    it('should set the drop-final Chrome segment option', () => {
+      setDropLastChromeSegment(true);
+      expect(getBreadcrumbStore().getState().dropLastChromeSegment).toBe(true);
+    });
+  });
+
   describe('CLEAR', () => {
     it('should reset storage/replaceMode/override but preserve pathname/appMountPathname', () => {
       setBreadcrumb('/insights/advisor/systems', { title: 'Systems' });
@@ -119,6 +128,7 @@ describe('breadcrumbStore', () => {
       setOverride([{ pathname: '/x', title: 'X' }]);
       setPathname('/insights/advisor/systems');
       setAppMountPathname('/insights/advisor');
+      setDropLastChromeSegment(true);
 
       clearBreadcrumbs();
 
@@ -129,6 +139,7 @@ describe('breadcrumbStore', () => {
       // preserved
       expect(state.pathname).toBe('/insights/advisor/systems');
       expect(state.appMountPathname).toBe('/insights/advisor');
+      expect(state.dropLastChromeSegment).toBe(false);
     });
   });
 

--- a/src/state/stores/breadcrumbStore.ts
+++ b/src/state/stores/breadcrumbStore.ts
@@ -13,9 +13,20 @@ export interface BreadcrumbState {
   pathname: string;
   /** App mount pathname set by ChromeRoute when switching applications */
   appMountPathname: string | undefined;
+  /** Allow replace-mode apps to drop the final Chrome breadcrumb */
+  dropLastChromeSegment: boolean;
 }
 
-const EVENTS = ['SET_BREADCRUMB', 'REMOVE_BREADCRUMB', 'SET_REPLACE_MODE', 'SET_OVERRIDE', 'SET_PATHNAME', 'SET_APP_MOUNT_PATHNAME', 'CLEAR'] as const;
+const EVENTS = [
+  'SET_BREADCRUMB',
+  'REMOVE_BREADCRUMB',
+  'SET_REPLACE_MODE',
+  'SET_OVERRIDE',
+  'SET_PATHNAME',
+  'SET_APP_MOUNT_PATHNAME',
+  'SET_DROP_LAST_CHROME_SEGMENT',
+  'CLEAR',
+] as const;
 
 export type BreadcrumbStore = ReturnType<typeof createSharedStore<BreadcrumbState, typeof EVENTS>>;
 
@@ -54,6 +65,7 @@ export const getBreadcrumbStore = (): BreadcrumbStore => {
         override: [],
         pathname: '/',
         appMountPathname: undefined,
+        dropLastChromeSegment: false,
       } as BreadcrumbState,
       events: EVENTS,
       onEventChange: (state, event, payload): BreadcrumbState => {
@@ -89,10 +101,21 @@ export const getBreadcrumbStore = (): BreadcrumbStore => {
             const appMountPathname = payload as string | undefined;
             return state.appMountPathname === appMountPathname ? state : { ...state, appMountPathname };
           }
+          case 'SET_DROP_LAST_CHROME_SEGMENT': {
+            const dropLastChromeSegment = payload as boolean;
+            return state.dropLastChromeSegment === dropLastChromeSegment ? state : { ...state, dropLastChromeSegment };
+          }
           case 'CLEAR':
-            // Reset app-provided breadcrumbs but preserve pathname/appMountPathname
+            // Reset app-provided breadcrumbs but preserve pathname/appMountPathname.
+            // The drop option belongs to the active app and must not leak across routes.
             // (matches the old clearAppBreadcrumbsAtom behavior)
-            return { ...state, storage: new Map<string, BreadcrumbEntry>(), replaceMode: false, override: [] };
+            return {
+              ...state,
+              storage: new Map<string, BreadcrumbEntry>(),
+              replaceMode: false,
+              override: [],
+              dropLastChromeSegment: false,
+            };
           default:
             return state;
         }
@@ -119,6 +142,10 @@ export const setOverride = (override: AppBreadcrumbSegment[]) => getBreadcrumbSt
 export const setPathname = (pathname: string) => getBreadcrumbStore().updateState('SET_PATHNAME', pathname);
 
 export const setAppMountPathname = (appMountPathname: string | undefined) => getBreadcrumbStore().updateState('SET_APP_MOUNT_PATHNAME', appMountPathname);
+
+/** Set whether replace-mode apps drop Chrome's final breadcrumb segment. */
+export const setDropLastChromeSegment = (dropLastChromeSegment: boolean) =>
+  getBreadcrumbStore().updateState('SET_DROP_LAST_CHROME_SEGMENT', dropLastChromeSegment);
 
 export const clearBreadcrumbs = () => getBreadcrumbStore().updateState('CLEAR');
 


### PR DESCRIPTION
### Description
This adds a new opt-in `dropLastChromeSegment` option to `useReplaceBreadcrumbs`. It would be useful for apps that don't have a dashboard/landing page _(Currently is desired by Lightwell UI)._

The need for this comes from this [PR](https://github.com/content-services/content-sources-frontend/pull/1167), that adds the new breadcrumb hooks to Lightwell UI. 
Without this change, there can be duplicated breadcrumbs (leading to the same page) or breadcrumbs that don't link to parents, but different pages.

Tested locally with insights-chrome and the mentioned PR with changes that set the new option to true.

[RHCLOUD-50437](https://redhat.atlassian.net/browse/RHCLOUD-50437)

---

### Screenshots

#### Before:
Duplicated | Non-parent
:-------------------------:|:-------------------------:
<img width="452" height="134" alt="screenshot_from_2026-09-03_11-12-37" src="https://github.com/user-attachments/assets/1a19ee40-c3ab-4ba4-9567-4aeca985de58" /> | <img width="452" height="134" alt="screenshot_from_2026-09-03_11-07-31" src="https://github.com/user-attachments/assets/a6aab5ac-56ea-4f4f-a2de-6c0256fa35ea" />


#### After:
Duplicated | Non-parent
:-------------------------:|:-------------------------:
<img width="452" height="134" alt="image" src="https://github.com/user-attachments/assets/2d996f8c-2223-4f1f-94e0-c2e1a4c77265" /> | <img width="452" height="134" alt="image" src="https://github.com/user-attachments/assets/bc11ef5d-da1e-48b0-a7a5-3ff7d958a676" />

---

### Anything reviewers should know?

Important to note: 
**This keeps the default behavior and doesn't impact pages that do not set the new option to true.**

But it extends the breadcrumbs API with something new, don't know how this aligns with you expectations/vision.
_Also my first time contributing to `insights-chrome`, open to feedback if anything would need adjustments._

---

### Checklist

- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure

Assisted by: Codex


[RHCLOUD-50437]: https://redhat.atlassian.net/browse/RHCLOUD-50437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional breadcrumb setting that lets applications omit Chrome’s final breadcrumb segment.
  - Chrome’s root breadcrumb remains visible when it is the only segment.
  - Existing breadcrumb behavior remains unchanged by default.
  - The setting automatically resets when breadcrumb replacement is cleared or unmounted.

- **Documentation**
  - Documented the new opt-in breadcrumb behavior, including configuration and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->